### PR TITLE
Add support for standalone Thread network creation command.

### DIFF
--- a/src/device-manager/WeaveDeviceManager.h
+++ b/src/device-manager/WeaveDeviceManager.h
@@ -434,6 +434,10 @@ private:
     uint32_t mCurReqProfileId;
     uint16_t mCurReqMsgType;
     PacketBuffer *mCurReqMsg;
+    PacketBuffer *mCurReqMsgRetained;
+#if WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
+    bool mCurReqCreateThreadNetwork;
+#endif
     ExchangeContext::MessageReceiveFunct mCurReqRcvFunct;
     IPAddress mRendezvousAddr;
     IPAddress mDeviceAddr;
@@ -530,7 +534,7 @@ private:
     static void HandleSessionEstablished(WeaveSecurityManager *sm, WeaveConnection *con, void *appReqState,
             uint16_t sessionKeyId, uint64_t peerNodeId, uint8_t encType);
     static void HandleSessionError(WeaveSecurityManager *sm, WeaveConnection *con, void *appReqState,
-	    WEAVE_ERROR localErr, uint64_t peerNodeId, StatusReport *statusReport);
+            WEAVE_ERROR localErr, uint64_t peerNodeId, StatusReport *statusReport);
     static void RetrySession(System::Layer* aSystemLayer, void* aAppState, System::Error aError);
 
     void ReenableConnectionMonitor();

--- a/src/device-manager/python/weave-device-mgr.py
+++ b/src/device-manager/python/weave-device-mgr.py
@@ -242,6 +242,7 @@ class DeviceMgrCmd(Cmd):
         'ping',
         'identify',
         'create-fabric',
+        'create-thread-network',
         'leave-fabric',
         'get-fabric-config',
         'join-existing-fabric',
@@ -1286,6 +1287,78 @@ class DeviceMgrCmd(Cmd):
         self.lastNetworkId = addResult
 
         print "Add thread network complete (network id = " + str(addResult) + ")"
+
+    def do_createthreadnetwork(self, line):
+        """
+          create-thread-network [ <options> ]
+
+          Send a request to device to create a new Thread network and wait for a reply.
+
+          Options:
+
+            --name <name>
+
+              Thread network name (string).
+
+            --key <key>
+
+              Thread network key (hex string of any length).
+
+            --panid <panid>
+
+              Thread network PAN id (16-bit hex int).
+
+            --channel <channel>
+
+              Thread network channel number (int). Valid supported range is [11 - 26].
+
+          All above parameters are optional and if not specified the value will be created by device.
+        """
+
+        args = shlex.split(line)
+
+        optParser = OptionParser(usage=optparse.SUPPRESS_USAGE, option_class=ExtendedOption)
+        optParser.add_option("-n", "--name", action="store", dest="threadNetworkName", type="string")
+        optParser.add_option("-k", "--key", action="store", dest="threadNetworkKey", type="string")
+        optParser.add_option("-p", "--panid", action="store", dest="threadPANId", type="hexint")
+        optParser.add_option("-c", "--channel", action="store", dest="threadChannel", type="int")
+
+        try:
+            (options, remainingArgs) = optParser.parse_args(args)
+        except SystemExit:
+            return
+
+        if (len(remainingArgs) > 0):
+            print "Unexpected argument: " + remainingArgs[0]
+            return
+
+        networkInfo = WeaveDeviceMgr.NetworkInfo()
+        networkInfo.NetworkType = WeaveDeviceMgr.NetworkType_Thread
+
+        if (options.threadNetworkName):
+            networkInfo.ThreadNetworkName = options.threadNetworkName
+        if (options.threadNetworkKey):
+            networkInfo.ThreadNetworkKey = bytearray(binascii.unhexlify(options.threadNetworkKey))
+        if (options.threadPANId):
+            networkInfo.ThreadPANId = options.threadPANId
+            if (networkInfo.ThreadPANId > 0xffff):
+                print "Thread PAN Id must be 16-bit hex value."
+                return
+        if (options.threadChannel):
+            networkInfo.ThreadChannel = options.threadChannel
+            if (networkInfo.ThreadChannel < 11 or networkInfo.ThreadChannel > 26):
+                print "Thread Channel value must be in a range [11 - 26]."
+                return
+
+        try:
+            addResult = self.devMgr.AddNetwork(networkInfo)
+        except WeaveDeviceMgr.DeviceManagerException, ex:
+            print str(ex)
+            return
+
+        self.lastNetworkId = addResult
+
+        print "Create Thread network complete (network id = " + str(addResult) + ")"
 
     def do_updatenetwork(self, line):
         """

--- a/src/lib/core/WeaveConfig.h
+++ b/src/lib/core/WeaveConfig.h
@@ -2007,6 +2007,21 @@
 #endif
 
 /**
+ *  @def WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
+ *
+ *  @brief
+ *    Enable (1) or disable (0) support for the depricated
+ *    version of AddNetwork() message in the Network Provisioning
+ *    profile.
+ *    This option should be enabled to support pairing with Nest
+ *    legacy devices that don't have latest SW.
+ *
+ */
+#ifndef WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
+#define WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE     1
+#endif // WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
+
+/**
  * @def WEAVE_NON_PRODUCTION_MARKER
  *
  * @brief Defines the name of a mark symbol whose presence signals that the Weave code

--- a/src/lib/core/WeaveError.h
+++ b/src/lib/core/WeaveError.h
@@ -1682,6 +1682,17 @@ typedef WEAVE_CONFIG_ERROR_TYPE WEAVE_ERROR;
 #define WEAVE_ERROR_WDM_POTENTIAL_DATA_LOSS                      _WEAVE_ERROR(177)
 
 /**
+ *  @def WEAVE_ERROR_UNSUPPORTED_THREAD_NETWORK_CREATE
+ *
+ *  @brief
+ *    Device doesn't support standalone Thread network creation.
+ *    On some legacy Nest devices new Thread network can only be created
+ *    together with Weave Fabric using CrateFabric() message.
+ *
+ */
+#define WEAVE_ERROR_UNSUPPORTED_THREAD_NETWORK_CREATE            _WEAVE_ERROR(178)
+
+/**
  *  @}
  */
 

--- a/src/lib/profiles/network-provisioning/NetworkProvisioning.cpp
+++ b/src/lib/profiles/network-provisioning/NetworkProvisioning.cpp
@@ -325,7 +325,10 @@ void NetworkProvisioningServer::HandleRequest(ExchangeContext *ec, const IPPacke
         err = delegate->HandleScanNetworks(networkType);
         break;
 
+#if WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
     case kMsgType_AddNetwork:
+#endif
+    case kMsgType_AddNetworkV2:
         VerifyOrExit(dataLen >= 1, err = WEAVE_ERROR_INVALID_MESSAGE_LENGTH);
         err = delegate->HandleAddNetwork(payload);
         payload = NULL;
@@ -432,7 +435,10 @@ void NetworkProvisioningDelegate::EnforceAccessControl(ExchangeContext *ec, uint
         switch (msgType)
         {
         case kMsgType_ScanNetworks:
+#if WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
         case kMsgType_AddNetwork:
+#endif
+        case kMsgType_AddNetworkV2:
         case kMsgType_UpdateNetwork:
         case kMsgType_RemoveNetwork:
         case kMsgType_EnableNetwork:

--- a/src/lib/profiles/network-provisioning/NetworkProvisioning.h
+++ b/src/lib/profiles/network-provisioning/NetworkProvisioning.h
@@ -102,7 +102,8 @@ enum
     kMsgType_SetRendezvousMode                  = 10,
     kMsgType_GetNetworks                        = 11,
     kMsgType_GetNetworksComplete                = 12,
-    kMsgType_GetLastResult                      = 13
+    kMsgType_GetLastResult                      = 13,
+    kMsgType_AddNetworkV2                       = 14
 };
 
 /**

--- a/src/lib/support/ErrorStr.cpp
+++ b/src/lib/support/ErrorStr.cpp
@@ -533,6 +533,7 @@ NL_DLL_EXPORT const char *ErrorStr(int32_t err)
     case WEAVE_ERROR_WDM_MALFORMED_UPDATE_RESPONSE              : return WeaveFormatError(err, "Malformed WDM Update response");
     case WEAVE_ERROR_WDM_VERSION_MISMATCH                       : return WeaveFormatError(err, "The conditional update of a WDM path failed for a version mismatch");
     case WEAVE_ERROR_WDM_POTENTIAL_DATA_LOSS                    : return WeaveFormatError(err, "A potential data loss was detected in a WDM Trait Instance");
+    case WEAVE_ERROR_UNSUPPORTED_THREAD_NETWORK_CREATE          : return WeaveFormatError(err, "Nest Legacy device doesn't support standalone Thread network creation");
 
     // ----- ASN1 Errors -----
     case ASN1_END                                               : return ASN1FormatError(err, "End of input");

--- a/src/lib/support/WeaveNames.cpp
+++ b/src/lib/support/WeaveNames.cpp
@@ -163,7 +163,9 @@ const char *GetMessageName(uint32_t profileId, uint8_t msgType)
         switch (msgType) {
         case NetworkProvisioning::kMsgType_ScanNetworks                     : return "ScanNetworks";
         case NetworkProvisioning::kMsgType_NetworkScanComplete              : return "NetworkScanComplete";
+#if WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
         case NetworkProvisioning::kMsgType_AddNetwork                       : return "AddNetwork";
+#endif
         case NetworkProvisioning::kMsgType_AddNetworkComplete               : return "AddNetworkComplete";
         case NetworkProvisioning::kMsgType_UpdateNetwork                    : return "UpdateNetwork";
         case NetworkProvisioning::kMsgType_RemoveNetwork                    : return "RemoveNetwork";
@@ -174,6 +176,7 @@ const char *GetMessageName(uint32_t profileId, uint8_t msgType)
         case NetworkProvisioning::kMsgType_GetNetworks                      : return "GetNetworks";
         case NetworkProvisioning::kMsgType_GetNetworksComplete              : return "GetNetworksComplete";
         case NetworkProvisioning::kMsgType_GetLastResult                    : return "GetLastResult";
+        case NetworkProvisioning::kMsgType_AddNetworkV2                     : return "AddNetworkV2";
         }
         break;
     case kWeaveProfile_Security:

--- a/src/test-apps/MockNPServer.cpp
+++ b/src/test-apps/MockNPServer.cpp
@@ -231,36 +231,34 @@ WEAVE_ERROR MockNetworkProvisioningServer::ValidateNetworkConfig(NetworkInfo& ne
 
     else if (netConfig.NetworkType == kNetworkType_Thread)
     {
-        if (netConfig.ThreadNetworkName == NULL)
+        // Verify that other network parameters are valid when Extended PAN Id (EPANID) present.
+        // When EPANID is specified: new Thread network should be added.
+        // When EPANID is not specified: new Thread network should be created.
+        if (netConfig.ThreadExtendedPANId != NULL)
         {
-            printf("Invalid network configuration: Missing Thread network name\n");
-            err = SendStatusReport(kWeaveProfile_NetworkProvisioning, kStatusCode_InvalidNetworkConfiguration);
-            SuccessOrExit(err);
-            ExitNow(err = WEAVE_ERROR_INVALID_ARGUMENT);
-        }
+            if (netConfig.ThreadNetworkName == NULL)
+            {
+                printf("Invalid network configuration: Missing Thread network name\n");
+                err = SendStatusReport(kWeaveProfile_NetworkProvisioning, kStatusCode_InvalidNetworkConfiguration);
+                SuccessOrExit(err);
+                ExitNow(err = WEAVE_ERROR_INVALID_ARGUMENT);
+            }
 
-        if (netConfig.ThreadExtendedPANId == NULL)
-        {
-            printf("Invalid network configuration: Missing Thread extended PAN id\n");
-            err = SendStatusReport(kWeaveProfile_NetworkProvisioning, kStatusCode_InvalidNetworkConfiguration);
-            SuccessOrExit(err);
-            ExitNow(err = WEAVE_ERROR_INVALID_ARGUMENT);
-        }
+            if (netConfig.ThreadNetworkKey == NULL)
+            {
+                printf("Invalid network configuration: Missing Thread network key\n");
+                err = SendStatusReport(kWeaveProfile_NetworkProvisioning, kStatusCode_InvalidNetworkConfiguration);
+                SuccessOrExit(err);
+                ExitNow(err = WEAVE_ERROR_INVALID_ARGUMENT);
+            }
 
-        if (netConfig.ThreadNetworkKey == NULL || netConfig.ThreadNetworkKeyLen == 0)
-        {
-            printf("Invalid network configuration: Missing Thread network key\n");
-            err = SendStatusReport(kWeaveProfile_NetworkProvisioning, kStatusCode_InvalidNetworkConfiguration);
-            SuccessOrExit(err);
-            ExitNow(err = WEAVE_ERROR_INVALID_ARGUMENT);
-        }
-
-        if (netConfig.ThreadNetworkKeyLen == 0)
-        {
-            printf("Invalid network configuration: Zero-length Thread network key\n");
-            err = SendStatusReport(kWeaveProfile_NetworkProvisioning, kStatusCode_InvalidNetworkConfiguration);
-            SuccessOrExit(err);
-            ExitNow(err = WEAVE_ERROR_INVALID_ARGUMENT);
+            if (netConfig.ThreadNetworkKeyLen == 0)
+            {
+                printf("Invalid network configuration: Zero-length Thread network key\n");
+                err = SendStatusReport(kWeaveProfile_NetworkProvisioning, kStatusCode_InvalidNetworkConfiguration);
+                SuccessOrExit(err);
+                ExitNow(err = WEAVE_ERROR_INVALID_ARGUMENT);
+            }
         }
     }
 
@@ -444,7 +442,10 @@ void MockNetworkProvisioningServer::CompleteCurrentOp()
 
     switch (mCurOpType)
     {
+#if WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
     case NetworkProvisioning::kMsgType_AddNetwork:
+#endif
+    case NetworkProvisioning::kMsgType_AddNetworkV2:
         err = CompleteAddNetwork(mOpArgs.networkInfoTLV);
         break;
     case NetworkProvisioning::kMsgType_DisableNetwork:


### PR DESCRIPTION
To achieve that, the following has been implemented:
  * Added new version of AddNetwork() message - kMsgType_AddNetworkV2.
  * Implemented mechanism, which automatically resends old version of
    AddNetwork() message if the new version of that message is not
    supported by the device.
  * Added new Create Thread Network (create-thread-network) command
    to the Python Device Manager.