### PR TITLE
Feature/notify tcp data delivered

### DIFF
--- a/src/inet/InetConfig.h
+++ b/src/inet/InetConfig.h
@@ -629,25 +629,44 @@
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
 
 /**
- *  @def INET_CONFIG_DEFAULT_TCP_USER_TIMER_PERIOD_MSEC
+ *  @def INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
  *
  *  @brief
- *    The default TCP_USER_TIMEOUT timer tick interval in
- *    milliseconds.
+ *    When this flag is set, the InetLayer enables
+ *    callbacks to the upper layer notifying it when
+ *    the send channel of the TCP connection changes
+ *    between being idle or not idle.
  *
- *  @details
- *    This interval specifies how often the TCP output
- *    queue would be checked to determine if data is
- *    being transmitted successfully or is sitting there
- *    unacknowledged. When a sufficient number of these
- *    periods(equivalent to the configured TCP_USER_TIMEOUT)
- *    have expired with unacknowledged data sitting in
- *    the queue, the connection would be closed.
+ *  @note
+ *    When enabled, the TCP send queue is actively
+ *    polled to determine if sent data has been
+ *    acknowledged.
  *
  */
-#ifndef INET_CONFIG_DEFAULT_TCP_USER_TIMER_PERIOD_MSEC
-#define INET_CONFIG_DEFAULT_TCP_USER_TIMER_PERIOD_MSEC     5000
-#endif // INET_CONFIG_DEFAULT_TCP_USER_TIMER_PERIOD_MSEC
+#ifndef INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+#define INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS         0
+#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+
+/**
+ *  @def INET_CONFIG_TCP_SEND_QUEUE_POLL_INTERVAL_MSEC
+ *
+ *  @brief
+ *    The default polling interval to check the progress
+ *    on the TCP SendQueue to determine if sent data is
+ *    being acknowledged.
+ *
+ *  @details
+ *    If progress is being made, then the TCP UserTimeout
+ *    period would be shifted further ahead by resetting
+ *    the max poll count. If, however, progress is not made,
+ *    then the next timer would still fire at the next poll
+ *    interval without resetting the poll count. The
+ *    connection would be torn down when the poll count
+ *    reaches zero.
+ */
+#ifndef INET_CONFIG_TCP_SEND_QUEUE_POLL_INTERVAL_MSEC
+#define INET_CONFIG_TCP_SEND_QUEUE_POLL_INTERVAL_MSEC      500
+#endif // INET_CONFIG_TCP_SEND_QUEUE_POLL_INTERVAL_MSEC
 
 /**
  *  @def INET_CONFIG_DEFAULT_TCP_USER_TIMEOUT_MSEC

--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -728,6 +728,7 @@ INET_ERROR TCPEndPoint::Send(PacketBuffer *data, bool push)
     {
         // Timer was not running before this send. So, start
         // the timer.
+
         StartTCPUserTimeoutTimer();
     }
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
@@ -1189,11 +1190,21 @@ void TCPEndPoint::Init(InetLayer *inetLayer)
 
     mUserTimeoutTimerRunning = false;
 
+#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+    mIsTCPSendIdle = true;
+
+    mTCPSendQueuePollPeriodMillis = INET_CONFIG_TCP_SEND_QUEUE_POLL_INTERVAL_MSEC;
+
+    mTCPSendQueueRemainingPollCount = MaxTCPSendQueuePolls();
+
+    OnTCPSendIdleChanged = NULL;
+#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
     mBytesWrittenSinceLastProbe = 0;
 
-    mLastTCPSendQueueLen = 0;
+    mLastTCPKernelSendQueueLen = 0;
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
@@ -1329,6 +1340,12 @@ INET_ERROR TCPEndPoint::DriveSending()
         if (OnDataSent != NULL)
             OnDataSent(this, (uint16_t) lenSent);
 
+#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+        // TCP Send is not Idle; Set state and notify if needed
+
+        SetTCPSendIdleAndNotifyChange(false);
+#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+
 #if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
         mBytesWrittenSinceLastProbe += lenSent;
 
@@ -1340,17 +1357,19 @@ INET_ERROR TCPEndPoint::DriveSending()
             break;
         }
 
-        if (isProgressing && mUserTimeoutTimerRunning)
-        {
-            // Progress is being made. So, shift the timer
-            // forward if it was started.
-            RestartTCPUserTimeoutTimer();
-        }
-        else if (!mUserTimeoutTimerRunning)
+        if (!mUserTimeoutTimerRunning)
         {
             // Timer was not running before this write. So, start
             // the timer.
+
             StartTCPUserTimeoutTimer();
+        }
+        else if (isProgressing)
+        {
+            // Progress is being made. So, shift the timer
+            // forward if it was started.
+
+            RestartTCPUserTimeoutTimer();
         }
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
 
@@ -1609,25 +1628,61 @@ void TCPEndPoint::TCPUserTimeoutHandler(Weave::System::Layer* aSystemLayer, void
     INET_ERROR err = INET_NO_ERROR;
     bool isProgressing = false;
     err = tcpEndPoint->CheckConnectionProgress(isProgressing);
-    if (err != INET_NO_ERROR)
+    SuccessOrExit(err);
+
+    if (tcpEndPoint->mLastTCPKernelSendQueueLen == 0)
     {
-        tcpEndPoint->DoClose(err, false);
+#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+        // If the kernel TCP send queue as well as the TCPEndPoint
+        // send queue have been flushed then notify application
+        // that all data has been acknowledged.
+
+        if (tcpEndPoint->mSendQueue == NULL)
+        {
+            tcpEndPoint->SetTCPSendIdleAndNotifyChange(true);
+        }
+#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
     }
     else
+    // There is data in the TCP Send Queue
     {
-        if (!isProgressing)
+        if (isProgressing)
         {
-            // Close Connection as we have timed out and there is still
-            // data not sent out successfully.
+            // Data is flowing, so restart the UserTimeout timer
+            // to shift it forward while also resetting the max
+            // poll count.
 
-            tcpEndPoint->DoClose(INET_ERROR_TCP_USER_TIMEOUT, false);
-        }
-        // If the transfer is progressing and there are residual bytes
-        // left in the TCP output queue, the timer needs to be restarted.
-        else if (tcpEndPoint->mLastTCPSendQueueLen > 0)
-        {
             tcpEndPoint->StartTCPUserTimeoutTimer();
         }
+        else
+        {
+#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+            // Data flow is not progressing.
+            // Decrement the remaining max TCP send queue polls.
+
+            tcpEndPoint->mTCPSendQueueRemainingPollCount--;
+
+            VerifyOrExit(tcpEndPoint->mTCPSendQueueRemainingPollCount != 0,
+                         err = INET_ERROR_TCP_USER_TIMEOUT);
+
+            // Restart timer to poll again
+
+            tcpEndPoint->ScheduleNextTCPUserTimeoutPoll(tcpEndPoint->mTCPSendQueuePollPeriodMillis);
+#else
+            // Close the connection as the TCP UserTimeout has expired
+
+            ExitNow(err = INET_ERROR_TCP_USER_TIMEOUT);
+#endif // !INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+        }
+    }
+
+exit:
+
+    if (err != INET_NO_ERROR)
+    {
+        // Close the connection as the TCP UserTimeout has expired
+
+        tcpEndPoint->DoClose(err, false);
     }
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
@@ -1640,11 +1695,46 @@ void TCPEndPoint::TCPUserTimeoutHandler(Weave::System::Layer* aSystemLayer, void
 
 }
 
-void TCPEndPoint::StartTCPUserTimeoutTimer()
+void TCPEndPoint::ScheduleNextTCPUserTimeoutPoll(uint32_t aTimeOut)
 {
     Weave::System::Layer& lSystemLayer = SystemLayer();
 
-    lSystemLayer.StartTimer(mUserTimeoutMillis, TCPUserTimeoutHandler, this);
+    lSystemLayer.StartTimer(aTimeOut, TCPUserTimeoutHandler, this);
+}
+
+#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+void TCPEndPoint::SetTCPSendIdleAndNotifyChange(bool aIsTCPSendIdle)
+{
+    if (mIsTCPSendIdle != aIsTCPSendIdle)
+    {
+        WeaveLogDetail(Inet, "TCP con send channel idle state changed : %s", aIsTCPSendIdle ? "false->true" : "true->false");
+
+        // Set the current Idle state
+        mIsTCPSendIdle = aIsTCPSendIdle;
+
+        if (OnTCPSendIdleChanged)
+        {
+            OnTCPSendIdleChanged(this, mIsTCPSendIdle);
+        }
+    }
+}
+#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+
+void TCPEndPoint::StartTCPUserTimeoutTimer()
+{
+    uint32_t timeOut = mUserTimeoutMillis;
+
+#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+    //Set timeout to the poll interval
+
+    timeOut = mTCPSendQueuePollPeriodMillis;
+
+    // Reset the poll count
+
+    mTCPSendQueueRemainingPollCount = MaxTCPSendQueuePolls();
+#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+
+    ScheduleNextTCPUserTimeoutPoll(timeOut);
 
     mUserTimeoutTimerRunning = true;
 }
@@ -1664,6 +1754,7 @@ void TCPEndPoint::RestartTCPUserTimeoutTimer()
 
     StartTCPUserTimeoutTimer();
 }
+
 #endif // INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
@@ -1756,13 +1847,19 @@ void TCPEndPoint::HandleDataSent(uint16_t lenSent)
         // across.
         if (lenSent > 0)
         {
-            if (mSendQueue == NULL && mUserTimeoutTimerRunning)
+            if (mSendQueue == NULL)
             {
                 // If the output queue has been flushed then stop the timer.
 
                 StopTCPUserTimeoutTimer();
+
+#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+                // Notify up if all outstanding data has been acknowledged
+
+                SetTCPSendIdleAndNotifyChange(true);
+#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
             }
-            else if (mSendQueue != NULL && mUserTimeoutTimerRunning)
+            else
             {
                 // Progress is being made. So, shift the timer
                 // forward if it was started.
@@ -2209,11 +2306,20 @@ void TCPEndPoint::ReceiveData()
         return;
     }
 
-    if (mLastTCPSendQueueLen == 0)
+    if (mLastTCPKernelSendQueueLen == 0)
     {
         // If the output queue has been flushed then stop the timer.
 
         StopTCPUserTimeoutTimer();
+
+#if INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
+        // Notify up if all outstanding data has been acknowledged
+
+        if (mSendQueue == NULL)
+        {
+            SetTCPSendIdleAndNotifyChange(true);
+        }
+#endif // INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS
     }
     else if (isProgressing && mUserTimeoutTimerRunning)
     {
@@ -2393,7 +2499,7 @@ INET_ERROR TCPEndPoint::CheckConnectionProgress(bool &isProgressing)
    }
 
    if ((currPendingBytes != 0) &&
-       (mBytesWrittenSinceLastProbe + mLastTCPSendQueueLen == static_cast<uint32_t>(currPendingBytes)))
+       (mBytesWrittenSinceLastProbe + mLastTCPKernelSendQueueLen == static_cast<uint32_t>(currPendingBytes)))
    {
        // No progress has been made
 
@@ -2411,7 +2517,7 @@ INET_ERROR TCPEndPoint::CheckConnectionProgress(bool &isProgressing)
 
    mBytesWrittenSinceLastProbe = 0;
 
-   mLastTCPSendQueueLen = currPendingBytes;
+   mLastTCPKernelSendQueueLen = currPendingBytes;
 
 exit:
    return err;

--- a/src/lib/core/WeaveConnection.cpp
+++ b/src/lib/core/WeaveConnection.cpp
@@ -1199,7 +1199,6 @@ WEAVE_ERROR WeaveConnection::StartConnect()
         WeaveLogProgress(MessageLayer, "TCP con start %04" PRIX16 " %s %d", LogId(), ipAddrStr, (int)PeerPort);
     }
 #endif
-
     // Initiate the TCP connection.
     return mTcpEndPoint->Connect(PeerAddr, PeerPort, mTargetInterface);
 }

--- a/src/lib/core/WeaveMessageLayer.h
+++ b/src/lib/core/WeaveMessageLayer.h
@@ -296,6 +296,8 @@ public:
     WEAVE_ERROR ResetUserTimeout(void);
     uint16_t LogId(void) const { return static_cast<uint16_t>(reinterpret_cast<intptr_t>(this)); }
 
+    TCPEndPoint * GetTCPEndPoint(void) const { return mTcpEndPoint; }
+
     /**
      *  This function is the application callback that is invoked when a connection setup is complete.
      *

--- a/src/lib/core/WeaveTunnelConfig.h
+++ b/src/lib/core/WeaveTunnelConfig.h
@@ -307,6 +307,19 @@
 #endif // WEAVE_CONFIG_TUNNEL_TCP_USER_TIMEOUT_SUPPORTED
 
 /**
+ *  @def WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
+ *
+ *  @brief
+ *    This defines whether support for enabling the TCP
+ *    send channel being idle is present for the Weave
+ *    Tunnel.
+ *
+ */
+#ifndef WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
+#define WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK             (INET_CONFIG_ENABLE_TCP_SEND_IDLE_CALLBACKS)
+#endif // WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
+
+/**
  *  @def WEAVE_CONFIG_TUNNEL_SHORTCUT_SUPPORTED
  *
  *  @brief

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.cpp
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.cpp
@@ -451,6 +451,7 @@ WEAVE_ERROR WeaveTunnelAgent::ConfigurePrimaryTunnelTimeout(uint16_t maxTimeoutS
 {
     return mPrimaryTunConnMgr.ConfigureConnTimeout(maxTimeoutSecs);
 }
+
 #endif // WEAVE_CONFIG_TUNNEL_TCP_USER_TIMEOUT_SUPPORTED
 
 #if WEAVE_CONFIG_TUNNEL_TCP_KEEPALIVE_SUPPORTED
@@ -662,6 +663,7 @@ WEAVE_ERROR WeaveTunnelAgent::ConfigureBackupTunnelTimeout(uint16_t maxTimeoutSe
 {
     return mBackupTunConnMgr.ConfigureConnTimeout(maxTimeoutSecs);
 }
+
 #endif // WEAVE_CONFIG_TUNNEL_TCP_USER_TIMEOUT_SUPPORTED
 
 #if WEAVE_CONFIG_TUNNEL_TCP_KEEPALIVE_SUPPORTED
@@ -1699,6 +1701,19 @@ void WeaveTunnelAgent::WeaveTunnelConnectionErrorNotify(const WeaveTunnelConnect
 #endif // WEAVE_CONFIG_TUNNEL_FAILOVER_SUPPORTED
     }
 }
+
+#if WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
+/**
+ * Tunnel TCP connection send queue state notifier.
+ */
+void WeaveTunnelAgent::WeaveTunnelNotifyTCPSendIdleStateChange(const TunnelType tunType, const bool isIdle)
+{
+    if (OnServiceTunTCPIdleNotify)
+    {
+        OnServiceTunTCPIdleNotify(tunType, isIdle, mAppContext);
+    }
+}
+#endif // WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
 
 void WeaveTunnelAgent::WeaveTunnelServiceReconnectRequested(const WeaveTunnelConnectionMgr *connMgr,
                                                             const char *reconnectHost,

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.h
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.h
@@ -221,6 +221,7 @@ public:
  *  Configure the TCP user timeout option on the primary tunnel connection.
  */
     WEAVE_ERROR ConfigurePrimaryTunnelTimeout(uint16_t maxTimeoutSecs);
+
 #endif // WEAVE_CONFIG_TUNNEL_TCP_USER_TIMEOUT_SUPPORTED
 
 #if WEAVE_CONFIG_TUNNEL_TCP_KEEPALIVE_SUPPORTED
@@ -317,6 +318,7 @@ public:
  *  Configure the TCP user timeout option on the backup tunnel connection.
  */
     WEAVE_ERROR ConfigureBackupTunnelTimeout(uint16_t maxTimeoutSecs);
+
 #endif // WEAVE_CONFIG_TUNNEL_TCP_USER_TIMEOUT_SUPPORTED
 
 #if WEAVE_CONFIG_TUNNEL_TCP_KEEPALIVE_SUPPORTED
@@ -446,6 +448,25 @@ public:
                                                         void *appCtxt);
 
     OnServiceTunnelReconnectNotifyFunct OnServiceTunReconnectNotify;
+
+#if WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
+/**
+ * Function pointer to handler set by a higher layer to act upon a notification related to
+ * the tunnel to the Service being idle or not.
+ *
+ * @param[in] tunType       The tunnel type, Primary or Backup.
+ *
+ * @param[in] isIdle        true if the Tunnel TCP connection is idle, otherwise false.
+ *
+ * @param[in] appCtxt       A pointer to an application context object
+ *
+ */
+    typedef void (*OnServiceTunnelTCPIdleNotifyFunct)(TunnelType tunType,
+                                                      bool isIdle,
+                                                      void *appCtxt);
+
+    OnServiceTunnelTCPIdleNotifyFunct OnServiceTunTCPIdleNotify;
+#endif // WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
 
 #if WEAVE_CONFIG_TUNNEL_ENABLE_TRANSIT_CALLBACK
 /**
@@ -668,6 +689,10 @@ private:
 
     void NotifyTunnelLiveness(TunnelType tunType, WEAVE_ERROR err);
 #endif // WEAVE_CONFIG_TUNNEL_LIVENESS_SUPPORTED
+
+#if WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
+    void WeaveTunnelNotifyTCPSendIdleStateChange(const TunnelType tunType, const bool isIdle);
+#endif // WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
 
 };
 

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.h
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.h
@@ -166,6 +166,13 @@ class NL_DLL_EXPORT WeaveTunnelConnectionMgr
  */
     static void HandleServiceConnectionComplete(WeaveConnection *con, WEAVE_ERROR conErr);
 
+#if WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
+/**
+ * Handler invoked when the Idle state of the underlying TCP connection's send channel changes.
+ */
+    static void HandleTCPSendIdleChanged(TCPEndPoint *tcpEndPoint, bool isIdle);
+#endif // WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
+
 /**
  * Handler invoked when Service TCP connection is closed. The device tries to re-establish the connection to
  * the Service if the mServiceConKeepAlive is set to true.
@@ -301,6 +308,7 @@ class NL_DLL_EXPORT WeaveTunnelConnectionMgr
     // Tunnel TCP connection max user timeout (in secs)
 
     uint16_t mMaxUserTimeoutSecs;
+
 #endif // WEAVE_CONFIG_TUNNEL_TCP_USER_TIMEOUT_SUPPORTED
 
 #if WEAVE_CONFIG_TUNNEL_LIVENESS_SUPPORTED

--- a/src/test-apps/TestWeaveTunnel.h
+++ b/src/test-apps/TestWeaveTunnel.h
@@ -80,6 +80,7 @@ enum
     kTestNum_TestTunnelResetReconnectBackoffImmediately         = 24,
     kTestNum_TestTunnelResetReconnectBackoffRandomized          = 25,
     kTestNum_TestTunnelNoStatusReportResetReconnectBackoff      = 26,
+    kTestNum_TestTunnelTCPIdle                                  = 27,
 };
 
 #endif // WEAVE_CONFIG_ENABLE_TUNNELING


### PR DESCRIPTION
Notify application when the send channel of the TCP connection changes state between being idle or not-idle.
    
This feature is configurable at compile time on the TCPEndPoint.
When enabled, it does the following:
After sending data, the device polls the TCP send queue periodically and if it has flushed all pending data, the application is notified and polling stopped.
    
If the data flow has not progressed and the configured TCP UserTimeout expires, the connection is closed.
    
If the data flow progresses at any poll, the TCP UserTimeout timer is reset.
    
The TunnelAgent utilizes this TCPEndPoint feature to, subsequently, notify the application.
    
Add Tunnel test case for sent-data flushed notification.