### PR TITLE
Enhancements to DNS name resolution

### DIFF
--- a/src/inet/AsyncDNSResolverSockets.h
+++ b/src/inet/AsyncDNSResolverSockets.h
@@ -64,9 +64,8 @@ public:
 
     INET_ERROR Shutdown(void);
 
-    INET_ERROR PrepareDNSResolver(DNSResolver &resolver, const char *hostName,
-                                  uint16_t hostNameLen, uint8_t maxAddrs,
-                                  IPAddress *addrArray,
+    INET_ERROR PrepareDNSResolver(DNSResolver &resolver, const char *hostName, uint16_t hostNameLen,
+                                  uint8_t options, uint8_t maxAddrs, IPAddress *addrArray,
                                   DNSResolver::OnResolveCompleteFunct onComplete, void *appState);
 
 private:

--- a/src/inet/DNSResolver.cpp
+++ b/src/inet/DNSResolver.cpp
@@ -23,10 +23,11 @@
  *
  */
 
-#include <InetLayer/DNSResolver.h>
-
 #include <InetLayer/InetLayer.h>
+#include <InetLayer/DNSResolver.h>
 #include <InetLayer/InetLayerEvents.h>
+
+#include <Weave/Support/CodeUtils.h>
 
 #include <string.h>
 
@@ -65,6 +66,9 @@ Weave::System::ObjectPool<DNSResolver, INET_CONFIG_NUM_DNS_RESOLVERS> DNSResolve
  *  @param[in]  hostNameLen The string length of host name.
  *  @param[in]  maxAddrs    The maximum number of addresses to store in the DNS
  *                          table.
+ *  @param[in]  options     An integer value controlling how host name address
+ *                          resolution is performed.  Values are from the #DNSOptions
+ *                          enumeration.
  *  @param[in]  addrArray   A pointer to the DNS table.
  *  @param[in]  onComplete  A pointer to the callback function when a DNS
  *                          request is complete.
@@ -82,13 +86,31 @@ Weave::System::ObjectPool<DNSResolver, INET_CONFIG_NUM_DNS_RESOLVERS> DNSResolve
  *                                          resolver implementation.
  *
  */
-INET_ERROR DNSResolver::Resolve(const char *hostName, uint16_t hostNameLen, uint8_t maxAddrs, IPAddress *addrArray,
-    DNSResolver::OnResolveCompleteFunct onComplete, void *appState)
+INET_ERROR DNSResolver::Resolve(const char *hostName, uint16_t hostNameLen, uint8_t options,
+        uint8_t maxAddrs, IPAddress *addrArray,
+        DNSResolver::OnResolveCompleteFunct onComplete, void *appState)
 {
+    INET_ERROR res = INET_NO_ERROR;
+
 #if !WEAVE_SYSTEM_CONFIG_USE_SOCKETS && !LWIP_DNS
     Release();
     return INET_ERROR_NOT_IMPLEMENTED;
 #endif // !WEAVE_SYSTEM_CONFIG_USE_SOCKETS && !LWIP_DNS
+
+    uint8_t addrFamilyOption = (options & kDNSOption_AddrFamily_Mask);
+    uint8_t optionFlags = (options & kDNSOption_Flags_Mask);
+
+    // Check that the supplied options are valid.
+    if ((addrFamilyOption != kDNSOption_AddrFamily_Any &&
+         addrFamilyOption != kDNSOption_AddrFamily_IPv4Only &&
+         addrFamilyOption != kDNSOption_AddrFamily_IPv4Preferred &&
+         addrFamilyOption != kDNSOption_AddrFamily_IPv6Only &&
+         addrFamilyOption != kDNSOption_AddrFamily_IPv6Preferred) ||
+        (optionFlags & ~kDNSOption_ValidFlags) != 0)
+    {
+        Release();
+        return INET_ERROR_BAD_ARGS;
+    }
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS || (WEAVE_SYSTEM_CONFIG_USE_LWIP && LWIP_DNS)
 
@@ -100,26 +122,64 @@ INET_ERROR DNSResolver::Resolve(const char *hostName, uint16_t hostNameLen, uint
     memcpy(hostNameBuf, hostName, hostNameLen);
     hostNameBuf[hostNameLen] = 0;
 
-#if WEAVE_SYSTEM_CONFIG_USE_LWIP
-
-    INET_ERROR res = INET_NO_ERROR;
-
     AppState = appState;
-
-    if (maxAddrs > INET_CONFIG_MAX_DNS_ADDRS)
-        maxAddrs = INET_CONFIG_MAX_DNS_ADDRS;
-
     AddrArray = addrArray;
     MaxAddrs = maxAddrs;
     NumAddrs = 0;
+    DNSOptions = options;
     OnComplete = onComplete;
+
+#if WEAVE_SYSTEM_CONFIG_USE_LWIP
+
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
+
+    u8_t lwipAddrType;
+
+#if INET_CONFIG_ENABLE_IPV4
+    switch (addrFamilyOption)
+    {
+    case kDNSOption_AddrFamily_IPv4Only:
+        lwipAddrType = LWIP_DNS_ADDRTYPE_IPV4;
+        break;
+    case kDNSOption_AddrFamily_Any:
+    case kDNSOption_AddrFamily_IPv4Preferred:
+        lwipAddrType = LWIP_DNS_ADDRTYPE_IPV4_IPV6;
+        break;
+    case kDNSOption_AddrFamily_IPv6Only:
+        lwipAddrType = LWIP_DNS_ADDRTYPE_IPV6;
+        break;
+    case kDNSOption_AddrFamily_IPv6Preferred:
+        lwipAddrType = LWIP_DNS_ADDRTYPE_IPV6_IPV4;
+        break;
+    }
+#else // INET_CONFIG_ENABLE_IPV4
+    lwipAddrType = LWIP_DNS_ADDRTYPE_IPV6;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+#else // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR < 5
+
+#if INET_CONFIG_ENABLE_IPV4
+    if (addrFamilyOption == kDNSOption_AddrFamily_IPv6Only)
+#endif
+    {
+        Release();
+        return INET_ERROR_NOT_IMPLEMENTED;
+    }
+
+#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR < 5
 
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
 
-    ip_addr_t lwipAddrArray[INET_CONFIG_MAX_DNS_ADDRS];
+    ip_addr_t lwipAddr;
     LWIP_DNS_FOUND_CALLBACK_TYPE lwipCallback = reinterpret_cast<LWIP_DNS_FOUND_CALLBACK_TYPE>(LwIPHandleResolveComplete);
-    err_t lwipErr = dns_gethostbyname(hostNameBuf, lwipAddrArray, lwipCallback, this);
+
+    err_t lwipErr =
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
+            dns_gethostbyname_addrtype(hostNameBuf, &lwipAddr, lwipCallback, this, lwipAddrType);
+#else
+            dns_gethostbyname(hostNameBuf, &lwipAddr, lwipCallback, this);
+#endif
 
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
@@ -128,7 +188,13 @@ INET_ERROR DNSResolver::Resolve(const char *hostName, uint16_t hostNameLen, uint
     {
         Weave::System::Layer& lSystemLayer = SystemLayer();
 
-        CopyAddresses(1, lwipAddrArray);
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
+        AddrArray[0] = IPAddress::FromLwIPAddr(lwipAddr);
+#else
+        AddrArray[0] = IPAddress::FromIPv4(lwipAddr);
+#endif
+        NumAddrs = 1;
+
         lSystemLayer.PostEvent(*this, kInetEvent_DNSResolveComplete, 0);
     }
     else if (lwipErr != ERR_INPROGRESS)
@@ -143,53 +209,24 @@ INET_ERROR DNSResolver::Resolve(const char *hostName, uint16_t hostNameLen, uint
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
-    INET_ERROR err = INET_NO_ERROR;
-    struct addrinfo hints;
-    struct addrinfo *lookupRes = NULL;
-    int getaddrinfoRes;
+    struct addrinfo gaiHints;
+    struct addrinfo * gaiResults = NULL;
+    int gaiReturnCode;
 
-    NumAddrs = 0;
+    // Configure the hints argument for getaddrinfo()
+    InitAddrInfoHints(gaiHints);
 
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_protocol = 6;
-    hints.ai_flags = AI_ADDRCONFIG;
+    // Call getaddrinfo() to perform the name resolution.
+    gaiReturnCode = getaddrinfo(hostNameBuf, NULL, &gaiHints, &gaiResults);
 
-    getaddrinfoRes = getaddrinfo(hostNameBuf, NULL, &hints, &lookupRes);
+    // Process the return code and results list returned by getaddrinfo(). If the call
+    // was successful this will copy the resultant addresses into the caller's array.
+    res = ProcessGetAddrInfoResult(gaiReturnCode, gaiResults);
 
-    if (getaddrinfoRes == 0)
-    {
-        for (struct addrinfo *addr = lookupRes; addr != NULL && NumAddrs < maxAddrs; addr = addr->ai_next, NumAddrs++)
-            addrArray[NumAddrs] = IPAddress::FromSockAddr(*addr->ai_addr);
-    }
-    else
-    {
-        switch (getaddrinfoRes)
-        {
-        case EAI_NODATA:
-            err = INET_NO_ERROR;
-            break;
-        case EAI_NONAME:
-            err = INET_ERROR_HOST_NOT_FOUND;
-            break;
-        case EAI_AGAIN:
-            err = INET_ERROR_DNS_TRY_AGAIN;
-            break;
-        case EAI_SYSTEM:
-            err = Weave::System::MapErrorPOSIX(errno);
-            break;
-        default:
-            err = INET_ERROR_DNS_NO_RECOVERY;
-            break;
-        }
-    }
+    // Invoke the caller's completion function.
+    onComplete(appState, res, NumAddrs, addrArray);
 
-    if (lookupRes != NULL)
-        freeaddrinfo(lookupRes);
-
-    onComplete(appState, err, NumAddrs, addrArray);
-
+    // Release DNSResolver object.
     Release();
 
     return INET_NO_ERROR;
@@ -197,6 +234,7 @@ INET_ERROR DNSResolver::Resolve(const char *hostName, uint16_t hostNameLen, uint
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS || (WEAVE_SYSTEM_CONFIG_USE_LWIP && LWIP_DNS)
 }
+
 
 /**
  *  This method cancels DNS requests that are in progress.
@@ -291,40 +329,199 @@ void DNSResolver::LwIPHandleResolveComplete(const char *name, ip_addr_t *ipaddr,
         Weave::System::Layer& lSystemLayer = resolver->SystemLayer();
 
         // Copy the resolved address to the application supplied buffer, but only if the request hasn't been canceled.
-        if (resolver->OnComplete != NULL)
-            resolver->CopyAddresses((ipaddr != NULL) ? 1 : 0, ipaddr);
+        if (resolver->OnComplete != NULL && ipaddr != NULL)
+        {
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
+            resolver->AddrArray[0] = IPAddress::FromLwIPAddr(*ipaddr);
+#else
+            resolver->AddrArray[0] = IPAddress::FromIPv4(*ipaddr);
+#endif
+            resolver->NumAddrs = 1;
+        }
 
         lSystemLayer.PostEvent(*resolver, kInetEvent_DNSResolveComplete, 0);
     }
 }
 
-/**
- *  This method copies a list of resolved IP addresses to the DNS table.
- *
- *  @param[in]  numAddrs    The number of addresses in the list.
- *  @param[in]  addrs       A list of resolved IP addresses.
- *
- */
-void DNSResolver::CopyAddresses(uint8_t numAddrs, const ip_addr_t *addrs)
-{
-    if (numAddrs > MaxAddrs)
-        numAddrs = MaxAddrs;
-
-    for (uint8_t i = 0; i < numAddrs; i++)
-    {
-#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
-        AddrArray[i] = IPAddress::FromLwIPAddr(addrs[i]);
-#else
-        AddrArray[i] = IPAddress::FromIPv4(addrs[i]);
-#endif
-    }
-
-    NumAddrs = numAddrs;
-}
-
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+
+void DNSResolver::InitAddrInfoHints(struct addrinfo & hints)
+{
+    uint8_t addrFamilyOption = (DNSOptions & kDNSOption_AddrFamily_Mask);
+
+    memset(&hints, 0, sizeof(hints));
+#if INET_CONFIG_ENABLE_IPV4
+    if (addrFamilyOption == kDNSOption_AddrFamily_IPv4Only)
+    {
+        hints.ai_family = AF_INET;
+    }
+    else if (addrFamilyOption == kDNSOption_AddrFamily_IPv6Only)
+    {
+        hints.ai_family = AF_INET6;
+    }
+    else
+    {
+        hints.ai_family = AF_UNSPEC;
+    }
+#else // INET_CONFIG_ENABLE_IPV4
+    hints.ai_family = AF_INET6;
+#endif // INET_CONFIG_ENABLE_IPV4
+    hints.ai_flags = AI_ADDRCONFIG;
+}
+
+INET_ERROR DNSResolver::ProcessGetAddrInfoResult(int returnCode, struct addrinfo * results)
+{
+    INET_ERROR err = INET_NO_ERROR;
+
+    // If getaddrinfo() succeeded, copy addresses in the returned addrinfo structures into the
+    // application's output array...
+    if (returnCode == 0)
+    {
+        NumAddrs = 0;
+
+#if INET_CONFIG_ENABLE_IPV4
+
+        // Based on the address family option specified by the application, determine which
+        // types of addresses should be returned and the order in which they should appear.
+        uint8_t addrFamilyOption = (DNSOptions & kDNSOption_AddrFamily_Mask);
+        int primaryFamily, secondaryFamily;
+        switch (addrFamilyOption)
+        {
+        case kDNSOption_AddrFamily_Any:
+            primaryFamily = AF_UNSPEC;
+            secondaryFamily = AF_UNSPEC;
+            break;
+        case kDNSOption_AddrFamily_IPv4Only:
+            primaryFamily = AF_INET;
+            secondaryFamily = AF_UNSPEC;
+            break;
+        case kDNSOption_AddrFamily_IPv4Preferred:
+            primaryFamily = AF_INET;
+            secondaryFamily = AF_INET6;
+            break;
+        case kDNSOption_AddrFamily_IPv6Only:
+            primaryFamily = AF_INET6;
+            secondaryFamily = AF_UNSPEC;
+            break;
+        case kDNSOption_AddrFamily_IPv6Preferred:
+            primaryFamily = AF_INET6;
+            secondaryFamily = AF_INET;
+            break;
+        }
+
+        // Determine the number of addresses of each family present in the results.
+        // In the case of the secondary address family, only count these if they are
+        // to be returned in the results.
+        uint8_t numPrimaryAddrs = CountAddresses(primaryFamily, results);
+        uint8_t numSecondaryAddrs = (secondaryFamily != AF_UNSPEC) ? CountAddresses(secondaryFamily, results) : 0;
+        uint8_t numAddrs = numPrimaryAddrs + numSecondaryAddrs;
+
+        // If the total number of addresses to be returned exceeds the application
+        // specified max, ensure that at least 1 address from the secondary family
+        // appears in the result (unless of course there are no such addresses or
+        // the max is set to 1).
+        // This ensures the application will try at least one secondary address
+        // when attempting to communicate with the host.
+        if (numAddrs > MaxAddrs && MaxAddrs > 1 && numPrimaryAddrs > 0 && numSecondaryAddrs > 0)
+        {
+            numPrimaryAddrs = ::nl::Weave::min(numPrimaryAddrs, (uint8_t)(MaxAddrs - 1));
+        }
+
+        // Copy the primary addresses into the beginning of the application's output array,
+        // up to the limit determined above.
+        CopyAddresses(primaryFamily, numPrimaryAddrs, results);
+
+        // If secondary addresses are being returned, copy them into the output array after
+        // the primary addresses.
+        if (numSecondaryAddrs != 0)
+        {
+            CopyAddresses(secondaryFamily, numSecondaryAddrs, results);
+        }
+
+#else // INET_CONFIG_ENABLE_IPV4
+
+        // Copy IPv6 addresses into the application's output array.
+        CopyAddresses(AF_INET6, UINT8_MAX, results);
+
+#endif // INET_CONFIG_ENABLE_IPV4
+
+        // If in the end no addresses were returned, treat this as a "host not found" error.
+        if (NumAddrs == 0)
+        {
+            err = INET_ERROR_HOST_NOT_FOUND;
+        }
+    }
+
+    // Otherwise, getaddrinfo() failed, so translate the return code to an appropriate
+    // Inet error...
+    else
+    {
+        switch (returnCode)
+        {
+        case EAI_NONAME:
+        case EAI_NODATA:
+        case EAI_ADDRFAMILY:
+            // Each of these errors is translated to "host not found" for simplicity at the
+            // application layer. On most systems, the errors have the following meanings:
+            //    EAI_NONAME is returned when there are no DNS records for the requested host name.
+            //    EAI_NODATA is returned when there are no host records (A or AAAA) for the requested
+            //      name, but other records do exist (e.g. MX or TXT).
+            //    EAI_ADDRFAMILY is returned when a text-form address is given as the name, but its
+            //      address family (IPv4 or IPv6) does not match the value specified in hints.ai_family.
+            err = INET_ERROR_HOST_NOT_FOUND;
+            break;
+        case EAI_AGAIN:
+            err = INET_ERROR_DNS_TRY_AGAIN;
+            break;
+        case EAI_SYSTEM:
+            err = Weave::System::MapErrorPOSIX(errno);
+            break;
+        default:
+            err = INET_ERROR_DNS_NO_RECOVERY;
+            break;
+        }
+    }
+
+    // Free the results structure.
+    if (results != NULL)
+        freeaddrinfo(results);
+
+    return err;
+}
+
+void DNSResolver::CopyAddresses(int family, uint8_t count, const struct addrinfo * addrs)
+{
+    for (const struct addrinfo *addr = addrs;
+         addr != NULL && NumAddrs < MaxAddrs && count > 0;
+         addr = addr->ai_next)
+    {
+        if (family == AF_UNSPEC || addr->ai_addr->sa_family == family)
+        {
+            AddrArray[NumAddrs++] = IPAddress::FromSockAddr(*addr->ai_addr);
+            count--;
+        }
+    }
+}
+
+uint8_t DNSResolver::CountAddresses(int family, const struct addrinfo * addrs)
+{
+    uint8_t count = 0;
+
+    for (const struct addrinfo *addr = addrs;
+         addr != NULL && count < UINT8_MAX;
+         addr = addr->ai_next)
+    {
+        if (family == AF_UNSPEC || addr->ai_addr->sa_family == family)
+        {
+            count++;
+        }
+    }
+
+    return count;
+}
+
 #if INET_CONFIG_ENABLE_ASYNC_DNS_SOCKETS
 
 void DNSResolver::HandleAsyncResolveComplete(void)

--- a/src/inet/InetError.h
+++ b/src/inet/InetError.h
@@ -348,6 +348,16 @@ typedef INET_CONFIG_ERROR_TYPE          INET_ERROR;
 #define INET_ERROR_TCP_CONNECT_TIMEOUT                      _INET_ERROR(26)
 
 /**
+ *  @def INET_ERROR_INCOMPATIBLE_IP_ADDRESS_TYPE
+ *
+ *  @brief
+ *    The supplied text-form IP address was not compatible with the requested
+ *    IP address type.
+ *
+ */
+#define INET_ERROR_INCOMPATIBLE_IP_ADDRESS_TYPE             _INET_ERROR(27)
+
+/**
  *  @}
  */
 

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -231,11 +231,17 @@ class NL_DLL_EXPORT InetLayer
 
 #if INET_CONFIG_ENABLE_DNS_RESOLVER
 
-    INET_ERROR ResolveHostAddress(const char *hostName, uint16_t hostNameLen, uint8_t maxAddrs, IPAddress *addrArray,
-            DNSResolver::OnResolveCompleteFunct onComplete, void *appState);
+    typedef DNSResolver::OnResolveCompleteFunct DNSResolveCompleteFunct;
+
+    INET_ERROR ResolveHostAddress(const char *hostName, uint16_t hostNameLen, uint8_t options,
+            uint8_t maxAddrs, IPAddress *addrArray,
+            DNSResolveCompleteFunct onComplete, void *appState);
+    INET_ERROR ResolveHostAddress(const char *hostName, uint16_t hostNameLen,
+            uint8_t maxAddrs, IPAddress *addrArray,
+            DNSResolveCompleteFunct onComplete, void *appState);
     INET_ERROR ResolveHostAddress(const char *hostName, uint8_t maxAddrs, IPAddress *addrArray,
-            DNSResolver::OnResolveCompleteFunct onComplete, void *appState);
-    void CancelResolveHostAddress(DNSResolver::OnResolveCompleteFunct onComplete, void *appState);
+            DNSResolveCompleteFunct onComplete, void *appState);
+    void CancelResolveHostAddress(DNSResolveCompleteFunct onComplete, void *appState);
 
 #endif // INET_CONFIG_ENABLE_DNS_RESOLVER
 

--- a/src/lib/support/ErrorStr.cpp
+++ b/src/lib/support/ErrorStr.cpp
@@ -321,6 +321,7 @@ NL_DLL_EXPORT const char *ErrorStr(int32_t err)
     case INET_ERROR_INTERFACE_INIT_FAILURE                      : return InetFormatError(err, "Failure to initialize interface");
     case INET_ERROR_TCP_USER_TIMEOUT                            : return InetFormatError(err, "TCP User Timeout");
     case INET_ERROR_TCP_CONNECT_TIMEOUT                         : return InetFormatError(err, "TCP Connect Timeout");
+    case INET_ERROR_INCOMPATIBLE_IP_ADDRESS_TYPE                : return InetFormatError(err, "Incompatible IP address type");
 
 #if CONFIG_NETWORK_LAYER_BLE
     // ----- BleLayer Errors -----

--- a/src/test-apps/TestDNSResolution.cpp
+++ b/src/test-apps/TestDNSResolution.cpp
@@ -32,189 +32,646 @@
 
 #include "ToolCommon.h"
 #include <nltest.h>
+#include <SystemLayer/SystemClock.h>
 #include <SystemLayer/SystemTimer.h>
+
+#if INET_CONFIG_ENABLE_DNS_RESOLVER
 
 using namespace nl::Inet;
 
-#define TOOL_NAME "TestAsyncDNS"
+#define TOOL_NAME "TestDNSResolution"
 #define DEFAULT_TEST_DURATION_MILLISECS               (10000)
 #define DEFAULT_CANCEL_TEST_DURATION_MILLISECS        (2000)
 
+static uint32_t sNumResInProgress = 0;
+constexpr uint8_t kMaxResults = 20;
+
+struct DNSResolutionTestCase
+{
+    const char * hostName;
+    uint8_t dnsOptions;
+    uint8_t maxResults;
+    INET_ERROR expectErr;
+    bool expectIPv4Addrs;
+    bool expectIPv6Addrs;
+};
+
+struct DNSResolutionTestContext
+{
+    nlTestSuite * testSuite;
+    DNSResolutionTestCase testCase;
+    bool callbackCalled;
+    IPAddress resultsBuf[kMaxResults];
+};
+
+static void RunTestCase(nlTestSuite * testSuite, const DNSResolutionTestCase & testCase);
+static void StartTestCase(DNSResolutionTestContext & testContext);
+static void HandleResolutionComplete(void *appState, INET_ERROR err, uint8_t addrCount, IPAddress *addrArray);
+static void ServiceNetworkUntilDone(uint32_t timeoutMS);
 static void HandleSIGUSR1(int sig);
 
-const char *destHostName = NULL;
-uint64_t gTestStartTime = 0;
-int32_t gNumOfResolutionDone = 0;
-int32_t gMaxNumResolve = 4; // Max number of DNS Resolutions being performed.
-uint64_t gMaxTestDurationMillisecs = DEFAULT_TEST_DURATION_MILLISECS;
-bool gTestSucceeded = false;
-IPAddress DestAddr = IPAddress::Any;
-IPAddress DestAddrPool[2] = { IPAddress::Any, IPAddress::Any };
-
-#if INET_CONFIG_ENABLE_DNS_RESOLVER
-static void HandleDNSResolveComplete(void *appState, INET_ERROR err, uint8_t addrCount, IPAddress *addrArray);
-static void HandleDNSCancel(void *appState, INET_ERROR err, uint8_t addrCount, IPAddress *addrArray);
-static void HandleDNSInvalid(void *appState, INET_ERROR err, uint8_t addrCount, IPAddress *addrArray);
-#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
-
-static void TestDNSResolution(nlTestSuite *inSuite, void *inContext)
+/**
+ * Test basic name resolution functionality.
+ */
+static void TestDNSResolution_Basic(nlTestSuite * testSuite, void * testContext)
 {
-    INET_ERROR err = INET_NO_ERROR;
-    Done = false;
-    char testHostName1[20] = "www.nest.com";
-    char testHostName2[20] = "10.0.0.1";
-    char testHostName3[20] = "www.google.com";
-    char testHostName4[20] = "pool.ntp.org";
-    gTestSucceeded = false;
-    gMaxTestDurationMillisecs = DEFAULT_TEST_DURATION_MILLISECS;
-    gTestStartTime = Now();
-
-#if INET_CONFIG_ENABLE_DNS_RESOLVER
-    printf("Resolving hostname %s\n", testHostName1);
-    err = Inet.ResolveHostAddress(testHostName1, 1, &DestAddr, HandleDNSResolveComplete, testHostName1);
-    SuccessOrExit(err);
-
-    printf("Resolving hostname %s\n", testHostName2);
-    err = Inet.ResolveHostAddress(testHostName2, 1, &DestAddr, HandleDNSResolveComplete, testHostName2);
-    SuccessOrExit(err);
-
-    printf("Resolving hostname %s\n", testHostName3);
-    err = Inet.ResolveHostAddress(testHostName3, 1, &DestAddr, HandleDNSResolveComplete, testHostName3);
-    SuccessOrExit(err);
-
-    printf("Resolving hostname %s\n", testHostName4);
-    err = Inet.ResolveHostAddress(testHostName4, 2, DestAddrPool, HandleDNSResolveComplete, testHostName4);
-    SuccessOrExit(err);
-#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
-
-    while (!Done)
-    {
-        struct timeval sleepTime;
-        sleepTime.tv_sec = 0;
-        sleepTime.tv_usec = 10000;
-
-        ServiceNetwork(sleepTime);
-
-        if (Now() < gTestStartTime + gMaxTestDurationMillisecs * System::kTimerFactor_micro_per_milli)
+    // Test resolving a name with only IPv4 addresses.
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
         {
-            if (gTestSucceeded)
+            "ipv4.google.com",
+            kDNSOption_Default,
+            kMaxResults,
+            INET_NO_ERROR,
+            true,
+            false
+        }
+    );
+
+    // Test resolving a name with only IPv6 addresses.
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "ipv6.google.com",
+            kDNSOption_Default,
+            kMaxResults,
+            INET_NO_ERROR,
+            false,
+            true
+        }
+    );
+
+    // Test resolving a name with IPv4 and IPv6 addresses.
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "google.com",
+            kDNSOption_Default,
+            kMaxResults,
+            INET_NO_ERROR,
+            true,
+            true
+        }
+    );
+}
+
+/**
+ * Test resolving a name using various address type options.
+ */
+static void TestDNSResolution_AddressTypeOption(nlTestSuite * testSuite, void * testContext)
+{
+    // Test requesting IPv4 addresses only.
+#if INET_CONFIG_ENABLE_IPV4
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "google.com",
+            kDNSOption_AddrFamily_IPv4Only,
+            kMaxResults,
+            INET_NO_ERROR,
+            true,
+            false
+        }
+    );
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    // Test requesting IPv6 addresses only.
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "google.com",
+            kDNSOption_AddrFamily_IPv6Only,
+            kMaxResults,
+            INET_NO_ERROR,
+            false,
+            true
+        }
+    );
+
+    // Test requesting IPv4 address preferentially.
+#if INET_CONFIG_ENABLE_IPV4
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "google.com",
+            kDNSOption_AddrFamily_IPv4Preferred,
+            kMaxResults,
+            INET_NO_ERROR,
+            true,
+            true
+        }
+    );
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    // Test requesting IPv6 address preferentially.
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "google.com",
+            kDNSOption_AddrFamily_IPv6Preferred,
+            kMaxResults,
+            INET_NO_ERROR,
+            true,
+            true
+        }
+    );
+}
+
+/**
+ * Test resolving a name with a limited number of results.
+ */
+static void TestDNSResolution_RestrictedResults(nlTestSuite * testSuite, void * testContext)
+{
+    // Test requesting 2 IPv4 addresses.  This should result in, at most, 2 IPv4 addresses.
+#if INET_CONFIG_ENABLE_IPV4
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "google.com",
+            kDNSOption_AddrFamily_IPv4Only,
+            2,
+            INET_NO_ERROR,
+            true,
+            false
+        }
+    );
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    // Test requesting 2 IPv6 addresses.  This should result in, at most, 2 IPv6 addresses.
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "google.com",
+            kDNSOption_AddrFamily_IPv6Only,
+            2,
+            INET_NO_ERROR,
+            false,
+            true
+        }
+    );
+
+    // Test requesting 2 addresses, preferring IPv4.  This should result in 1 IPv4 address
+    // followed by 1 IPv6 address.
+#if INET_CONFIG_ENABLE_IPV4
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "google.com",
+            kDNSOption_AddrFamily_IPv4Preferred,
+            2,
+            INET_NO_ERROR,
+            true,
+            true
+        }
+    );
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    // Test requesting 2 addresses, preferring IPv6.  This should result in 1 IPv6 address
+    // followed by 1 IPv4 address.
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "google.com",
+            kDNSOption_AddrFamily_IPv6Preferred,
+            2,
+            INET_NO_ERROR,
+            true,
+            true
+        }
+    );
+}
+
+/**
+ * Test resolving a non-existant name.
+ */
+static void TestDNSResolution_NoRecord(nlTestSuite * testSuite, void * testContext)
+{
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "www.google.invalid.",
+            kDNSOption_AddrFamily_Any,
+            1,
+            INET_ERROR_HOST_NOT_FOUND,
+            false,
+            false
+        }
+    );
+}
+
+/**
+ * Test resolving a name where the resultant DNS entry lacks an A or AAAA record.
+ */
+static void TestDNSResolution_NoHostRecord(nlTestSuite * testSuite, void * testContext)
+{
+    // Test resolving a name that has no host records (A or AAAA).
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "_spf.google.com",
+            kDNSOption_AddrFamily_Any,
+            kMaxResults,
+            INET_ERROR_HOST_NOT_FOUND,
+            false,
+            false
+        }
+    );
+
+    // Test resolving a name that has only AAAA records, while requesting IPv4 addresses only.
+#if INET_CONFIG_ENABLE_IPV4
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "ipv6.google.com",
+            kDNSOption_AddrFamily_IPv4Only,
+            kMaxResults,
+            INET_ERROR_HOST_NOT_FOUND,
+            true,
+            false
+        }
+    );
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    // Test resolving a name that has only A records, while requesting IPv6 addresses only.
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "ipv4.google.com",
+            kDNSOption_AddrFamily_IPv6Only,
+            kMaxResults,
+            INET_ERROR_HOST_NOT_FOUND,
+            false,
+            false
+        }
+    );
+}
+
+/**
+ * Test resolving text form IP addresses.
+ */
+static void TestDNSResolution_TextForm(nlTestSuite * testSuite, void * testContext)
+{
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "216.58.194.174",
+            kDNSOption_AddrFamily_Any,
+            1,
+            INET_NO_ERROR,
+            true,
+            false
+        }
+    );
+
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "2607:f8b0:4005:804::200e",
+            kDNSOption_AddrFamily_Any,
+            1,
+            INET_NO_ERROR,
+            false,
+            true
+        }
+    );
+
+    // Test resolving text form IPv4 and IPv6 addresses while requesting an
+    // incompatible address type.
+
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "216.58.194.174",
+            kDNSOption_AddrFamily_IPv6Only,
+            1,
+            INET_ERROR_INCOMPATIBLE_IP_ADDRESS_TYPE,
+            false,
+            false
+        }
+    );
+
+    RunTestCase(testSuite,
+        DNSResolutionTestCase
+        {
+            "2607:f8b0:4005:804::200e",
+            kDNSOption_AddrFamily_IPv4Only,
+            1,
+            INET_ERROR_INCOMPATIBLE_IP_ADDRESS_TYPE,
+            false,
+            false
+        }
+    );
+}
+
+static void TestDNSResolution_Cancel(nlTestSuite *testSuite, void *inContext)
+{
+    DNSResolutionTestContext testContext
+    {
+        testSuite,
+        DNSResolutionTestCase
+        {
+            "www.google.com",
+            kDNSOption_Default,
+            kMaxResults,
+            INET_NO_ERROR,
+            true,
+            false
+        }
+    };
+
+    // Start DNS resolution.
+    StartTestCase(testContext);
+
+    // If address resolution did NOT complete synchronously...
+    // (NOTE: If address resolution completes synchronously then this test is effectively
+    // void, as there's no opportunity to cancel the request).
+    if (!testContext.callbackCalled)
+    {
+        // Cancel the resolution before it completes.
+        Inet.CancelResolveHostAddress(HandleResolutionComplete, (void *)&testContext);
+
+        // Service the network for awhile to see what happens (should timeout).
+        ServiceNetworkUntilDone(DEFAULT_CANCEL_TEST_DURATION_MILLISECS);
+
+        // Verify that the completion function was NOT called.
+        NL_TEST_ASSERT(testSuite, testContext.callbackCalled == false);
+    }
+
+    Done = true;
+    sNumResInProgress = 0;
+}
+
+static void TestDNSResolution_Simultaneous(nlTestSuite *testSuite, void *inContext)
+{
+    DNSResolutionTestContext tests[] =
+    {
+        {
+            testSuite,
+            DNSResolutionTestCase
             {
-                Done = true;
+                "www.nest.com",
+                kDNSOption_Default,
+                kMaxResults,
+                INET_NO_ERROR,
+                true,
+                false
             }
-            else
+        },
+        {
+            testSuite,
+            DNSResolutionTestCase
             {
-                continue;
+                "10.0.0.1",
+                kDNSOption_Default,
+                kMaxResults,
+                INET_NO_ERROR,
+                true,
+                false
+            }
+        },
+        {
+            testSuite,
+            DNSResolutionTestCase
+            {
+                "www.google.com",
+                kDNSOption_Default,
+                kMaxResults,
+                INET_NO_ERROR,
+                true,
+                true
+            }
+        },
+        {
+            testSuite,
+            DNSResolutionTestCase
+            {
+                "pool.ntp.org",
+                kDNSOption_Default,
+                kMaxResults,
+                INET_NO_ERROR,
+                true,
+                false
             }
         }
-        else // Time's up
+    };
+
+    // Start multiple DNS resolutions simultaneously.
+    for (DNSResolutionTestContext & testContext : tests)
+    {
+        StartTestCase(testContext);
+    }
+
+    // Service the network until each completes, or a timeout occurs.
+    ServiceNetworkUntilDone(DEFAULT_TEST_DURATION_MILLISECS);
+
+    // Verify no timeout occurred.
+    NL_TEST_ASSERT(testSuite, Done == true);
+
+    // Sanity check test logic.
+    NL_TEST_ASSERT(testSuite, sNumResInProgress == 0);
+}
+
+static void RunTestCase(nlTestSuite * testSuite, const DNSResolutionTestCase & testCase)
+{
+    DNSResolutionTestContext testContext {
+        testSuite,
+        testCase
+    };
+
+    // Start DNS resolution.
+    StartTestCase(testContext);
+
+    // Service the network until the completion callback is called.
+    ServiceNetworkUntilDone(DEFAULT_TEST_DURATION_MILLISECS);
+
+    // Verify no timeout occurred.
+    NL_TEST_ASSERT(testSuite, Done == true);
+
+    // Sanity check test logic.
+    NL_TEST_ASSERT(testSuite, sNumResInProgress == 0);
+}
+
+static void StartTestCase(DNSResolutionTestContext & testContext)
+{
+    INET_ERROR err = INET_NO_ERROR;
+    DNSResolutionTestCase & testCase = testContext.testCase;
+    nlTestSuite * testSuite = testContext.testSuite;
+
+    Done = false;
+    sNumResInProgress++;
+
+    printf("Resolving hostname %s\n", testCase.hostName);
+    err = Inet.ResolveHostAddress(testCase.hostName, strlen(testCase.hostName), testCase.dnsOptions,
+            testCase.maxResults, testContext.resultsBuf, HandleResolutionComplete, (void *)&testContext);
+
+    if (err != INET_NO_ERROR)
+    {
+        printf("ResolveHostAddress failed for %s: %s\n", testCase.hostName, ::nl::ErrorStr(err));
+
+        // Verify the expected error
+        NL_TEST_ASSERT(testSuite, err == testCase.expectErr);
+
+        // Verify the callback WASN'T called
+        NL_TEST_ASSERT(testSuite, testContext.callbackCalled == false); //
+
+        sNumResInProgress--;
+        if (sNumResInProgress == 0)
         {
-            gTestSucceeded = false;
             Done = true;
         }
     }
-
-
-exit:
-
-    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, gTestSucceeded == true);
 }
 
-static void TestDNSCancel(nlTestSuite *inSuite, void *inContext)
+static void HandleResolutionComplete(void *appState, INET_ERROR err, uint8_t addrCount, IPAddress *addrArray)
 {
-    INET_ERROR err = INET_NO_ERROR;
-    Done = false;
-    char testHostName1[20] = "www.nest.com";
-    gTestSucceeded = false;
-    gMaxTestDurationMillisecs = DEFAULT_CANCEL_TEST_DURATION_MILLISECS;
-    gTestStartTime = Now();
+    DNSResolutionTestContext & testContext = *static_cast<DNSResolutionTestContext *>(appState);
+    DNSResolutionTestCase & testCase = testContext.testCase;
+    nlTestSuite * testSuite = testContext.testSuite;
 
-#if INET_CONFIG_ENABLE_DNS_RESOLVER
-    printf("Resolving hostname %s\n", testHostName1);
-    err = Inet.ResolveHostAddress(testHostName1, 1, &DestAddr, HandleDNSCancel, NULL);
-    SuccessOrExit(err);
-
-    // Cancel the DNS request.
-    Inet.CancelResolveHostAddress(HandleDNSCancel, NULL);
-
-    gTestSucceeded = true;
-
-    while (Now() < gTestStartTime + gMaxTestDurationMillisecs * System::kTimerFactor_micro_per_milli)
+    if (err == INET_NO_ERROR)
     {
-        struct timeval sleepTime;
-        sleepTime.tv_sec = 0;
-        sleepTime.tv_usec = 10000;
-
-        ServiceNetwork(sleepTime);
+        printf("DNS resolution complete for %s: %" PRIu8 " result%s returned\n",
+               testCase.hostName, addrCount, (addrCount != 1) ? "s" : "");
+        for (uint8_t i = 0; i < addrCount; i++)
+        {
+            char ipAddrStr[32];
+            printf("    %s\n", addrArray[i].ToString(ipAddrStr, sizeof(ipAddrStr)));
+        }
+    }
+    else
+    {
+        printf("DNS resolution complete for %s: %s\n", testCase.hostName, ::nl::ErrorStr(err));
     }
 
-#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
+    // Verify the expected result.
+    NL_TEST_ASSERT(testSuite, err == testCase.expectErr);
 
-exit:
+    if (err == INET_NO_ERROR)
+    {
+        // Make sure the number of addresses is within the max expected.
+        NL_TEST_ASSERT(testSuite, addrCount <= testCase.maxResults);
 
-    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, gTestSucceeded == true);
+        // Determine the types of addresses in the response and their relative ordering.
+        bool respContainsIPv4Addrs = false;
+        bool respContainsIPv6Addrs = false;
+        for (uint8_t i = 0; i < addrCount; i++)
+        {
+            respContainsIPv4Addrs = respContainsIPv4Addrs || (addrArray[i].Type() == kIPAddressType_IPv4);
+            respContainsIPv6Addrs = respContainsIPv6Addrs || (addrArray[i].Type() == kIPAddressType_IPv6);
+        }
+
+        // Verify the expected address types were returned.
+        // The current LwIP DNS implementation returns at most one address.  So if the test expects
+        // both IPv4 and IPv6 addresses, relax this to accept either.
+#if WEAVE_SYSTEM_CONFIG_USE_LWIP
+        if (testCase.expectIPv4Addrs && testCase.expectIPv6Addrs)
+        {
+            NL_TEST_ASSERT(testSuite, respContainsIPv4Addrs || respContainsIPv6Addrs);
+        }
+        else
+#endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
+        {
+            if (testCase.expectIPv4Addrs)
+            {
+                NL_TEST_ASSERT(testSuite, respContainsIPv4Addrs);
+            }
+            if (testCase.expectIPv6Addrs)
+            {
+                NL_TEST_ASSERT(testSuite, respContainsIPv6Addrs);
+            }
+        }
+
+        // Verify that only the requested address types were returned, and that the
+        // addresses were returned in the correct order.
+        switch (testCase.dnsOptions & kDNSOption_AddrFamily_Mask)
+        {
+        case kDNSOption_AddrFamily_Any:
+            break;
+        case kDNSOption_AddrFamily_IPv4Only:
+            NL_TEST_ASSERT(testSuite, !respContainsIPv6Addrs);
+            break;
+        case kDNSOption_AddrFamily_IPv4Preferred:
+            if (respContainsIPv4Addrs)
+            {
+                NL_TEST_ASSERT(testSuite, addrArray[0].Type() == kIPAddressType_IPv4);
+            }
+            break;
+        case kDNSOption_AddrFamily_IPv6Only:
+            NL_TEST_ASSERT(testSuite, !respContainsIPv4Addrs);
+            break;
+        case kDNSOption_AddrFamily_IPv6Preferred:
+            if (respContainsIPv6Addrs)
+            {
+                NL_TEST_ASSERT(testSuite, addrArray[0].Type() == kIPAddressType_IPv6);
+            }
+            break;
+        default:
+            constexpr bool UnexpectedAddressTypeValue = true;
+            NL_TEST_ASSERT(testSuite, !UnexpectedAddressTypeValue);
+        }
+    }
+
+    testContext.callbackCalled = true;
+
+    sNumResInProgress--;
+    if (sNumResInProgress == 0)
+    {
+        Done = true;
+    }
 }
 
-static void TestDNSInvalid(nlTestSuite *inSuite, void *inContext)
+static void ServiceNetworkUntilDone(uint32_t timeoutMS)
 {
-    INET_ERROR err = INET_NO_ERROR;
-    Done = false;
-    char testInvalidHostName[20] = "www.google.invalid.";
-    gTestSucceeded = false;
-    gMaxTestDurationMillisecs = DEFAULT_CANCEL_TEST_DURATION_MILLISECS;
-    gTestStartTime = Now();
-
-#if INET_CONFIG_ENABLE_DNS_RESOLVER
-    printf("Resolving hostname %s\n", testInvalidHostName);
-    err = Inet.ResolveHostAddress(testInvalidHostName, 1, &DestAddr, HandleDNSInvalid, NULL);
-    SuccessOrExit(err);
+    uint64_t timeoutTimeMS = System::Layer::GetClock_MonotonicMS() + timeoutMS;
+    struct timeval sleepTime;
+    sleepTime.tv_sec = 0;
+    sleepTime.tv_usec = 10000;
 
     while (!Done)
     {
-        struct timeval sleepTime;
-        sleepTime.tv_sec = 0;
-        sleepTime.tv_usec = 10000;
-
         ServiceNetwork(sleepTime);
 
-        if (Now() < gTestStartTime + gMaxTestDurationMillisecs * System::kTimerFactor_micro_per_milli)
+        if (System::Layer::GetClock_MonotonicMS() >= timeoutTimeMS)
         {
-            if (gTestSucceeded)
-            {
-                Done = true;
-            }
-            else
-            {
-                continue;
-            }
-        }
-        else // Time's up
-        {
-            gTestSucceeded = false;
-            Done = true;
+            break;
         }
     }
-
-#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
-
-exit:
-
-    NL_TEST_ASSERT(inSuite, err == INET_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, gTestSucceeded == true);
 }
 
-static const nlTest DNSTests[] = {
-    NL_TEST_DEF("TestDNSResolution", TestDNSResolution),
-    NL_TEST_DEF("TestDNSCancel", TestDNSCancel),
-    NL_TEST_DEF("TestDNSInvalid", TestDNSInvalid),
-    NL_TEST_SENTINEL()
+static void HandleSIGUSR1(int sig)
+{
+    Inet.Shutdown();
+    exit(0);
+}
+
+static HelpOptions gHelpOptions(
+    TOOL_NAME,
+    "Usage: " TOOL_NAME " [<options...>]\n",
+    WEAVE_VERSION_STRING "\n" WEAVE_TOOL_COPYRIGHT
+);
+
+static OptionSet *gToolOptionSets[] =
+{
+    &gNetworkOptions,
+    &gWeaveNodeOptions,
+    &gFaultInjectionOptions,
+    &gHelpOptions,
+    NULL
 };
 
 int main(int argc, char *argv[])
 {
-#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
-    SetSignalHandler(HandleSIGUSR1);
+    const nlTest DNSTests[] = {
+        NL_TEST_DEF("TestDNSResolution:Basic", TestDNSResolution_Basic),
+        NL_TEST_DEF("TestDNSResolution:AddressTypeOption", TestDNSResolution_AddressTypeOption),
+        NL_TEST_DEF("TestDNSResolution:RestrictedResults", TestDNSResolution_RestrictedResults),
+        NL_TEST_DEF("TestDNSResolution:TextForm", TestDNSResolution_TextForm),
+        NL_TEST_DEF("TestDNSResolution:NoRecord", TestDNSResolution_NoRecord),
+        NL_TEST_DEF("TestDNSResolution:NoHostRecord", TestDNSResolution_NoHostRecord),
+        NL_TEST_DEF("TestDNSResolution:Cancel", TestDNSResolution_Cancel),
+        NL_TEST_DEF("TestDNSResolution:Simultaneous", TestDNSResolution_Simultaneous),
+        NL_TEST_SENTINEL()
+    };
 
     nlTestSuite DNSTestSuite = {
         "DNS",
@@ -223,7 +680,20 @@ int main(int argc, char *argv[])
 
     nl_test_set_output_style(OUTPUT_CSV);
 
+    InitToolCommon();
+
+    SetupFaultInjectionContext(argc, argv);
+
+    SetSignalHandler(HandleSIGUSR1);
+
+    if (!ParseArgsFromEnvVar(TOOL_NAME, TOOL_OPTIONS_ENV_VAR_NAME, gToolOptionSets, NULL, true) ||
+        !ParseArgs(TOOL_NAME, argc, argv, gToolOptionSets, NULL))
+    {
+        exit(EXIT_FAILURE);
+    }
+
     InitSystemLayer();
+
     InitNetwork();
 
     // Run all tests in Suite
@@ -234,53 +704,13 @@ int main(int argc, char *argv[])
     ShutdownSystemLayer();
 
     return nlTestRunnerStats(&DNSTestSuite);
-#else // !WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+}
+
+#else // !INET_CONFIG_ENABLE_DNS_RESOLVER
+
+int main(int argc, char *argv[])
+{
     return 0;
-#endif // !WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 }
 
-void HandleSIGUSR1(int sig)
-{
-    Inet.Shutdown();
-    exit(0);
-}
-
-#if INET_CONFIG_ENABLE_DNS_RESOLVER
-static void HandleDNSCancel(void *appState, INET_ERROR err, uint8_t addrCount, IPAddress *addrArray)
-{
-    printf("DNS Cancel failed: Callback should not have been called\n");
-    gTestSucceeded = false;
-}
-
-static void HandleDNSInvalid(void *appState, INET_ERROR err, uint8_t addrCount, IPAddress *addrArray)
-{
-    if (err != INET_NO_ERROR)
-      gTestSucceeded = true;
-}
-
-void HandleDNSResolveComplete(void *appState, INET_ERROR err, uint8_t addrCount, IPAddress *addrArray)
-{
-
-    FAIL_ERROR(err, "DNS name resolution failed");
-    char *hostName = static_cast<char *>(appState);
-
-    gNumOfResolutionDone++;
-
-    if (addrCount > 0)
-    {
-        for (int i = 0; i < addrCount; i++)
-        {
-            char destAddrStr[64];
-            addrArray[i].ToString(destAddrStr, sizeof(destAddrStr));
-            printf("DNS name resolution complete for %s: %s\n", hostName, destAddrStr);
-        }
-    }
-    else
-        printf("DNS name resolution return no addresses\n");
-
-    if (gNumOfResolutionDone == gMaxNumResolve)
-    {
-       gTestSucceeded = true;
-    }
-}
-#endif // INET_CONFIG_ENABLE_DNS_RESOLVER
+#endif // !INET_CONFIG_ENABLE_DNS_RESOLVER


### PR DESCRIPTION
(This work is part of WEAV-3088).

-- Enhanced the System Layer’s ResolveHostAddress() API to provide an option for controlling the type and ordering of IP addresses to be returned by DNS name resolution.  Available options are: IPv4Only, IPv6Only, IPv4Preferred, IPv6Preferred.

-- Revised the handing of some corner-case DNS errors on sockets platforms.  The net effect is that, in some cases where DNS records of the appropriate type do not exist, ResolveHostAddress() will return INET_ERROR_HOST_NOT_FOUND rather than an empty list of addresses.  This is consistent with how higher layer code treated these cases (specifically WeaveConnection and WeaveBinding).

-- Consolidated the implementation of ResolveHostAddress() on sockets platforms between the synchronous and asynchronous implementations.

-- Rewrote TestDNSResolution to cover the new address type functionality, plus other aspects of the DNS API that were not fully tested in the previous incarnation.

-- Enhanced TestDNSResolution to support testing using LwIP.
