### PR TITLE
Fix for Issue #26 -- Double release of Weave Connection object

### DIFF
--- a/src/lib/core/ExchangeContext.cpp
+++ b/src/lib/core/ExchangeContext.cpp
@@ -854,6 +854,7 @@ void ExchangeContext::Release(void)
         // If configured, automatically release a reference to the WeaveConnection object.
         if (ShouldAutoReleaseConnection() && Con != NULL)
         {
+            SetShouldAutoReleaseConnection(false);
             Con->Release();
         }
 
@@ -1604,8 +1605,8 @@ void ExchangeContext::HandleConnectionClosed(WEAVE_ERROR conErr)
     // If configured, automatically release the EC's reference to the WeaveConnection object.
     if (ShouldAutoReleaseConnection() && Con != NULL)
     {
-        Con->Release();
         SetShouldAutoReleaseConnection(false);
+        Con->Release();
     }
 
     // Discard the EC's pointer to the connection, preventing further use.


### PR DESCRIPTION
-- Re-ordered the clearing of the ExchangeContext ShouldAutoReleaseConnection flag such that
it is always cleared prior to releasing the associated WeaveConnection object.  This ensures
that, should the release of the connection result in a synchronous callback into the same
ExchangeContext, the ExchangeContext will not attempt to release the connection object a
second time.