### PR TITLE
Fix build issues when DNS resolver disabled

### DIFF
--- a/src/lib/core/WeaveBinding.cpp
+++ b/src/lib/core/WeaveBinding.cpp
@@ -443,7 +443,9 @@ void Binding::ResetConfig()
 
     mFlags = 0;
 
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
     mDNSOptions = ::nl::Inet::kDNSOption_Default;
+#endif
 }
 
 /**
@@ -1546,7 +1548,11 @@ Binding::Configuration& Binding::Configuration::TargetAddress_IP(const char *aHo
  */
 Binding::Configuration& Binding::Configuration::DNS_Options(uint8_t dnsOptions)
 {
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
     mBinding.mDNSOptions = dnsOptions;
+#else // WEAVE_CONFIG_ENABLE_DNS_RESOLVER
+    mError = WEAVE_ERROR_NOT_IMPLEMENTED;
+#endif // WEAVE_CONFIG_ENABLE_DNS_RESOLVER
     return *this;
 }
 

--- a/src/lib/core/WeaveBinding.h
+++ b/src/lib/core/WeaveBinding.h
@@ -274,7 +274,9 @@ private:
     AddressingOption mAddressingOption : 3;
     TransportOption mTransportOption : 3;
     unsigned mFlags : 3;
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
     uint8_t mDNSOptions;
+#endif
 
     EventCallback mAppEventCallback;
     EventCallback mProtocolLayerCallback;

--- a/src/lib/core/WeaveConnection.cpp
+++ b/src/lib/core/WeaveConnection.cpp
@@ -300,7 +300,12 @@ WEAVE_ERROR WeaveConnection::Connect(uint64_t peerNodeId, WeaveAuthMode authMode
 WEAVE_ERROR WeaveConnection::Connect(uint64_t peerNodeId, WeaveAuthMode authMode, const char *peerAddr,
                                      uint16_t peerAddrLen, uint16_t defaultPort)
 {
-    return Connect(peerNodeId, authMode, peerAddr, peerAddrLen, ::nl::Inet::kDNSOption_Default, defaultPort);
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
+    const uint8_t dnsOptions = ::nl::Inet::kDNSOption_Default;
+#else
+    const uint8_t dnsOptions = 0;
+#endif
+    return Connect(peerNodeId, authMode, peerAddr, peerAddrLen, dnsOptions, defaultPort);
 }
 
 /**
@@ -436,7 +441,12 @@ exit:
 WEAVE_ERROR WeaveConnection::Connect(uint64_t peerNodeId, WeaveAuthMode authMode, HostPortList hostPortList,
                                      InterfaceId intf)
 {
-    return Connect(peerNodeId, authMode, hostPortList, kDNSOption_Default, intf);
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
+    const uint8_t dnsOptions = ::nl::Inet::kDNSOption_Default;
+#else
+    const uint8_t dnsOptions = 0;
+#endif
+    return Connect(peerNodeId, authMode, hostPortList, dnsOptions, intf);
 }
 
 /**
@@ -487,7 +497,9 @@ WEAVE_ERROR WeaveConnection::Connect(uint64_t peerNodeId, WeaveAuthMode authMode
     AuthMode = authMode;
     mPeerHostPortList = hostPortList;
     mTargetInterface = intf;
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
     mDNSOptions = dnsOptions;
+#endif
 
     // Bump the reference count when we start the connection process. The corresponding decrement happens when the
     // DoClose() method is called. This ensures the object stays live while there's the possibility of a callback
@@ -1620,7 +1632,9 @@ void WeaveConnection::Init(WeaveMessageLayer *msgLayer)
     SendSourceNodeId = false;
     SendDestNodeId = false;
     mConnectTimeout = 0;
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
     mDNSOptions = 0;
+#endif
 }
 
 // Default OnConnectionClosed handler.

--- a/src/lib/core/WeaveMessageLayer.h
+++ b/src/lib/core/WeaveMessageLayer.h
@@ -377,7 +377,9 @@ private:
     InterfaceId mTargetInterface;
     uint32_t mConnectTimeout;
     uint8_t mRefCount;
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
     uint8_t mDNSOptions;
+#endif
 
     void Init(WeaveMessageLayer *msgLayer);
     void MakeConnectedTcp(TCPEndPoint *endPoint, const IPAddress &localAddr, const IPAddress &peerAddr);

--- a/src/lib/profiles/service-directory/ServiceDirectory.cpp
+++ b/src/lib/profiles/service-directory/ServiceDirectory.cpp
@@ -1491,8 +1491,12 @@ WEAVE_ERROR WeaveServiceManager::lookupAndConnect(WeaveConnection *aConnection,
             &hostPortList,
             aConnectIntf,
             aAuthMode,
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
             ::nl::Inet::kDNSOption_Default
-             );
+#else
+            0
+#endif
+            );
 
         if (mConnectBegin != NULL)
         {

--- a/src/test-apps/ToolCommonOptions.cpp
+++ b/src/test-apps/ToolCommonOptions.cpp
@@ -692,8 +692,10 @@ ServiceDirClientOptions::ServiceDirClientOptions()
 #if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
         { "service-dir-server",             kArgumentRequired, kToolCommonOpt_ServiceDirServer },
         { "service-dir-url",                kArgumentRequired, kToolCommonOpt_ServiceDirServer }, // deprecated alias for service-dir-server
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
         { "service-dir-dns-options",        kArgumentRequired, kToolCommonOpt_ServiceDirDNSOptions },
         { "service-dir-target-dns-options", kArgumentRequired, kToolCommonOpt_ServiceDirTargetDNSOptions },
+#endif // WEAVE_CONFIG_ENABLE_DNS_RESOLVER
 #endif // WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
         { NULL }
     };
@@ -707,6 +709,7 @@ ServiceDirClientOptions::ServiceDirClientOptions()
         "       Use the specified server when making service directory requests.\n"
         "       (Deprecated alias: --service-dir-url)\n"
         "\n"
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
         "  --service-dir-dns-options <dns-options>\n"
         "  --service-dir-target-dns-options <dns-options>\n"
         "       Use the specified DNS options when resolving hostnames during a\n"
@@ -729,14 +732,17 @@ ServiceDirClientOptions::ServiceDirClientOptions()
         "              - Resolve IPv4 and/or IPv6 addresses, with IPv6 addresses\n"
         "                given preference over IPv4.\n"
         "\n"
+#endif // WEAVE_CONFIG_ENABLE_DNS_RESOLVER
 #endif // WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
         "";
 
     // Defaults.
     ServerHost = "frontdoor.integration.nestlabs.com";
     ServerPort = WEAVE_PORT;
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
     DNSOptions_ServiceDirEndpoint = kDNSOption_AddrFamily_Any;
     DNSOptions_TargetEndpoint = kDNSOption_AddrFamily_Any;
+#endif
 }
 
 bool ServiceDirClientOptions::HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg)
@@ -759,6 +765,7 @@ bool ServiceDirClientOptions::HandleOption(const char *progName, OptionSet *optS
         if (ServerPort == 0)
             ServerPort = WEAVE_PORT;
         break;
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
     case kToolCommonOpt_ServiceDirDNSOptions:
         if (!ParseDNSOptions(progName, name, arg, DNSOptions_ServiceDirEndpoint))
         {
@@ -771,6 +778,7 @@ bool ServiceDirClientOptions::HandleOption(const char *progName, OptionSet *optS
             return false;
         }
         break;
+#endif // WEAVE_CONFIG_ENABLE_DNS_RESOLVER
 #endif // WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", progName, name);
@@ -808,6 +816,8 @@ WEAVE_ERROR GetRootServiceDirectoryEntry(uint8_t *buf, uint16_t bufSize)
 
 void ServiceDirClientOptions::OverrideConnectArguments(ServiceConnectBeginArgs & args)
 {
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
+
     // If specific DNS options have been set for the connection to the
     // ServiceDirectory endpoint, override the default DNS options.
     if (args.ServiceEndpoint == kServiceEndpoint_Directory)
@@ -827,6 +837,8 @@ void ServiceDirClientOptions::OverrideConnectArguments(ServiceConnectBeginArgs &
             args.DNSOptions = DNSOptions_TargetEndpoint;
         }
     }
+
+#endif // WEAVE_CONFIG_ENABLE_DNS_RESOLVER
 }
 
 void OverrideServiceConnectArguments(::nl::Weave::Profiles::ServiceDirectory::ServiceConnectBeginArgs & args)
@@ -939,6 +951,8 @@ bool FaultInjectionOptions::HandleOption(const char *progName, OptionSet *optSet
 }
 
 
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
+
 static bool GetToken(const char * & inStr, const char * & token, size_t & tokenLen, const char * sepChars)
 {
     token = inStr;
@@ -1033,3 +1047,5 @@ bool ParseDNSOptions(const char * progName, const char *argName, const char * ar
 
     return true;
 }
+
+#endif // WEAVE_CONFIG_ENABLE_DNS_RESOLVER

--- a/src/test-apps/ToolCommonOptions.h
+++ b/src/test-apps/ToolCommonOptions.h
@@ -247,8 +247,10 @@ class ServiceDirClientOptions : public OptionSetBase
 public:
     const char *ServerHost;
     uint16_t ServerPort;
+#if WEAVE_CONFIG_ENABLE_DNS_RESOLVER
     uint8_t DNSOptions_ServiceDirEndpoint;
     uint8_t DNSOptions_TargetEndpoint;
+#endif
 
     ServiceDirClientOptions();
 


### PR DESCRIPTION
-- Modified WeaveConnection, WeaveServiceManager and Weave Binding, along with a few
test apps, to not reference DNSOptions when Weave is built with DNS name resolution
support disabled.