### PR TITLE
Handle ending sub while in resubscribe holdoff

### DIFF
--- a/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
@@ -832,6 +832,7 @@ WEAVE_ERROR SubscriptionClient::EndSubscription()
     switch (mCurrentState)
     {
     case kState_Subscribing:
+    case kState_Resubscribe_Holdoff:
         // fall through
     case kState_Subscribing_IdAssigned:
 


### PR DESCRIPTION
Looks like this state was added quite a while after the EndSubscription code was written, so maybe it was left out accidentally. 