### PR TITLE
Address a Unit Test Failure against TestWeaveTool.py

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,6 @@
 #
-#    Copyright (c) 2014-2017 Nest Labs, Inc.
+#    Copyright (c) 2014-2018 Nest Labs, Inc.
+#    Copyright (c) 2018 Google LLC
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -140,8 +141,8 @@ SUBDIRS                           = \
     $(MAYBE_DEVICE_MANAGER_SUBDIRS) \
     wrappers/jni                    \
     ra-daemon                       \
-    test-apps                       \
     tools/weave                     \
+    test-apps                       \
     test-apps/fuzz                  \
     tools/misc                      \
     $(EXAMPLES_SUBDIR)              \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -15,7 +15,8 @@
 @SET_MAKE@
 
 #
-#    Copyright (c) 2014-2017 Nest Labs, Inc.
+#    Copyright (c) 2014-2018 Nest Labs, Inc.
+#    Copyright (c) 2018 Google LLC
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -564,8 +565,8 @@ SUBDIRS = \
     $(MAYBE_DEVICE_MANAGER_SUBDIRS) \
     wrappers/jni                    \
     ra-daemon                       \
-    test-apps                       \
     tools/weave                     \
+    test-apps                       \
     test-apps/fuzz                  \
     tools/misc                      \
     $(EXAMPLES_SUBDIR)              \


### PR DESCRIPTION
The test script, TestWeaveTool.py, runs against the 'weave' tool produced by tools/weave/.... Consequently, tools/weave must be iterated and built before test-apps. Otherwise, the TestWeaveTool.py test will fail.

This reorders SUBDIRS such that tools/weave appears before test-apps to satisfy this dependency.