### PR TITLE
EAX encryption support

### DIFF
--- a/src/device-manager/python/Makefile.in
+++ b/src/device-manager/python/Makefile.in
@@ -983,8 +983,8 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-@WEAVE_WITH_PYTHON_FALSE@uninstall-local:
 @WEAVE_WITH_PYTHON_FALSE@install-exec-local:
+@WEAVE_WITH_PYTHON_FALSE@uninstall-local:
 @WEAVE_WITH_PYTHON_FALSE@install-exec-hook:
 clean: clean-am
 

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -393,6 +393,7 @@ nl_public_WeaveSupport_crypto_header_sources = \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/AESBlockCipher.h \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/CTRMode.h \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/DRBG.h \
+$(nl_public_WeaveSupport_source_dirstem)/crypto/EAX.h \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/EllipticCurve.h \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/HKDF.h \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/HMAC.h \

--- a/src/include/Makefile.in
+++ b/src/include/Makefile.in
@@ -865,6 +865,7 @@ nl_public_WeaveSupport_crypto_header_sources = \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/AESBlockCipher.h \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/CTRMode.h \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/DRBG.h \
+$(nl_public_WeaveSupport_source_dirstem)/crypto/EAX.h \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/EllipticCurve.h \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/HKDF.h \
 $(nl_public_WeaveSupport_source_dirstem)/crypto/HMAC.h \

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -486,6 +486,7 @@ am__libWeave_a_SOURCES_DIST =  \
 	@top_builddir@/src/lib/support/crypto/AESBlockCipher-AESNI.cpp \
 	@top_builddir@/src/lib/support/crypto/CTRMode.cpp \
 	@top_builddir@/src/lib/support/crypto/DRBG.cpp \
+	@top_builddir@/src/lib/support/crypto/EAX.cpp \
 	@top_builddir@/src/lib/support/crypto/EllipticCurve.cpp \
 	@top_builddir@/src/lib/support/crypto/EllipticCurve-OpenSSL.cpp \
 	@top_builddir@/src/lib/support/crypto/EllipticCurve-uECC.cpp \
@@ -686,6 +687,7 @@ am__objects_17 =  \
 	@top_builddir@/src/lib/support/crypto/libWeave_a-AESBlockCipher-AESNI.$(OBJEXT) \
 	@top_builddir@/src/lib/support/crypto/libWeave_a-CTRMode.$(OBJEXT) \
 	@top_builddir@/src/lib/support/crypto/libWeave_a-DRBG.$(OBJEXT) \
+	@top_builddir@/src/lib/support/crypto/libWeave_a-EAX.$(OBJEXT) \
 	@top_builddir@/src/lib/support/crypto/libWeave_a-EllipticCurve.$(OBJEXT) \
 	@top_builddir@/src/lib/support/crypto/libWeave_a-EllipticCurve-OpenSSL.$(OBJEXT) \
 	@top_builddir@/src/lib/support/crypto/libWeave_a-EllipticCurve-uECC.$(OBJEXT) \
@@ -1188,6 +1190,7 @@ nl_WeaveSupport_sources = @top_builddir@/src/lib/support/ASN1OID.cpp \
 	@top_builddir@/src/lib/support/crypto/AESBlockCipher-AESNI.cpp \
 	@top_builddir@/src/lib/support/crypto/CTRMode.cpp \
 	@top_builddir@/src/lib/support/crypto/DRBG.cpp \
+	@top_builddir@/src/lib/support/crypto/EAX.cpp \
 	@top_builddir@/src/lib/support/crypto/EllipticCurve.cpp \
 	@top_builddir@/src/lib/support/crypto/EllipticCurve-OpenSSL.cpp \
 	@top_builddir@/src/lib/support/crypto/EllipticCurve-uECC.cpp \
@@ -1662,6 +1665,9 @@ clean-libLIBRARIES:
 	@top_builddir@/src/lib/support/crypto/$(am__dirstamp) \
 	@top_builddir@/src/lib/support/crypto/$(DEPDIR)/$(am__dirstamp)
 @top_builddir@/src/lib/support/crypto/libWeave_a-DRBG.$(OBJEXT):  \
+	@top_builddir@/src/lib/support/crypto/$(am__dirstamp) \
+	@top_builddir@/src/lib/support/crypto/$(DEPDIR)/$(am__dirstamp)
+@top_builddir@/src/lib/support/crypto/libWeave_a-EAX.$(OBJEXT):  \
 	@top_builddir@/src/lib/support/crypto/$(am__dirstamp) \
 	@top_builddir@/src/lib/support/crypto/$(DEPDIR)/$(am__dirstamp)
 @top_builddir@/src/lib/support/crypto/libWeave_a-EllipticCurve.$(OBJEXT):  \
@@ -2289,6 +2295,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-AESBlockCipher-OpenSSL.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-CTRMode.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-DRBG.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EAX.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EllipticCurve-OpenSSL.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EllipticCurve-uECC.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EllipticCurve.Po@am__quote@
@@ -3380,6 +3387,20 @@ distclean-compile:
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='@top_builddir@/src/lib/support/crypto/DRBG.cpp' object='@top_builddir@/src/lib/support/crypto/libWeave_a-DRBG.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o @top_builddir@/src/lib/support/crypto/libWeave_a-DRBG.obj `if test -f '@top_builddir@/src/lib/support/crypto/DRBG.cpp'; then $(CYGPATH_W) '@top_builddir@/src/lib/support/crypto/DRBG.cpp'; else $(CYGPATH_W) '$(srcdir)/@top_builddir@/src/lib/support/crypto/DRBG.cpp'; fi`
+
+@top_builddir@/src/lib/support/crypto/libWeave_a-EAX.o: @top_builddir@/src/lib/support/crypto/EAX.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT @top_builddir@/src/lib/support/crypto/libWeave_a-EAX.o -MD -MP -MF @top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EAX.Tpo -c -o @top_builddir@/src/lib/support/crypto/libWeave_a-EAX.o `test -f '@top_builddir@/src/lib/support/crypto/EAX.cpp' || echo '$(srcdir)/'`@top_builddir@/src/lib/support/crypto/EAX.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) @top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EAX.Tpo @top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EAX.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='@top_builddir@/src/lib/support/crypto/EAX.cpp' object='@top_builddir@/src/lib/support/crypto/libWeave_a-EAX.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o @top_builddir@/src/lib/support/crypto/libWeave_a-EAX.o `test -f '@top_builddir@/src/lib/support/crypto/EAX.cpp' || echo '$(srcdir)/'`@top_builddir@/src/lib/support/crypto/EAX.cpp
+
+@top_builddir@/src/lib/support/crypto/libWeave_a-EAX.obj: @top_builddir@/src/lib/support/crypto/EAX.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT @top_builddir@/src/lib/support/crypto/libWeave_a-EAX.obj -MD -MP -MF @top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EAX.Tpo -c -o @top_builddir@/src/lib/support/crypto/libWeave_a-EAX.obj `if test -f '@top_builddir@/src/lib/support/crypto/EAX.cpp'; then $(CYGPATH_W) '@top_builddir@/src/lib/support/crypto/EAX.cpp'; else $(CYGPATH_W) '$(srcdir)/@top_builddir@/src/lib/support/crypto/EAX.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) @top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EAX.Tpo @top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EAX.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='@top_builddir@/src/lib/support/crypto/EAX.cpp' object='@top_builddir@/src/lib/support/crypto/libWeave_a-EAX.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o @top_builddir@/src/lib/support/crypto/libWeave_a-EAX.obj `if test -f '@top_builddir@/src/lib/support/crypto/EAX.cpp'; then $(CYGPATH_W) '@top_builddir@/src/lib/support/crypto/EAX.cpp'; else $(CYGPATH_W) '$(srcdir)/@top_builddir@/src/lib/support/crypto/EAX.cpp'; fi`
 
 @top_builddir@/src/lib/support/crypto/libWeave_a-EllipticCurve.o: @top_builddir@/src/lib/support/crypto/EllipticCurve.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT @top_builddir@/src/lib/support/crypto/libWeave_a-EllipticCurve.o -MD -MP -MF @top_builddir@/src/lib/support/crypto/$(DEPDIR)/libWeave_a-EllipticCurve.Tpo -c -o @top_builddir@/src/lib/support/crypto/libWeave_a-EllipticCurve.o `test -f '@top_builddir@/src/lib/support/crypto/EllipticCurve.cpp' || echo '$(srcdir)/'`@top_builddir@/src/lib/support/crypto/EllipticCurve.cpp

--- a/src/lib/core/WeaveConfig.h
+++ b/src/lib/core/WeaveConfig.h
@@ -756,6 +756,61 @@
 
 
 /**
+ *  @def WEAVE_CONFIG_EAX_NO_PAD_CACHE
+ *
+ *  @brief
+ *    If enabled (1), this option makes the EAX implementation class
+ *    save 16 bytes of RAM at the expense of extra computations; when
+ *    disabled (0), encryption cost is lower but RAM usage is slightly
+ *    greater.
+ *
+ */
+#ifndef WEAVE_CONFIG_EAX_NO_PAD_CACHE
+#define WEAVE_CONFIG_EAX_NO_PAD_CACHE                       0
+#endif // WEAVE_CONFIG_EAX_NO_PAD_CACHE
+
+
+/**
+ *  @def WEAVE_CONFIG_EAX_NO_CHUNK
+ *
+ *  @brief
+ *    If enabled (1), this option makes the EAX implementation class
+ *    save 33 bytes of RAM, but prevents processing of messages by
+ *    chunks.
+ *
+ */
+#ifndef WEAVE_CONFIG_EAX_NO_CHUNK
+#define WEAVE_CONFIG_EAX_NO_CHUNK                           0
+#endif // WEAVE_CONFIG_EAX_NO_PAD_CACHE
+
+
+/**
+ *  @def WEAVE_CONFIG_AES128EAX64
+ *
+ *  @brief
+ *    If enabled (1), messages encrypted with AES-128-EAX (with 64-bit
+ *    authentication tags) will be supported.
+ *
+ */
+#ifndef WEAVE_CONFIG_AES128EAX64
+#define WEAVE_CONFIG_AES128EAX64                            1
+#endif // WEAVE_CONFIG_AES128EAX64
+
+
+/**
+ *  @def WEAVE_CONFIG_AES128EAX128
+ *
+ *  @brief
+ *    If enabled (1), messages encrypted with AES-128-EAX (with 128-bit
+ *    authentication tags) will be supported.
+ *
+ */
+#ifndef WEAVE_CONFIG_AES128EAX128
+#define WEAVE_CONFIG_AES128EAX128                           1
+#endif // WEAVE_CONFIG_AES128EAX128
+
+
+/**
  *  @name Weave SHA1 and SHA256 Hash Algorithms Implementation Configuration.
  *
  *  @brief

--- a/src/lib/core/WeaveFabricState.h
+++ b/src/lib/core/WeaveFabricState.h
@@ -281,10 +281,22 @@ public:
     uint8_t IntegrityKey[IntegrityKeySize];
 };
 
+// Encryption key for the AES-128-EAX-* message encryption types
+class WeaveEncryptionKey_AES128EAX
+{
+public:
+    enum
+    {
+        KeySize = 16
+    };
+    uint8_t Key[KeySize];
+};
+
 // Represents a key or key set used to encrypt Weave messages.
 typedef union WeaveEncryptionKey
 {
-    WeaveEncryptionKey_AES128CTRSHA1 AES128CTRSHA1;
+    WeaveEncryptionKey_AES128CTRSHA1  AES128CTRSHA1;
+    WeaveEncryptionKey_AES128EAX      AES128EAX;
 } WeaveEncryptionKey;
 
 // AES128CTRSHA1 encryption and integrity test keys, which should only be used for testing purposes.

--- a/src/lib/core/WeaveMessageLayer.h
+++ b/src/lib/core/WeaveMessageLayer.h
@@ -160,8 +160,12 @@ typedef enum WeaveMessageFlags
 typedef enum WeaveEncryptionType
 {
     kWeaveEncryptionType_None                           = 0, /**< Message not encrypted. */
-    kWeaveEncryptionType_AES128CTRSHA1                  = 1  /**< Message encrypted using AES-128-CTR
+    kWeaveEncryptionType_AES128CTRSHA1                  = 1, /**< Message encrypted using AES-128-CTR
                                                                   encryption with HMAC-SHA-1 message integrity. */
+    kWeaveEncryptionType_AES128EAX64                    = 2, /**< Message encryption using AES-128-EAX
+                                                                  encryption with 64-bit authentication tags. */
+    kWeaveEncryptionType_AES128EAX128                   = 3, /**< Message encryption using AES-128-EAX
+                                                                  encryption with 128-bit authentication tags. */
 } WeaveEncryptionType;
 
 /**
@@ -741,6 +745,12 @@ private:
                                       const uint8_t *inData, uint16_t inLen, uint8_t *outBuf);
     static void ComputeIntegrityCheck_AES128CTRSHA1(const WeaveMessageInfo *msgInfo, const uint8_t *key,
                                                     const uint8_t *inData, uint16_t inLen, uint8_t *outBuf);
+#if WEAVE_CONFIG_AES128EAX64 || WEAVE_CONFIG_AES128EAX128
+    static void Encrypt_AES128EAX(const WeaveMessageInfo *msgInfo, const uint8_t *key,
+                                  const uint8_t *inData, uint16_t inLen, uint8_t *outBuf, uint16_t tagLen);
+    static bool Decrypt_AES128EAX(const WeaveMessageInfo *msgInfo, const uint8_t *key,
+                                  const uint8_t *inData, uint16_t inLen, uint8_t *outBuf, uint16_t tagLen);
+#endif  // WEAVE_CONFIG_AES128EAX64 || WEAVE_CONFIG_AES128EAX128
     static bool IsIgnoredMulticastSendError(WEAVE_ERROR err);
 
     static bool IsSendErrorNonCritical(WEAVE_ERROR err);

--- a/src/lib/support/WeaveSupport.am
+++ b/src/lib/support/WeaveSupport.am
@@ -48,6 +48,7 @@ nl_WeaveSupport_sources                                                         
     @top_builddir@/src/lib/support/crypto/AESBlockCipher-AESNI.cpp                          \
     @top_builddir@/src/lib/support/crypto/CTRMode.cpp                                       \
     @top_builddir@/src/lib/support/crypto/DRBG.cpp                                          \
+    @top_builddir@/src/lib/support/crypto/EAX.cpp                                           \
     @top_builddir@/src/lib/support/crypto/EllipticCurve.cpp                                 \
     @top_builddir@/src/lib/support/crypto/EllipticCurve-OpenSSL.cpp                         \
     @top_builddir@/src/lib/support/crypto/EllipticCurve-uECC.cpp                            \

--- a/src/lib/support/crypto/EAX.cpp
+++ b/src/lib/support/crypto/EAX.cpp
@@ -1,0 +1,929 @@
+/*
+ *
+ *    Copyright (c) 2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements EAX functions for the Weave layer.
+ *
+ */
+
+#include <string.h>
+
+#include <Weave/Support/CodeUtils.h>
+
+#include "WeaveCrypto.h"
+#include "EAX.h"
+
+namespace nl {
+namespace Weave {
+namespace Platform {
+namespace Security {
+
+/*
+ * The 'state' variable maintains current status of the object:
+ *
+ *   ST_EMPTY     Created, no key set yet
+ *   ST_KEYED     Key is set, ready for a new message (Start() call)
+ *   ST_AAD       Start() was called, waiting for AAD
+ *   ST_ENCRYPT   Payload is being encrypted
+ *   ST_DECRYPT   Payload is being decrypted
+ *   ST_PAYLOAD   AAD finished, ready for payload
+ *   ST_TAG       Tag was computed in acc[]
+ *
+ * Calls and transitions:
+ *   SetKey()        goes to ST_KEYED; cancels any ongoing computation
+ *   Start()         requires not ST_EMPTY; goes to ST_AAD; cancels ongoing
+ *   InjectHeader()  requires ST_AAD
+ *   Encrypt()       requires ST_AAD, ST_ENCRYPT or ST_PAYLOAD;
+ *                   goes to ST_ENCRYPT
+ *   Decrypt()       requires ST_AAD, ST_DECRYPT or ST_PAYLOAD;
+ *                   goes to ST_DECRYPT
+ *   GetTag()        requires ST_ADD, ST_ENCRYPT, ST_DECRYPT or ST_PAYLOAD;
+ *                   goes to ST_TAG
+ *   CheckTag()      requires ST_ADD, ST_ENCRYPT, ST_DECRYPT or ST_PAYLOAD;
+ *                   goes to ST_TAG
+ *
+ * The ST_PAYLOAD is a special case for when the AAD was injected from a
+ * saved state object (EAXSaved).
+ *
+ * The VerifyOrDie() macro is used to react on violations. Such cases
+ * happen only if the calling code is wrong, not because of invalid
+ * data from the outside.
+ *
+ * When WEAVE_CONFIG_EAX_NO_CHUNK is activated, ST_ENCRYPT and ST_DECRYPT
+ * are not used; instead, AAD processing leads to ST_PAYLOAD state, and
+ * calling Encrypt() or Decrypt() brings to ST_TAG.
+ */
+#define ST_EMPTY     0
+#define ST_KEYED     1
+#define ST_AAD       2
+#define ST_PAYLOAD   3
+#define ST_ENCRYPT   4
+#define ST_DECRYPT   5
+#define ST_TAG       6
+
+/*
+ * Implementation Notes
+ * ====================
+ *
+ * L1[] contains the encryption of the all-zero block. This is used when
+ * processing the nonce; the pad blocks for OMAC also use it (pad blocks
+ * use either L2 or L4, where L2 is the double of L1 in GF(2^128), and
+ * L4 is the double of L2 in GF(2^128)).
+ *
+ * buf[] is an all-purpose buffer:
+ *
+ *  - When using OMAC only (processing of nonce and header), it contains
+ *    ptr unprocessed bytes. That value ranges from 1 to 16 (inclusive).
+ *
+ *  - When using both OMAC and CTR (processing of payload):
+ *      The first ptr bytes must still be processed with OMAC.
+ *      The remaining 16-ptr bytes are CTR stream bytes to be XORed into
+ *      the next 16-ptr payload bytes.
+ *    Again, ptr ranges from 1 to 16.
+ *
+ * cbcmac[] is the OMAC buffer. It contains the current CBC-MAC value.
+ *
+ * ctr[] is the counter for CTR encryption/decryption. It contains the
+ * counter value for the next invocation of AES/CTR.
+ *
+ * acc[] is the buffer that accumulates the tag value:
+ *  - It first receives a copy of OMAC^0(nonce).
+ *  - OMAC^1(header) is XORed into it.
+ *  - OMAC^2(ciphertext) is XORed into it.
+ *
+ * When WEAVE_CONFIG_EAX_NO_CHUNK is not enabled, the 'ptr' field is
+ * present and normally has a value between 1 and 16 (inclusive). There
+ * is a special case where ptr == 0: when StartSaved() has been used.
+ * In that case, the first OMAC^2 block, already encrypted, has been
+ * saved in cbcmac[]. Code in this class defensively assumes that ptr
+ * may be zero at all times.
+ */
+
+EAXSaved::EAXSaved(void)
+{
+}
+
+EAXSaved::~EAXSaved(void)
+{
+    ClearSecretData(aad, sizeof aad);
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    ClearSecretData(om2, sizeof om2);
+#endif
+}
+
+EAX::EAX(void)
+{
+    state = ST_EMPTY;
+}
+
+EAX::~EAX(void)
+{
+    Reset();
+}
+
+void
+EAX::Reset(void)
+{
+#if !WEAVE_CONFIG_EAX_NO_PAD_CACHE
+    ClearSecretData(L1, sizeof L1);
+#endif
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    ClearSecretData(buf, sizeof buf);
+    ClearSecretData(cbcmac, sizeof cbcmac);
+#endif
+    ClearSecretData(ctr, sizeof ctr);
+    ClearSecretData(acc, sizeof acc);
+
+    state = ST_EMPTY;
+}
+
+/*
+ * Double a value in finite field GF(2^128), with modulus X^128+X^7+X^2+X+1.
+ * Value bytes are in big-endian order: elt[15] is the byte corresponding
+ * to 1, X, X^2,... X^7. Within each byte, numerical encoding is used, i.e.
+ * X^7 is the most significant bit in elt[15].
+ */
+void
+EAX::double_gf128(uint8_t *elt)
+{
+    unsigned cc;
+    int i;
+
+    /*
+     * 'cc' is a constant-time extraction of the top bit, promoted to the
+     * effect of the field modulus (0x87 is the encoding for X^7+X^2+X+1).
+     */
+    cc = 0x87 & -((unsigned)elt[0] >> 7);
+    for (i = kBlockLength - 1; i >= 0; i --) {
+        unsigned z;
+
+        z = (elt[i] << 1) ^ cc;
+        cc = z >> 8;
+        elt[i] = (uint8_t)z;
+    }
+}
+
+/*
+ * XOR a block (16 bytes) into another.
+ */
+void
+EAX::xor_block(const uint8_t *src, uint8_t *dst)
+{
+    /*
+     * TODO: this is done byte-by-byte; on some architectures, it
+     * could be done by full words, or even bigger values. E.g. on
+     * x86 with SSE2, _mm_loadu_si128() and _mm_storeu_si128() can
+     * read and write unaligned 128-bit values, and _mm_xor_si128()
+     * can compute the full XOR in a single cycle.
+     */
+    size_t u;
+
+    for (u = 0; u < kBlockLength; u ++) {
+        dst[u] ^= src[u];
+    }
+}
+
+/*
+ * This method computes OMAC^val on data[], result in mac[] (16 bytes).
+ * This handles non-chunked input, with no buffering.
+ *
+ * If val == 0 and len != 0, then the first block to be encrypted will
+ * be the all-zero block. If WEAVE_CONFIG_EAX_NO_PAD_CACHE is not enabled,
+ * the encryption of the all-zero block is available in the L1[] array,
+ * and it is automatically reused by this function.
+ */
+void
+EAX::omac(unsigned val, const uint8_t *data, size_t len, uint8_t *mac)
+{
+    /*
+     * There are three situations:
+     *
+     *  - Data is empty; the pad block is L2, XORed into the initial
+     *    OMAC^2 block (0000...0002).
+     *
+     *  - Data has length multiple of 16 and is not empty; pad block
+     *    is L2, XORed into the last block.
+     *
+     *  - Data has length not multiple of 16; last partial block is
+     *    padded with 0x80 then zeros, and XORed with the pad block,
+     *    which is L4.
+     */
+    uint8_t pad[kBlockLength];
+    size_t u, v;
+
+#if WEAVE_CONFIG_EAX_NO_PAD_CACHE
+    memset(pad, 0, sizeof pad);
+    AESEncryptBlock(pad);
+#else
+    memcpy(pad, L1, sizeof L1);
+#endif
+    double_gf128(pad);
+    if ((len & (kBlockLength - 1)) != 0) {
+        /*
+         * Note: we wanted to test whether len was a multiple of the
+         * block length (16 bytes), but divisions are expensive. Here,
+         * we used the fact that the block length is a power of two,
+         * which allows for using a faster bitwise AND.
+         */
+        double_gf128(pad);
+    }
+
+    /*
+     * The following cases may happen:
+     *
+     *  - If len == 0, then the output is the encryption of the XOR of
+     *    the first block (all-zero except the last byte) with the pad
+     *    block.
+     *
+     *  - If len != 0 and val == 0 and WEAVE_CONFIG_EAX_NO_PAD_CACHE is
+     *    disabled, then the first block to be encrypted is the all-zero
+     *    block, and it already is in L1[], so we reuse it.
+     *
+     *  - Otherwise, the first block to be encrypted is not the all-zero
+     *    block (or we don't have L1); the first block must be assembled
+     *    and used as starting point.
+     */
+    if (len == 0) {
+        memcpy(mac, pad, sizeof pad);
+        mac[kBlockLength - 1] ^= (uint8_t)val;
+        AESEncryptBlock(mac);
+    } else {
+#if WEAVE_CONFIG_EAX_NO_PAD_CACHE
+        memset(mac, 0, kBlockLength);
+        mac[kBlockLength - 1] = (uint8_t)val;
+        AESEncryptBlock(mac);
+#else
+        if (val == 0) {
+            memcpy(mac, L1, sizeof L1);
+        } else {
+            memset(mac, 0, kBlockLength);
+            mac[kBlockLength - 1] = (uint8_t)val;
+            AESEncryptBlock(mac);
+        }
+#endif
+        for (u = 0; (u + kBlockLength) < len; u += kBlockLength) {
+            xor_block(data + u, mac);
+            AESEncryptBlock(mac);
+        }
+        for (v = 0; (u + v) < len; v ++) {
+            mac[v] ^= data[u + v];
+        }
+        if (v < kBlockLength) {
+            mac[v] ^= 0x80;
+        }
+        xor_block(pad, mac);
+        AESEncryptBlock(mac);
+    }
+}
+
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+
+/*
+ * Start OMAC processing: buffer is set to the initial block whose last
+ * byte has value 'val' (normally, 0 for the nonce, 1 for the header,
+ * 2 for the ciphertext).
+ */
+void
+EAX::omac_start(unsigned val)
+{
+    memset(cbcmac, 0, sizeof cbcmac);
+    memset(buf, 0, sizeof buf);
+    buf[kBlockLength - 1] = val;
+    ptr = kBlockLength;
+}
+
+/*
+ * Continue OMAC processing on the provided data.
+ */
+void
+EAX::omac_process(const uint8_t *data, size_t len)
+{
+    if (len == 0) {
+        return;
+    }
+
+    /*
+     * Make sure that buf[] is full, and that there still are bytes to
+     * process after that.
+     */
+    if (ptr != kBlockLength) {
+        size_t clen;
+
+        clen = kBlockLength - ptr;
+        if (clen >= len) {
+            memcpy(buf + ptr, data, len);
+            ptr += len;
+            return;
+        }
+        memcpy(buf + ptr, data, clen);
+        data += clen;
+        len -= clen;
+    }
+
+    /*
+     * buf[] is full and there are remaining bytes to process, so we
+     * can compute one block.
+     */
+    xor_block(buf, cbcmac);
+    AESEncryptBlock(cbcmac);
+
+    /*
+     * Process full blocks, as long as at least one unprocessed byte
+     * remains afterwards.
+     */
+    while (len > kBlockLength) {
+        xor_block(data, cbcmac);
+        AESEncryptBlock(cbcmac);
+        data += kBlockLength;
+        len -= kBlockLength;
+    }
+
+    /*
+     * Buffer unprocessed bytes.
+     */
+    memcpy(buf, data, len);
+    ptr = len;
+}
+
+/*
+ * Finish OMAC. The MAC value is in cbcmac[]. The 'val' parameter is the
+ * type of OMAC (1 for AAD, 2 for ciphertext): it is used if ptr == 0
+ * (meaning that the first block must be rebuilt and subject to padding).
+ */
+void
+EAX::omac_finish(unsigned val)
+{
+    uint8_t pad[kBlockLength];
+
+    /*
+     * If the total input size is a multiple of the block size, then
+     * the last block (still in buf[] at that point) is XORed with L1;
+     * otherwise, padding is applied (0x80, then 0x00 bytes up to the
+     * next block boundary) and L4 is XORed in.
+     */
+#if WEAVE_CONFIG_EAX_NO_PAD_CACHE
+    memset(pad, 0, sizeof pad);
+    AESEncryptBlock(pad);
+#else
+    memcpy(pad, L1, sizeof L1);
+#endif
+    double_gf128(pad);
+    if (ptr == 0) {
+        memcpy(cbcmac, pad, sizeof pad);
+        cbcmac[kBlockLength - 1] ^= (uint8_t)val;
+    } else {
+        if (ptr != kBlockLength) {
+            double_gf128(pad);
+            buf[ptr ++] = 0x80;
+            memset(buf + ptr, 0x00, kBlockLength - ptr);
+        }
+        xor_block(buf, cbcmac);
+        xor_block(pad, cbcmac);
+    }
+    AESEncryptBlock(cbcmac);
+}
+
+/*
+ * Finish the OMAC^1 on AAD, and prepare things for payload processing.
+ * This does NOT set the 'state' value.
+ */
+void
+EAX::aad_finish(void)
+{
+    omac_finish(1);
+    xor_block(cbcmac, acc);
+    omac_start(2);
+}
+
+#endif  // WEAVE_CONFIG_EAX_NO_CHUNK
+
+/*
+ * Increment the CTR counter.
+ */
+void
+EAX::incr_ctr(void)
+{
+    /*
+     * TODO: optimize this when possible. Counter encoding is big-endian
+     * with the full 128-bit width; since the starting point is the
+     * OMAC^0(nonce) value, it cannot be assumed that the leftmost bytes
+     * will remain untouched.
+     *
+     * If the current architecture supports big-endian unaligned accesses
+     * for words, when we could read the counter as a sequence of four
+     * 32-bit words, or even two 64-bit words, and handle the long addition
+     * with fewer iterations.
+     */
+    unsigned cc;
+    int i;
+
+    cc = 1;
+    for (i = kBlockLength - 1; i >= 0; i --) {
+        unsigned z;
+
+        z = ctr[i] + cc;
+        ctr[i] = (uint8_t)z;
+        cc = z >> 8;
+    }
+}
+
+/*
+ * Payload processing. Data is encrypted or decrypted in place. This
+ * method assumes that the 'state' has already been checked.
+ */
+void
+EAX::payload_process(bool encrypt, uint8_t *data, size_t len)
+{
+
+#if WEAVE_CONFIG_EAX_NO_CHUNK
+
+    /*
+     * In non-buffering mode, we process the whole payload in one go.
+     * We have to XOR the data with the AES/CTR stream, and also
+     * compute the CBC-MAC on the ciphertext. Depending on whether we
+     * encrypt or decrypt, AES/CTR must happen first or not.
+     */
+    int i, te;
+
+    te = encrypt ? 0 : 1;
+    for (i = 0; i < 2; i ++) {
+        if (i == te) {
+            /*
+             * AES/CTR encryption. This is straightforward, except for
+             * the final block, which may be incomplete.
+             */
+            size_t u;
+
+            for (u = 0; u < len; u += kBlockLength) {
+                uint8_t tmp[kBlockLength];
+
+                memcpy(tmp, ctr, sizeof ctr);
+                incr_ctr();
+                AESEncryptBlock(tmp);
+                if ((u + kBlockLength) <= len) {
+                    xor_block(tmp, data + u);
+                } else {
+                    size_t v;
+
+                    for (v = u; v < len; v ++) {
+                        data[v] ^= tmp[v - u];
+                    }
+                }
+            }
+        } else {
+            /*
+             * CBC-MAC on the ciphertext.
+             */
+            uint8_t mac[kBlockLength];
+
+            omac(2, data, len, mac);
+            xor_block(mac, acc);
+        }
+    }
+
+#else
+
+    uint8_t tmp[kBlockLength];
+
+    /*
+     * Complete current block, if applicable.
+     * If ptr == 0, this is a special case: the previous OMAC block
+     * has been encrypted, but the next CTR block has not been generated.
+     */
+    if (ptr < kBlockLength) {
+        size_t clen, u;
+
+        if (ptr == 0) {
+            if (len == 0) {
+                return;
+            }
+            memcpy(buf, ctr, sizeof ctr);
+            incr_ctr();
+            AESEncryptBlock(buf);
+        }
+        clen = kBlockLength - ptr;
+        if (clen > len) {
+            clen = len;
+        }
+        if (encrypt) {
+            for (u = 0; u < clen; u ++) {
+                data[u] ^= buf[ptr + u];
+                buf[ptr + u] = data[u];
+            }
+        } else {
+            for (u = 0; u < clen; u ++) {
+                unsigned z;
+
+                z = data[u];
+                data[u] ^= buf[ptr + u];
+                buf[ptr + u] = z;
+            }
+        }
+        data += clen;
+        ptr += clen;
+        len -= clen;
+    }
+
+    if (len == 0) {
+        return;
+    }
+
+    /*
+     * At that point, the buffer is full, and some data remains afterwards.
+     * Therefore, we can process the buffered block with OMAC.
+     */
+    xor_block(buf, cbcmac);
+    AESEncryptBlock(cbcmac);
+
+    /*
+     * We now have an empty buffer; we MUST exit this function with a
+     * non-empty buffer, so we process full blocks without buffering
+     * only as long as there remain more than 16 bytes.
+     *
+     * We perform interleaved CTR and CBC-MAC under the hope that, on
+     * recent enough x86 with AES-NI opcodes, the out-of-order execution
+     * unit will leverage parallelism and run two AES instances at a
+     * time.
+     */
+    if (encrypt) {
+        while (len > kBlockLength) {
+            memcpy(tmp, ctr, sizeof ctr);
+            incr_ctr();
+            AESEncryptBlock(tmp);
+            xor_block(tmp, data);
+            xor_block(data, cbcmac);
+            AESEncryptBlock(cbcmac);
+            data += kBlockLength;
+            len -= kBlockLength;
+        }
+    } else {
+        while (len > kBlockLength) {
+            memcpy(tmp, ctr, sizeof ctr);
+            incr_ctr();
+            AESEncryptBlock(tmp);
+            xor_block(data, cbcmac);
+            xor_block(tmp, data);
+            AESEncryptBlock(cbcmac);
+            data += kBlockLength;
+            len -= kBlockLength;
+        }
+    }
+
+    /*
+     * Now there are between 1 and 16 bytes that need to be processed.
+     * We need to put the 'len' ciphertext bytes in buf[], along with
+     * the remainder of the CTR stream block.
+     */
+    memcpy(tmp, ctr, sizeof ctr);
+    incr_ctr();
+    AESEncryptBlock(tmp);
+    if (encrypt) {
+        size_t u;
+
+        for (u = 0; u < len; u ++) {
+            data[u] ^= tmp[u];
+        }
+        memcpy(buf, data, len);
+    } else {
+        size_t u;
+
+        memcpy(buf, data, len);
+        for (u = 0; u < len; u ++) {
+            data[u] ^= tmp[u];
+        }
+    }
+    memcpy(buf + len, tmp + len, kBlockLength - len);
+    ptr = len;
+
+#endif  // WEAVE_CONFIG_EAX_NO_CHUNK
+}
+
+void
+EAX::SetKey(const uint8_t *key)
+{
+    AESSetKey(key);
+
+#if !WEAVE_CONFIG_EAX_NO_PAD_CACHE
+    /*
+     * We encrypt the all-zero block.
+     */
+    memset(L1, 0, sizeof L1);
+    AESEncryptBlock(L1);
+#endif
+
+    state = ST_KEYED;
+}
+
+void
+EAX::SaveHeader(const uint8_t *header, size_t headerLen, EAXSaved *sav)
+{
+    /*
+     * We compute OMAC^1(header) and save it.
+     */
+    omac(1, header, headerLen, sav->aad);
+
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    /*
+     * We also pre-process the first block of OMAC^2 (it will be used to
+     * speed up the processing of the ciphertext, except in the
+     * pathological case of an empty ciphertext).
+     */
+    memset(sav->om2, 0, sizeof sav->om2);
+    sav->om2[kBlockLength - 1] = 2;
+    AESEncryptBlock(sav->om2);
+#endif
+}
+
+void
+EAX::Start(const uint8_t *nonce, size_t nonceLen)
+{
+    /*
+     * A key must have been set.
+     */
+    VerifyOrDie(state != ST_EMPTY);
+
+    /*
+     * Process the nonce with OMAC^0.
+     * Result is both one of the three values that make up the tag, but
+     * also the initial counter value for CTR encryption.
+     */
+    omac(0, nonce, nonceLen, acc);
+    memcpy(ctr, acc, sizeof acc);
+
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    /*
+     * Start OMAC^1 for the AAD (header).
+     */
+    omac_start(1);
+#endif
+
+    state = ST_AAD;
+}
+
+void
+EAX::StartWeave(uint64_t sendingNodeId, uint32_t msgId)
+{
+    /*
+     * We reuse ctr[] in order to avoid allocating a stack buffer
+     * for the synthetic nonce. It saves a dozen bytes.
+     */
+    ctr[ 0] = (uint8_t)(sendingNodeId >> 56);
+    ctr[ 1] = (uint8_t)(sendingNodeId >> 48);
+    ctr[ 2] = (uint8_t)(sendingNodeId >> 40);
+    ctr[ 3] = (uint8_t)(sendingNodeId >> 32);
+    ctr[ 4] = (uint8_t)(sendingNodeId >> 24);
+    ctr[ 5] = (uint8_t)(sendingNodeId >> 16);
+    ctr[ 6] = (uint8_t)(sendingNodeId >>  8);
+    ctr[ 7] = (uint8_t)sendingNodeId;
+    ctr[ 8] = (uint8_t)(msgId >> 24);
+    ctr[ 9] = (uint8_t)(msgId >> 16);
+    ctr[10] = (uint8_t)(msgId >>  8);
+    ctr[11] = (uint8_t)msgId;
+    Start(ctr, 12);
+}
+
+void
+EAX::StartSaved(const uint8_t *nonce, size_t nonceLen, const EAXSaved *sav)
+{
+    Start(nonce, nonceLen);
+    xor_block(sav->aad, acc);
+    state = ST_PAYLOAD;
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    memcpy(cbcmac, sav->om2, sizeof sav->om2);
+    ptr = 0;
+#endif
+}
+
+void
+EAX::StartWeaveSaved(uint64_t sendingNodeId,
+                     uint32_t msgId,
+                     const EAXSaved *sav)
+{
+    StartWeave(sendingNodeId, msgId);
+    xor_block(sav->aad, acc);
+    state = ST_PAYLOAD;
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    memcpy(cbcmac, sav->om2, sizeof sav->om2);
+    ptr = 0;
+#endif
+}
+
+void
+EAX::InjectHeader(const uint8_t *header, size_t headerLen)
+{
+    /*
+     * We can inject AAD only in ST_AAD state.
+     */
+    VerifyOrDie(state == ST_AAD);
+
+#if WEAVE_CONFIG_EAX_NO_CHUNK
+    uint8_t mac[kBlockLength];
+
+    omac(1, header, headerLen, mac);
+    xor_block(mac, acc);
+    state = ST_PAYLOAD;
+#else
+    omac_process(header, headerLen);
+#endif
+}
+
+void
+EAX::Encrypt(const uint8_t *input, size_t inputLen, uint8_t *output)
+{
+    if (input != output) {
+        memmove(output, input, inputLen);
+    }
+    Encrypt(output, inputLen);
+}
+
+void
+EAX::Encrypt(uint8_t *data, size_t dataLen)
+{
+#if WEAVE_CONFIG_EAX_NO_CHUNK
+    if (state == ST_AAD) {
+        InjectHeader(NULL, 0);
+    } else {
+        VerifyOrDie(state == ST_PAYLOAD);
+    }
+#else
+    if (state == ST_AAD) {
+        aad_finish();
+        state = ST_ENCRYPT;
+    } else if (state == ST_PAYLOAD) {
+        state = ST_ENCRYPT;
+    } else {
+        VerifyOrDie(state == ST_ENCRYPT);
+    }
+#endif
+
+    payload_process(true, data, dataLen);
+#if WEAVE_CONFIG_EAX_NO_CHUNK
+    state = ST_TAG;
+#endif
+}
+
+void
+EAX::Decrypt(const uint8_t *input, size_t inputLen, uint8_t *output)
+{
+    if (input != output) {
+        memmove(output, input, inputLen);
+    }
+    Decrypt(output, inputLen);
+}
+
+void
+EAX::Decrypt(uint8_t *data, size_t dataLen)
+{
+#if WEAVE_CONFIG_EAX_NO_CHUNK
+    if (state == ST_AAD) {
+        InjectHeader(NULL, 0);
+    } else {
+        VerifyOrDie(state == ST_PAYLOAD);
+    }
+#else
+    if (state == ST_AAD) {
+        aad_finish();
+        state = ST_DECRYPT;
+    } else if (state == ST_PAYLOAD) {
+        state = ST_DECRYPT;
+    } else {
+        VerifyOrDie(state == ST_DECRYPT);
+    }
+#endif
+
+    payload_process(false, data, dataLen);
+#if WEAVE_CONFIG_EAX_NO_CHUNK
+    state = ST_TAG;
+#endif
+}
+
+void
+EAX::GetTag(uint8_t *tag, size_t tagLen)
+{
+    /*
+     * Sanity check on tag length.
+     */
+    VerifyOrDie(tagLen >= kMinTagLength && tagLen <= kMaxTagLength);
+
+#if WEAVE_CONFIG_EAX_NO_CHUNK
+    if (state == ST_AAD || state == ST_PAYLOAD) {
+        /*
+         * If we are not at ST_TAG yet, then the payload and possibly
+         * the AAD have not been provided, which means they are empty.
+         * Calling Encrypt() will set things right.
+         */
+        Encrypt(NULL, 0);
+    } else {
+        VerifyOrDie(state == ST_TAG);
+    }
+#else
+    if (state == ST_AAD || state == ST_PAYLOAD) {
+        /*
+         * If we are still in ST_AAD, then this means that the
+         * payload is empty. We temporarily claim encryption.
+         */
+        Encrypt(NULL, 0);
+    }
+    if (state == ST_ENCRYPT || state == ST_DECRYPT) {
+        /*
+         * We have to finish OMAC^2.
+         */
+        omac_finish(2);
+        xor_block(cbcmac, acc);
+        state = ST_TAG;
+    } else {
+        VerifyOrDie(state == ST_TAG);
+    }
+#endif
+
+    /* At that point, the tag is in acc[] and state is ST_TAG. */
+    memcpy(tag, acc, tagLen);
+}
+
+bool
+EAX::CheckTag(const uint8_t *tag, size_t tagLen)
+{
+    uint8_t tmp[kMaxTagLength];
+    unsigned z;
+    size_t u;
+
+    /*
+     * Invalid tag lengths are reported with false, since that might be
+     * triggered with crafted incoming data.
+     */
+    if (tagLen < kMinTagLength || tagLen > kMaxTagLength) {
+        return false;
+    }
+
+    /*
+     * Get the tag and compare it with the provided value. The loop
+     * below performs a constant-time equality comparison.
+     */
+    GetTag(tmp, tagLen);
+    z = 0;
+    for (u = 0; u < tagLen; u ++) {
+        z |= tag[u] ^ tmp[u];
+    }
+    return z == 0;
+}
+
+/*
+ * Key-size specific functions.
+ */
+
+void
+EAX128::AESReset(void)
+{
+    aesCtx.Reset();
+}
+
+void
+EAX128::AESSetKey(const uint8_t *key)
+{
+    aesCtx.SetKey(key);
+}
+
+void
+EAX128::AESEncryptBlock(uint8_t *data)
+{
+    aesCtx.EncryptBlock(data, data);
+}
+
+void
+EAX256::AESReset(void)
+{
+    aesCtx.Reset();
+}
+
+void
+EAX256::AESSetKey(const uint8_t *key)
+{
+    aesCtx.SetKey(key);
+}
+
+void
+EAX256::AESEncryptBlock(uint8_t *data)
+{
+    aesCtx.EncryptBlock(data, data);
+}
+
+} // namespace Security
+} // namespace Platform
+} // namespace Weave
+} // namespace nl

--- a/src/lib/support/crypto/EAX.cpp
+++ b/src/lib/support/crypto/EAX.cpp
@@ -497,7 +497,7 @@ EAX::payload_process(bool encrypt, uint8_t *data, size_t len)
         }
     }
 
-#else
+#else  // WEAVE_CONFIG_EAX_NO_CHUNK
 
     uint8_t tmp[kBlockLength];
 
@@ -850,7 +850,7 @@ EAX::GetTag(uint8_t *tag, size_t tagLen)
     } else {
         VerifyOrDie(state == ST_TAG);
     }
-#endif
+#endif  // WEAVE_CONFIG_EAX_NO_CHUNK
 
     /* At that point, the tag is in acc[] and state is ST_TAG. */
     memcpy(tag, acc, tagLen);

--- a/src/lib/support/crypto/EAX.h
+++ b/src/lib/support/crypto/EAX.h
@@ -1,0 +1,312 @@
+/*
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file provides EAX implementations for the Weave layer.
+ *
+ */
+
+#ifndef EAX_H_
+#define EAX_H_
+
+#include "AESBlockCipher.h"
+#include "WeaveCrypto.h"
+
+/*
+ * Configurable option: if WEAVE_CONFIG_EAX_NO_PAD_CACHE is defined and
+ * non-zero, then the internal "L1" value is not cached; this saves 16
+ * bytes of RAM in the EAX class, but requires three extra AES block
+ * invocations per message.
+ *
+#define WEAVE_CONFIG_EAX_NO_PAD_CACHE   1
+ */
+
+/*
+ * Configurable option: if WEAVE_CONFIG_EAX_NO_CHUNK is defined and
+ * non-zero, then the EAX class expects non-chunked input of header
+ * and payload: only a single InjectHeader() call, and a single
+ * Encrypt() or Decrypt() call, may be used for a given message. This
+ * constrains usage, but saves 32 bytes of RAM in the EAX class. There
+ * is no CPU cost penalty.
+ *
+#define WEAVE_CONFIG_EAX_NO_CHUNK       1
+ */
+
+namespace nl {
+namespace Weave {
+namespace Platform {
+namespace Security {
+
+class EAX;
+
+/*
+ * Support class for EAX optimization: an instance can be filled with
+ * intermediate processing results, so that several messages that use
+ * the same header and are encrypted or decrypted with the same key can
+ * share some of the computational cost.
+ */
+class EAXSaved
+{
+public:
+    EAXSaved(void);
+    ~EAXSaved(void);
+private:
+    enum {
+        kBlockLength = 16
+    };
+    uint8_t aad[kBlockLength];  // Saved OMAC^1(header)
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    uint8_t om2[kBlockLength];  // Saved encryption of the OMAC^2 start block
+#endif
+    friend class EAX;
+};
+
+/*
+ * Base class for EAX implementations; users should create an
+ * EAX128 or EAX256 instance, based on key size.
+ *
+ * Normal usage:
+ *
+ *  - Use SetKey() to set the AES key. This must be done first. A new
+ *    key can be set at any time, which cancels any ongoing computation.
+ *
+ *  - Call Start() or StartWeave() to start processing a new message.
+ *    A key must have been set. These methods can be called at any
+ *    time (this cancels any ongoing computation). StartWeave() uses
+ *    a 12-byte nonce that encodes the sending node ID and the message ID.
+ *
+ *  - Inject the header with one or several calls to InjectHeader().
+ *    This must follow a Start(), but must precede payload encryption
+ *    or decryption. If InjectHeader() is not called, a zero-length
+ *    header is assumed.
+ *
+ *  - Encrypt or decrypt the data, with one or several calls to
+ *    Encrypt() or Decrypt(). Calls for a given message must be all
+ *    encrypt or all decrypt. Encryption and decryption do not change
+ *    the length of the data; chunks of arbitrary lengths can be used
+ *    (even zero-length chunks).
+ *
+ *  - Finalize the computation of the authentication tag, and get it
+ *    (with GetTag()) or check it (with CheckTag()). Encryption will
+ *    typically use GetTag() (to obtain the tag value to send to the
+ *    recipient) while decryption more naturally involves calling
+ *    CheckTag() (to verify the tag value received from the sender).
+ */
+class EAX
+{
+public:
+    enum {
+        kMinTagLength = 8,   // minimum tag length, in bytes
+        kMaxTagLength = 16   // maximum tag length, in bytes
+    };
+
+    /*
+     * Clear this object from all secret key and data. This is
+     * automatically called by the destructor.
+     */
+    void Reset(void);
+
+    /*
+     * Set the AES key. The key size depends on the chosen concrete class
+     * (EAX128 or EAX256).
+     */
+    void SetKey(const uint8_t *key);
+
+    /*
+     * Process a header and fill the provided 'sav' object with the
+     * result. That object can then be reused with StartSaved()
+     * or StartWeaveSaved() to process messages that share the same
+     * header value (and use the same key).
+     */
+    void SaveHeader(const uint8_t *header, size_t headerLen, EAXSaved *sav);
+
+    /*
+     * Start a new message processing, with the given nonce. This may be
+     * called at any time, provided that the key has been set. Nonce
+     * length is arbitrary, but the same nonce value MUST NOT be reused
+     * with the same key for a different message.
+     */
+    void Start(const uint8_t *nonce, size_t nonceLen);
+
+    /*
+     * Variant of Start() that uses a 12-byte nonce that encodes the
+     * provided sending node ID, and message ID (values use big-endian
+     * encoding, the sending node ID comes first).
+     */
+    void StartWeave(uint64_t sendingNodeId, uint32_t msgId);
+
+    /*
+     * Start a new message processing, with the given nonce and saved
+     * processed header. The 'sav' object is not modified, and may be
+     * reused for other messages that use the same key and header.
+     */
+    void StartSaved(const uint8_t *nonce, size_t nonceLen, const EAXSaved *sav);
+
+    /*
+     * Variant of StartSaved() that uses a 12-byte nonce that encodes the
+     * provided sending node ID, and message ID (values use big-endian
+     * encoding, the sending node ID comes first).
+     */
+    void StartWeaveSaved(uint64_t sendingNodeId,
+                         uint32_t msgId,
+                         const EAXSaved *sav);
+
+    /*
+     * Inject the header. The header data is not encrypted, but participates
+     * to the authentication tag. Header injection must occur after the
+     * call to Start(), but before processing the payload. If no header
+     * is injected, then a zero-length header is used.
+     *
+     * Unless WEAVE_CONFIG_EAX_NO_CHUNK is enabled, the header may be
+     * injected in several chunks (several calls to InjectHeader() with
+     * arbitrary chunk lengths).
+     */
+    void InjectHeader(const uint8_t *header, size_t headerLen);
+
+    /*
+     * Encrypt the provided payload. Input data (plaintext) is read from
+     * 'input' and has size 'inputLen' bytes; the corresponding data has
+     * the same length and is written in 'output'. The 'input' and 'output'
+     * buffers may overlap partially or totally.
+     *
+     * Unless WEAVE_CONFIG_EAX_NO_CHUNK is enabled, the payload may be
+     * processed in several chunks (several calls to Encrypt() with
+     * arbitrary chunk lengths).
+     */
+    void Encrypt(const uint8_t *input, size_t inputLen, uint8_t *output);
+
+    /*
+     * Variant of Encrypt() for in-place processing: the encrypted data
+     * replaces the plaintext data in the 'data' buffer.
+     */
+    void Encrypt(uint8_t *data, size_t dataLen);
+
+    /*
+     * Identical to Encrypt(), except for decryption instead of encryption.
+     * Note that, for a given message, all chunks must be encrypted, or
+     * all chunks must be decrypted; mixing encryption and decryption for
+     * a single message is not permitted.
+     */
+    void Decrypt(const uint8_t *input, size_t inputLen, uint8_t *output);
+
+    /*
+     * Variant of Decrypt() for in-place processing: the decrypted data
+     * replaces the ciphertext data in the 'data' buffer.
+     */
+    void Decrypt(uint8_t *data, size_t dataLen);
+
+    /*
+     * Finalize encryption or decryption, and get the authentication tag.
+     * This may be called only once per message; after the tag has been
+     * obtained, only SetKey() and Start() may be called again on the
+     * instance.
+     *
+     * Tag length must be between 8 and 16 bytes. Normal EAX tag length is
+     * 16 bytes.
+     */
+    void GetTag(uint8_t *tag, size_t tagLen);
+
+    /*
+     * Variant of GetTag() that does not return the tag, but compares it
+     * with the provided tag value. This is meant to be used by recipient,
+     * to verify the tag on an incoming message. Returned value is true
+     * if the tags match, false otherwise. Comparison is constant-time.
+     */
+    bool CheckTag(const uint8_t *tag, size_t tagLen);
+
+protected:
+    EAX(void);
+    ~EAX(void);
+
+private:
+    enum {
+        kBlockLength = 16
+    };
+    virtual void AESReset(void) = 0;
+    virtual void AESSetKey(const uint8_t *key) = 0;
+    virtual void AESEncryptBlock(uint8_t *data) = 0;
+
+#if !WEAVE_CONFIG_EAX_NO_PAD_CACHE
+    uint8_t L1[kBlockLength];
+#endif
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    uint8_t buf[kBlockLength];
+    uint8_t cbcmac[kBlockLength];
+#endif
+    uint8_t ctr[kBlockLength];
+    uint8_t acc[kBlockLength];
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    uint8_t ptr;
+#endif
+    uint8_t state;
+
+    void double_gf128(uint8_t *elt);
+    void xor_block(const uint8_t *src, uint8_t *dst);
+    void omac(unsigned val, const uint8_t *data, size_t len, uint8_t *mac);
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    void omac_start(unsigned val);
+    void omac_process(const uint8_t *data, size_t len);
+    void omac_finish(unsigned val);
+    void aad_finish(void);
+#endif
+    void incr_ctr(void);
+    void payload_process(bool encrypt, uint8_t *data, size_t len);
+};
+
+/*
+ * Concrete class for EAX with a 128-bit key (16 bytes).
+ */
+class NL_DLL_EXPORT EAX128 : public EAX
+{
+public:
+    enum
+    {
+        kKeyLength      = 16,
+        kKeyLengthBits  = kKeyLength * CHAR_BIT
+    };
+private:
+    AES128BlockCipherEnc aesCtx;
+    void AESReset(void);
+    void AESSetKey(const uint8_t *key);
+    void AESEncryptBlock(uint8_t *data);
+};
+
+/*
+ * Concrete class for EAX with a 256-bit key (32 bytes).
+ */
+class NL_DLL_EXPORT EAX256 : public EAX
+{
+public:
+    enum
+    {
+        kKeyLength      = 32,
+        kKeyLengthBits  = kKeyLength * CHAR_BIT
+    };
+private:
+    AES256BlockCipherEnc aesCtx;
+    void AESReset(void);
+    void AESSetKey(const uint8_t *key);
+    void AESEncryptBlock(uint8_t *data);
+};
+
+} // namespace Security
+} // namespace Platform
+} // namespace Weave
+} // namespace nl
+
+#endif /* AES_H_ */

--- a/src/test-apps/Makefile.am
+++ b/src/test-apps/Makefile.am
@@ -309,6 +309,7 @@ check_PROGRAMS                                 = \
     TestDRBG                                     \
     TestDeviceDescriptor                         \
     TestDNSResolution                            \
+    TestEAX                                      \
     TestECDH                                     \
     TestECDSA                                    \
     TestECMath                                   \
@@ -419,6 +420,7 @@ local_test_programs                            = \
     TestDRBG                                     \
     TestDeviceDescriptor                         \
     TestDNSResolution                            \
+    TestEAX                                      \
     TestECDH                                     \
     TestECDSA                                    \
     TestECMath                                   \
@@ -1167,6 +1169,9 @@ TestDataManagement_LDADD                 = libWeaveTestCommon.a $(COMMON_LDADD)
 
 TestDeviceDescriptor_SOURCES             = TestDeviceDescriptor.cpp
 TestDeviceDescriptor_LDADD               = $(COMMON_LDADD)
+
+TestEAX_SOURCES                          = TestEAX.cpp
+TestEAX_LDADD                            = $(COMMON_LDADD)
 
 TestECDH_SOURCES                         = TestECDH.cpp
 TestECDH_LDADD                           = $(COMMON_LDADD)

--- a/src/test-apps/Makefile.in
+++ b/src/test-apps/Makefile.in
@@ -149,8 +149,8 @@ target_triplet = @target@
 @WEAVE_BUILD_TESTS_TRUE@	TestCrypto$(EXEEXT) TestDRBG$(EXEEXT) \
 @WEAVE_BUILD_TESTS_TRUE@	TestDeviceDescriptor$(EXEEXT) \
 @WEAVE_BUILD_TESTS_TRUE@	TestDNSResolution$(EXEEXT) \
-@WEAVE_BUILD_TESTS_TRUE@	TestECDH$(EXEEXT) TestECDSA$(EXEEXT) \
-@WEAVE_BUILD_TESTS_TRUE@	TestECMath$(EXEEXT) \
+@WEAVE_BUILD_TESTS_TRUE@	TestEAX$(EXEEXT) TestECDH$(EXEEXT) \
+@WEAVE_BUILD_TESTS_TRUE@	TestECDSA$(EXEEXT) TestECMath$(EXEEXT) \
 @WEAVE_BUILD_TESTS_TRUE@	TestEventLogging$(EXEEXT) \
 @WEAVE_BUILD_TESTS_TRUE@	TestFabricStateDelegate$(EXEEXT) \
 @WEAVE_BUILD_TESTS_TRUE@	TestInetAddress$(EXEEXT) \
@@ -716,8 +716,8 @@ am__installdirs = "$(DESTDIR)$(libexecdir)"
 @WEAVE_BUILD_TESTS_TRUE@	TestCrypto$(EXEEXT) TestDRBG$(EXEEXT) \
 @WEAVE_BUILD_TESTS_TRUE@	TestDeviceDescriptor$(EXEEXT) \
 @WEAVE_BUILD_TESTS_TRUE@	TestDNSResolution$(EXEEXT) \
-@WEAVE_BUILD_TESTS_TRUE@	TestECDH$(EXEEXT) TestECDSA$(EXEEXT) \
-@WEAVE_BUILD_TESTS_TRUE@	TestECMath$(EXEEXT) \
+@WEAVE_BUILD_TESTS_TRUE@	TestEAX$(EXEEXT) TestECDH$(EXEEXT) \
+@WEAVE_BUILD_TESTS_TRUE@	TestECDSA$(EXEEXT) TestECMath$(EXEEXT) \
 @WEAVE_BUILD_TESTS_TRUE@	TestFabricStateDelegate$(EXEEXT) \
 @WEAVE_BUILD_TESTS_TRUE@	TestInetAddress$(EXEEXT) \
 @WEAVE_BUILD_TESTS_TRUE@	TestInetBuffer$(EXEEXT) \
@@ -903,6 +903,10 @@ am__TestDeviceDescriptor_SOURCES_DIST = TestDeviceDescriptor.cpp
 TestDeviceDescriptor_OBJECTS = $(am_TestDeviceDescriptor_OBJECTS)
 @WEAVE_BUILD_TESTS_TRUE@TestDeviceDescriptor_DEPENDENCIES =  \
 @WEAVE_BUILD_TESTS_TRUE@	$(am__DEPENDENCIES_6)
+am__TestEAX_SOURCES_DIST = TestEAX.cpp
+@WEAVE_BUILD_TESTS_TRUE@am_TestEAX_OBJECTS = TestEAX.$(OBJEXT)
+TestEAX_OBJECTS = $(am_TestEAX_OBJECTS)
+@WEAVE_BUILD_TESTS_TRUE@TestEAX_DEPENDENCIES = $(am__DEPENDENCIES_6)
 am__TestECDH_SOURCES_DIST = TestECDH.cpp
 @WEAVE_BUILD_TESTS_TRUE@am_TestECDH_OBJECTS = TestECDH.$(OBJEXT)
 TestECDH_OBJECTS = $(am_TestECDH_OBJECTS)
@@ -1770,16 +1774,17 @@ SOURCES = $(libMockBleApplicationDelegate_a_SOURCES) \
 	$(TestCodeUtils_SOURCES) $(TestCrypto_SOURCES) \
 	$(TestDNSResolution_SOURCES) $(TestDRBG_SOURCES) \
 	$(TestDataManagement_SOURCES) $(TestDeviceDescriptor_SOURCES) \
-	$(TestECDH_SOURCES) $(TestECDSA_SOURCES) $(TestECMath_SOURCES) \
-	$(TestErrorStr_SOURCES) $(TestEventLogging_SOURCES) \
-	$(TestFabricStateDelegate_SOURCES) $(TestInetAddress_SOURCES) \
-	$(TestInetBuffer_SOURCES) $(TestInetEndPoint_SOURCES) \
-	$(TestInetLayer_SOURCES) $(TestInetTimer_SOURCES) \
-	$(TestKeyExport_SOURCES) $(TestKeyIds_SOURCES) \
-	$(TestMsgEnc_SOURCES) $(TestNetworkInfo_SOURCES) \
-	$(TestPASE_SOURCES) $(TestPacketBuffer_SOURCES) \
-	$(TestPairingCodeUtils_SOURCES) $(TestPasscodeEnc_SOURCES) \
-	$(TestPathStore_SOURCES) $(TestPersistedCounter_SOURCES) \
+	$(TestEAX_SOURCES) $(TestECDH_SOURCES) $(TestECDSA_SOURCES) \
+	$(TestECMath_SOURCES) $(TestErrorStr_SOURCES) \
+	$(TestEventLogging_SOURCES) $(TestFabricStateDelegate_SOURCES) \
+	$(TestInetAddress_SOURCES) $(TestInetBuffer_SOURCES) \
+	$(TestInetEndPoint_SOURCES) $(TestInetLayer_SOURCES) \
+	$(TestInetTimer_SOURCES) $(TestKeyExport_SOURCES) \
+	$(TestKeyIds_SOURCES) $(TestMsgEnc_SOURCES) \
+	$(TestNetworkInfo_SOURCES) $(TestPASE_SOURCES) \
+	$(TestPacketBuffer_SOURCES) $(TestPairingCodeUtils_SOURCES) \
+	$(TestPasscodeEnc_SOURCES) $(TestPathStore_SOURCES) \
+	$(TestPersistedCounter_SOURCES) \
 	$(TestPersistedStorage_SOURCES) \
 	$(TestProfileStringSupport_SOURCES) $(TestProvHash_SOURCES) \
 	$(TestRADaemon_SOURCES) $(TestResourceIdentifier_SOURCES) \
@@ -1824,8 +1829,8 @@ DIST_SOURCES = $(am__libMockBleApplicationDelegate_a_SOURCES_DIST) \
 	$(am__TestDRBG_SOURCES_DIST) \
 	$(am__TestDataManagement_SOURCES_DIST) \
 	$(am__TestDeviceDescriptor_SOURCES_DIST) \
-	$(am__TestECDH_SOURCES_DIST) $(am__TestECDSA_SOURCES_DIST) \
-	$(am__TestECMath_SOURCES_DIST) \
+	$(am__TestEAX_SOURCES_DIST) $(am__TestECDH_SOURCES_DIST) \
+	$(am__TestECDSA_SOURCES_DIST) $(am__TestECMath_SOURCES_DIST) \
 	$(am__TestErrorStr_SOURCES_DIST) \
 	$(am__TestEventLogging_SOURCES_DIST) \
 	$(am__TestFabricStateDelegate_SOURCES_DIST) \
@@ -3008,8 +3013,9 @@ noinst_HEADERS = CASEOptions.h DMTestClient.h DeviceDescOptions.h \
 @WEAVE_BUILD_TESTS_TRUE@	TestASN1 TestAppKeys TestArgParser \
 @WEAVE_BUILD_TESTS_TRUE@	TestCASE TestCodeUtils TestCrypto \
 @WEAVE_BUILD_TESTS_TRUE@	TestDRBG TestDeviceDescriptor \
-@WEAVE_BUILD_TESTS_TRUE@	TestDNSResolution TestECDH TestECDSA \
-@WEAVE_BUILD_TESTS_TRUE@	TestECMath TestFabricStateDelegate \
+@WEAVE_BUILD_TESTS_TRUE@	TestDNSResolution TestEAX TestECDH \
+@WEAVE_BUILD_TESTS_TRUE@	TestECDSA TestECMath \
+@WEAVE_BUILD_TESTS_TRUE@	TestFabricStateDelegate \
 @WEAVE_BUILD_TESTS_TRUE@	TestInetAddress TestInetBuffer \
 @WEAVE_BUILD_TESTS_TRUE@	TestInetEndPoint TestInetTimer \
 @WEAVE_BUILD_TESTS_TRUE@	TestKeyExport TestKeyIds TestMsgEnc \
@@ -3118,6 +3124,8 @@ noinst_HEADERS = CASEOptions.h DMTestClient.h DeviceDescOptions.h \
 @WEAVE_BUILD_TESTS_TRUE@TestDataManagement_LDADD = libWeaveTestCommon.a $(COMMON_LDADD)
 @WEAVE_BUILD_TESTS_TRUE@TestDeviceDescriptor_SOURCES = TestDeviceDescriptor.cpp
 @WEAVE_BUILD_TESTS_TRUE@TestDeviceDescriptor_LDADD = $(COMMON_LDADD)
+@WEAVE_BUILD_TESTS_TRUE@TestEAX_SOURCES = TestEAX.cpp
+@WEAVE_BUILD_TESTS_TRUE@TestEAX_LDADD = $(COMMON_LDADD)
 @WEAVE_BUILD_TESTS_TRUE@TestECDH_SOURCES = TestECDH.cpp
 @WEAVE_BUILD_TESTS_TRUE@TestECDH_LDADD = $(COMMON_LDADD)
 @WEAVE_BUILD_TESTS_TRUE@TestECDSA_SOURCES = TestECDSA.cpp
@@ -3658,6 +3666,10 @@ TestDeviceDescriptor$(EXEEXT): $(TestDeviceDescriptor_OBJECTS) $(TestDeviceDescr
 	@rm -f TestDeviceDescriptor$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(TestDeviceDescriptor_OBJECTS) $(TestDeviceDescriptor_LDADD) $(LIBS)
 
+TestEAX$(EXEEXT): $(TestEAX_OBJECTS) $(TestEAX_DEPENDENCIES) $(EXTRA_TestEAX_DEPENDENCIES) 
+	@rm -f TestEAX$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(TestEAX_OBJECTS) $(TestEAX_LDADD) $(LIBS)
+
 TestECDH$(EXEEXT): $(TestECDH_OBJECTS) $(TestECDH_DEPENDENCIES) $(EXTRA_TestECDH_DEPENDENCIES) 
 	@rm -f TestECDH$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(TestECDH_OBJECTS) $(TestECDH_LDADD) $(LIBS)
@@ -4117,6 +4129,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/TestDRBG.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/TestDataManagement.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/TestDeviceDescriptor.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/TestEAX.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/TestECDH.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/TestECDSA.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/TestECMath.Po@am__quote@
@@ -6153,6 +6166,13 @@ TestDeviceDescriptor.log: TestDeviceDescriptor$(EXEEXT)
 TestDNSResolution.log: TestDNSResolution$(EXEEXT)
 	@p='TestDNSResolution$(EXEEXT)'; \
 	b='TestDNSResolution'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
+TestEAX.log: TestEAX$(EXEEXT)
+	@p='TestEAX$(EXEEXT)'; \
+	b='TestEAX'; \
 	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
@@ -8507,11 +8527,11 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
+@WEAVE_BUILD_TESTS_FALSE@install-exec-local:
+@WEAVE_BUILD_TESTS_FALSE@uninstall-local:
 @WEAVE_BUILD_COVERAGE_FALSE@clean-local:
 @WEAVE_BUILD_COVERAGE_REPORTS_FALSE@clean-local:
 @WEAVE_BUILD_TESTS_FALSE@clean-local:
-@WEAVE_BUILD_TESTS_FALSE@uninstall-local:
-@WEAVE_BUILD_TESTS_FALSE@install-exec-local:
 clean: clean-recursive
 
 clean-am: clean-checkPROGRAMS clean-generic clean-libexecPROGRAMS \

--- a/src/test-apps/TestEAX.cpp
+++ b/src/test-apps/TestEAX.cpp
@@ -1,0 +1,1296 @@
+/*
+ *
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements tests of the EAX implementation against
+ *      known-answer test vectors from the Wycheproof project:
+ *         https://github.com/google/wycheproof
+ *
+ */
+
+#include <Weave/Core/WeaveConfig.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include "ToolCommon.h"
+#include <Weave/Support/crypto/EAX.h>
+
+/*
+ * Decode hexadecimal characters. The maximum size of the dst[] buffer is
+ * dst_len; the actual length (in bytes) is returned.
+ *
+ * A failure (process exit) is reported in the following situations:
+ *
+ *  - Destination buffer is too small.
+ *
+ *  - One of the characters is not an hexadecimal digit (decimal digits,
+ *    letters from 'A' to 'F', letters from 'a' to 'f') or an "ignored
+ *    character" (ignored characters are all ASCII control characters
+ *    from 0 to 31, ASCII space 0x20, ':' and '-').
+ *
+ *  - Source contains an odd number of hexadecimal digits.
+ */
+static size_t
+hextobin(uint8_t *dst, size_t dst_len, const char *src)
+{
+    size_t u;
+    int z;
+    unsigned acc;
+
+    u = 0;
+    z = 0;
+    acc = 0;
+    while (*src != 0) {
+        int c;
+
+        c = *src ++;
+        if (c >= '0' && c <= '9') {
+            c -= '0';
+        } else if (c >= 'A' && c <= 'F') {
+            c -= ('A' - 10);
+        } else if (c >= 'a' && c <= 'f') {
+            c -= ('a' - 10);
+        } else if (c <= 32 || c == ':' || c == '-') {
+            continue;
+        } else {
+            fprintf(stderr, "not an hex character: 0x%02X\n", c);
+            exit(EXIT_FAILURE);
+        }
+        if (z) {
+            if (u >= dst_len) {
+                fprintf(stderr, "destination too small\n");
+                exit(EXIT_FAILURE);
+            }
+            dst[u ++] = (acc << 4) + c;
+        } else {
+            acc = c;
+        }
+        z = !z;
+    }
+    if (z) {
+        fprintf(stderr, "odd number of hex digits\n");
+        exit(EXIT_FAILURE);
+    }
+    return u;
+}
+
+/*
+ * Check that b1[] and b2[], of common length 'len', have identical
+ * contents. If not, then an error message is printed, that contains
+ * the provided banner string, and hex dumps of the two buffers; then
+ * the process exits.
+ */
+static void
+check_eq(const char *banner, const void *b1, const void *b2, size_t len)
+{
+    size_t u;
+    const uint8_t *a1, *a2;
+
+    if (memcmp(b1, b2, len) == 0) {
+        return;
+    }
+    fprintf(stderr, "%s: DIFF:\n", banner);
+    a1 = (const uint8_t *)b1;
+    a2 = (const uint8_t *)b2;
+    for (u = 0; u < len; u ++) {
+        fprintf(stderr, "%02x", a1[u]);
+    }
+    fprintf(stderr, "\n");
+    for (u = 0; u < len; u ++) {
+        fprintf(stderr, "%02x", a2[u]);
+    }
+    fprintf(stderr, "\n");
+    exit(EXIT_FAILURE);
+}
+
+/*
+ * Inner test function; the EAX engine has already been initialized with
+ * a key. Elements (nonce, AAD, plaintext, ciphertext, and tag) are
+ * provided as hexadecimal strings. If 'valid' is true, then the provided
+ * tag is supposed to match the recomputed tag; otherwise, it is expected
+ * _not_ to match.
+ */
+static void
+test_EAX_inner(nl::Weave::Platform::Security::EAX *eax,
+    const char *hexnonce, const char *hexaad, const char *hexplain,
+    const char *hexcipher, const char *hextag, bool valid)
+{
+    uint8_t nonce[200];
+    uint8_t aad[200];
+    uint8_t plain[200];
+    uint8_t cipher[200];
+    uint8_t tag[16];
+    uint8_t tmp[200], tmptag[16];
+    size_t nonce_len, aad_len, plain_len, cipher_len, tag_len;
+    nl::Weave::Platform::Security::EAXSaved sav;
+#if !WEAVE_CONFIG_EAX_NO_CHUNK
+    size_t u;
+#endif
+
+    /*
+     * Decode elements into bytes. Plaintext and ciphertext are supposed
+     * to have the same length.
+     */
+    nonce_len = hextobin(nonce, sizeof nonce, hexnonce);
+    aad_len = hextobin(aad, sizeof aad, hexaad);
+    plain_len = hextobin(plain, sizeof plain, hexplain);
+    cipher_len = hextobin(cipher, sizeof cipher, hexcipher);
+    tag_len = hextobin(tag, sizeof tag, hextag);
+    if (plain_len != cipher_len) {
+        fprintf(stderr, "inconsistent: plain_len=%zu cipher_len=%zu\n",
+            plain_len, cipher_len);
+        exit(EXIT_FAILURE);
+    }
+
+    /*
+     * Try encryption, and verify the tag against the reference value.
+     */
+    eax->Start(nonce, nonce_len);
+    eax->InjectHeader(aad, aad_len);
+    eax->Encrypt(plain, plain_len, tmp);
+    check_eq("KAT 1", cipher, tmp, cipher_len);
+    eax->GetTag(tmptag, tag_len);
+    if (valid) {
+        check_eq("KAT 2", tag, tmptag, tag_len);
+    } else {
+        if (memcmp(tag, tmptag, tag_len) == 0) {
+            fprintf(stderr, "KAT 2: should have obtained"
+                " a different tag\n");
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    printf(".");
+    fflush(stdout);
+
+    /*
+     * Try decryption, and check the tag against the reference value.
+     * This one uses CheckTag() instead of GetTag().
+     */
+    eax->Start(nonce, nonce_len);
+    eax->InjectHeader(aad, aad_len);
+    eax->Decrypt(cipher, cipher_len, tmp);
+    check_eq("KAT 3", plain, tmp, plain_len);
+    if (valid != eax->CheckTag(tag, tag_len)) {
+        fprintf(stderr, "wrong validation status\n");
+        exit(EXIT_FAILURE);
+    }
+
+    printf(".");
+    fflush(stdout);
+
+    if (!valid) {
+        return;
+    }
+
+    /*
+     * Try encryption again. This time:
+     *
+     *  - If chunked processing is supported, inject AAD and plaintext
+     *    one byte at a time. If the AAD and/or the plaintext is empty,
+     *    then the corresponding method is not called at all.
+     *
+     *  - If chunked processing is not supported, AAD and plaintext are
+     *    injected with a single call each. However, if the AAD and/or
+     *    the plaintext is empty, the method is skipped.
+     */
+    eax->Start(nonce, nonce_len);
+#if WEAVE_CONFIG_EAX_NO_CHUNK
+    if (aad_len > 0) {
+        eax->InjectHeader(aad, aad_len);
+    }
+    if (plain_len > 0) {
+        eax->Encrypt(plain, plain_len, tmp);
+    }
+#else
+    for (u = 0; u < aad_len; u ++) {
+        eax->InjectHeader(&aad[u], 1);
+    }
+    for (u = 0; u < plain_len; u ++) {
+        eax->Encrypt(&plain[u], 1, &tmp[u]);
+    }
+#endif
+    check_eq("KAT 4", cipher, tmp, cipher_len);
+    eax->GetTag(tmptag, tag_len);
+    check_eq("KAT 5", tag, tmptag, tag_len);
+
+    printf(".");
+    fflush(stdout);
+
+    /*
+     * Try decryption again. This time:
+     *
+     *  - If chunked processing is supported, inject AAD and plaintext
+     *    one byte at a time. If the AAD and/or the plaintext is empty,
+     *    then the corresponding method is not called at all.
+     *
+     *  - If chunked processing is not supported, AAD and plaintext are
+     *    injected with a single call each. However, if the AAD and/or
+     *    the plaintext is empty, the method is skipped.
+     */
+    eax->Start(nonce, nonce_len);
+#if WEAVE_CONFIG_EAX_NO_CHUNK
+    if (aad_len > 0) {
+        eax->InjectHeader(aad, aad_len);
+    }
+    if (plain_len > 0) {
+        eax->Decrypt(cipher, cipher_len, tmp);
+    }
+#else
+    for (u = 0; u < aad_len; u ++) {
+        eax->InjectHeader(&aad[u], 1);
+    }
+    for (u = 0; u < plain_len; u ++) {
+        eax->Decrypt(&cipher[u], 1, &tmp[u]);
+    }
+#endif
+    check_eq("KAT 6", plain, tmp, plain_len);
+    eax->GetTag(tmptag, tag_len);
+    check_eq("KAT 7", tag, tmptag, tag_len);
+
+    printf(".");
+    fflush(stdout);
+
+    /*
+     * Save the header, then use it for encryption.
+     */
+    eax->SaveHeader(aad, aad_len, &sav);
+    eax->StartSaved(nonce, nonce_len, &sav);
+    eax->Encrypt(plain, plain_len, tmp);
+    check_eq("KAT 8", cipher, tmp, cipher_len);
+    eax->GetTag(tmptag, tag_len);
+    check_eq("KAT 9", tag, tmptag, tag_len);
+
+    printf(".");
+    fflush(stdout);
+
+    /*
+     * Also use the saved header for decryption. We also verify that
+     * we can get the tag several times.
+     */
+    eax->StartSaved(nonce, nonce_len, &sav);
+    eax->Decrypt(tmp, cipher_len);
+    check_eq("KAT 10", plain, tmp, plain_len);
+    eax->GetTag(tmptag, tag_len);
+    check_eq("KAT 11", tag, tmptag, tag_len);
+    eax->GetTag(tmptag, tag_len);
+    check_eq("KAT 12", tag, tmptag, tag_len);
+
+    printf(".");
+    fflush(stdout);
+}
+
+/*
+ * Outer test function. The test name is provided; it will be printed.
+ * Elements (key, nonce, AAD, plaintext, ciphertext, and tag) are
+ * provided as hexadecimal strings. If 'valid' is true, then the provided
+ * tag is supposed to match the recomputed tag; otherwise, it is expected
+ * _not_ to match.
+ */
+static void
+test_EAX(const char *name,
+    const char *hexkey, const char *hexnonce, const char *hexaad,
+    const char *hexplain, const char *hexcipher, const char *hextag,
+    bool valid)
+{
+    unsigned char key[32];
+    size_t key_len;
+
+    printf("Test %s: ", name);
+    fflush(stdout);
+    key_len = hextobin(key, sizeof key, hexkey);
+    if (key_len == 16) {
+        nl::Weave::Platform::Security::EAX128 eax;
+
+        eax.SetKey(key);
+        test_EAX_inner(&eax, hexnonce, hexaad, hexplain,
+            hexcipher, hextag, valid);
+    } else if (key_len == 32) {
+        nl::Weave::Platform::Security::EAX256 eax;
+
+        eax.SetKey(key);
+        test_EAX_inner(&eax, hexnonce, hexaad, hexplain,
+            hexcipher, hextag, valid);
+    } else {
+        fprintf(stderr, "unsupported key length: %zu bytes\n", key_len);
+        exit(EXIT_FAILURE);
+    }
+    printf("OK\n");
+    fflush(stdout);
+}
+
+int
+main(int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    /*
+     * Following test vectors are from the Wycheproof project. Source file is:
+     *  https://github.com/google/wycheproof/blob/master/testvectors/aes_eax_test.json
+     * (retrieved on 2018-10-17.)
+     *
+     * Test vectors with a key size of 192 bits have not been retained,
+     * since we only support keys of 128 and 256 bits.
+     */
+
+    /* ivSize=128 keySize=128 */
+    test_EAX("wycheproof-1",
+        "233952dee4d5ed5f9b9c6d6ff80ff478",
+        "62ec67f9c3a4a407fcb2a8c49031a8b3",
+        "6bfb914fd07eae6b",
+        "",
+        "",
+        "e037830e8389f27b025a2d6527e79d01",
+        true);
+    test_EAX("wycheproof-2",
+        "91945d3f4dcbee0bf45ef52255f095a4",
+        "becaf043b0a23d843194ba972c66debd",
+        "fa3bfd4806eb53fa",
+        "f7fb",
+        "19dd",
+        "5c4c9331049d0bdab0277408f67967e5",
+        true);
+    test_EAX("wycheproof-3",
+        "01f74ad64077f2e704c0f60ada3dd523",
+        "70c3db4f0d26368400a10ed05d2bff5e",
+        "234a3463c1264ac6",
+        "1a47cb4933",
+        "d851d5bae0",
+        "3a59f238a23e39199dc9266626c40f80",
+        true);
+    test_EAX("wycheproof-4",
+        "d07cf6cbb7f313bdde66b727afd3c5e8",
+        "8408dfff3c1a2b1292dc199e46b7d617",
+        "33cce2eabff5a79d",
+        "481c9e39b1",
+        "632a9d131a",
+        "d4c168a4225d8e1ff755939974a7bede",
+        true);
+    test_EAX("wycheproof-5",
+        "35b6d0580005bbc12b0587124557d2c2",
+        "fdb6b06676eedc5c61d74276e1f8e816",
+        "aeb96eaebe2970e9",
+        "40d0c07da5e4",
+        "071dfe16c675",
+        "cb0677e536f73afe6a14b74ee49844dd",
+        true);
+    test_EAX("wycheproof-6",
+        "bd8e6e11475e60b268784c38c62feb22",
+        "6eac5c93072d8e8513f750935e46da1b",
+        "d4482d1ca78dce0f",
+        "4de3b35c3fc039245bd1fb7d",
+        "835bb4f15d743e350e728414",
+        "abb8644fd6ccb86947c5e10590210a4f",
+        true);
+    test_EAX("wycheproof-7",
+        "7c77d6e813bed5ac98baa417477a2e7d",
+        "1a8c98dcd73d38393b2bf1569deefc19",
+        "65d2017990d62528",
+        "8b0a79306c9ce7ed99dae4f87f8dd61636",
+        "02083e3979da014812f59f11d52630da30",
+        "137327d10649b0aa6e1c181db617d7f2",
+        true);
+    test_EAX("wycheproof-8",
+        "5fff20cafab119ca2fc73549e20f5b0d",
+        "dde59b97d722156d4d9aff2bc7559826",
+        "54b9f04e6a09189a",
+        "1bda122bce8a8dbaf1877d962b8592dd2d56",
+        "2ec47b2c4954a489afc7ba4897edcdae8cc3",
+        "3b60450599bd02c96382902aef7f832a",
+        true);
+    test_EAX("wycheproof-9",
+        "a4a4782bcffd3ec5e7ef6d8c34a56123",
+        "b781fcf2f75fa5a8de97a9ca48e522ec",
+        "899a175897561d7e",
+        "6cf36720872b8513f6eab1a8a44438d5ef11",
+        "0de18fd0fdd91e7af19f1d8ee8733938b1e8",
+        "e7f6d2231618102fdb7fe55ff1991700",
+        true);
+    test_EAX("wycheproof-10",
+        "8395fcf1e95bebd697bd010bc766aac3",
+        "22e7add93cfc6393c57ec0b3c17d6b44",
+        "126735fcc320d25a",
+        "ca40d7446e545ffaed3bd12a740a659ffbbb3ceab7",
+        "cb8920f87a6c75cff39627b56e3ed197c552d295a7",
+        "cfc46afc253b4652b1af3795b124ab6e",
+        true);
+    test_EAX("wycheproof-11",
+        "000102030405060708090a0b0c0d0e0f",
+        "3c8cc2970a008f75cc5beae2847258c2",
+        "",
+        "0000000000000000000000000000000011111111111111111111111111111111",
+        "3c441f32ce07822364d7a2990e50bb13d7b02a26969e4a937e5e9073b0d9c968",
+        "db90bdb3da3d00afd0fc6a83551da95e",
+        true);
+    test_EAX("wycheproof-12",
+        "000102030405060708090a0b0c0d0e0f",
+        "aef03d00598494e9fb03cd7d8b590866",
+        "",
+        "0000000000000000000000000000000011111111111111111111111111111111",
+        "d19ac59849026a91aa1b9aec29b11a202a4d739fd86c28e3ae3d588ea21d70c6",
+        "c30f6cd9202074ed6e2a2a360eac8c47",
+        true);
+    test_EAX("wycheproof-13",
+        "000102030405060708090a0b0c0d0e0f",
+        "55d12511c696a80d0514d1ffba49cada",
+        "",
+        "0000000000000000000000000000000011111111111111111111111111111111",
+        "2108558ac4b2c2d5cc66cea51d6210e046177a67631cd2dd8f09469733acb517",
+        "fc355e87a267be3ae3e44c0bf3f99b2b",
+        true);
+    test_EAX("wycheproof-14",
+        "000102030405060708090a0b0c0d0e0f",
+        "79422ddd91c4eee2deaef1f968305304",
+        "",
+        "0000000000000000000000000000000011111111111111111111111111111111",
+        "4d2c1524ca4baa4eefcce6b91b227ee83abaff8105dcafa2ab191f5df2575035",
+        "e2c865ce2d7abdac024c6f991a848390",
+        true);
+    test_EAX("wycheproof-15",
+        "000102030405060708090a0b0c0d0e0f",
+        "0af5aa7a7676e28306306bcd9bf2003a",
+        "",
+        "0000000000000000000000000000000011111111111111111111111111111111",
+        "8eb01e62185d782eb9287a341a6862ac5257d6f9adc99ee0a24d9c22b3e9b38a",
+        "39c339bc8a74c75e2c65c6119544d61e",
+        true);
+    test_EAX("wycheproof-16",
+        "000102030405060708090a0b0c0d0e0f",
+        "af5a03ae7edd73471bdcdfac5e194a60",
+        "",
+        "0000000000000000000000000000000011111111111111111111111111111111",
+        "94c5d2aca6dbbce8c24513a25e095c0e54a942860d327a222a815cc713b163b4",
+        "f50b30304e45c9d411e8df4508a98612",
+        true);
+    test_EAX("wycheproof-17",
+        "000102030405060708090a0b0c0d0e0f",
+        "b37087680f0edd5a52228b8c7aaea664",
+        "",
+        "00000000000000000000000000000000111111111111111111111111111111112222222222222222222222222222222233333333333333333333333333333333",
+        "3bb6173e3772d4b62eef37f9ef0781f360b6c74be3bf6b371067bc1b090d9d6622a1fbec6ac471b3349cd4277a101d40890fbf27dfdcd0b4e3781f9806daabb6",
+        "a0498745e59999ddc32d5b140241124e",
+        true);
+    test_EAX("wycheproof-18",
+        "000102030405060708090a0b0c0d0e0f",
+        "4f802da62a384555a19bc2b382eb25af",
+        "",
+        "0000000000000000000000000000000011111111111111111111111111111111222222222222222222222222222222223333333333333333333333333333333344444444444444444444444444444444",
+        "e9b0bb8857818ce3201c3690d21daa7f264fb8ee93cc7a4674ea2fc32bf182fb2a7e8ad51507ad4f31cefc2356fe7936a7f6e19f95e88fdbf17620916d3a6f3d01fc17d358672f777fd4099246e436e1",
+        "67910be744b8315ae0eb6124590c5d8b",
+        true);
+    test_EAX("wycheproof-19",
+        "b67b1a6efdd40d37080fbe8f8047aeb9",
+        "fa294b129972f7fc5bbd5b96bba837c9",
+        "",
+        "",
+        "",
+        "b14b64fb589899699570cc9160e39896",
+        true);
+    test_EAX("wycheproof-20",
+        "209e6dbf2ad26a105445fc0207cd9e9a",
+        "9477849d6ccdfca112d92e53fae4a7ca",
+        "",
+        "01",
+        "1d",
+        "52a5f600fe5338026a7cb09c11640082",
+        true);
+    test_EAX("wycheproof-21",
+        "a549442e35154032d07c8666006aa6a2",
+        "5171524568e81d97e8c4de4ba56c10a0",
+        "",
+        "1182e93596cac5608946400bc73f3a",
+        "d7b8a6b43d2e9f98c2b44ce5e3cfdb",
+        "1bdd52fc987daf0ee19234c905ea645f",
+        true);
+    test_EAX("wycheproof-22",
+        "958bcdb66a3952b53701582a68a0e474",
+        "0e6ec879b02c6f516976e35898428da7",
+        "",
+        "140415823ecc8932a058384b738ea6ea6d4dfe3bbeee",
+        "73e5c6f0e703a52d02f7f7faeb1b77fd4fd0cb421eaf",
+        "6c154a85968edd74776575a4450bd897",
+        true);
+    test_EAX("wycheproof-23",
+        "965b757ba5018a8d66edc78e0ceee86b",
+        "2e35901ae7d491eecc8838fedd631405",
+        "df10d0d212242450",
+        "36e57a763958b02cea9d6a676ebce81f",
+        "936b69b6c955adfd15539b9be4989cb6",
+        "ee15a1454e88faad8e48a8df2983b425",
+        true);
+    test_EAX("wycheproof-24",
+        "88d02033781c7b4164711a05420f256e",
+        "7f2985296315507aa4c0a93d5c12bd77",
+        "7c571d2fbb5f62523c0eb338bef9a9",
+        "d98adc03d9d582732eb07df23d7b9f74",
+        "67caac35443a3138d2cb811f0ce04dd2",
+        "b7968e0b5640e3b236569653208b9deb",
+        true);
+    test_EAX("wycheproof-25",
+        "515840cf67d2e40eb65e54a24c72cbf2",
+        "bf47afdfd492137a24236bc36797a88e",
+        "16843c091d43b0a191d0c73d15601be9",
+        "c834588cb6daf9f06dd23519f4be9f56",
+        "200ac451fbeb0f6151d61583a43b7343",
+        "2ad43e4caa51983a9d4d24481bf4c839",
+        true);
+    test_EAX("wycheproof-26",
+        "2e4492d444e5b6f4cec8c2d3615ac858",
+        "d02bf0763a9fefbf70c33aee1e9da1d6",
+        "904d86f133cec15a0c3caf14d7e029c82a07705a23f0d080",
+        "9e62d6511b0bda7dd7740b614d97bae0",
+        "27c6e9a653c5253ca1c5673f97b9b33e",
+        "2d581271e1fa9e3686136caa8f4d6c8e",
+        true);
+    test_EAX("wycheproof-27",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e70e7c5013a6dbf25298b1929bc356a7",
+        false);
+    test_EAX("wycheproof-28",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e40e7c5013a6dbf25298b1929bc356a7",
+        false);
+    test_EAX("wycheproof-29",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "660e7c5013a6dbf25298b1929bc356a7",
+        false);
+    test_EAX("wycheproof-30",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60f7c5013a6dbf25298b1929bc356a7",
+        false);
+    test_EAX("wycheproof-31",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7cd013a6dbf25298b1929bc356a7",
+        false);
+    test_EAX("wycheproof-32",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5012a6dbf25298b1929bc356a7",
+        false);
+    test_EAX("wycheproof-33",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5011a6dbf25298b1929bc356a7",
+        false);
+    test_EAX("wycheproof-34",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6db725298b1929bc356a7",
+        false);
+    test_EAX("wycheproof-35",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf25398b1929bc356a7",
+        false);
+    test_EAX("wycheproof-36",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf2d298b1929bc356a7",
+        false);
+    test_EAX("wycheproof-37",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf252b8b1929bc356a7",
+        false);
+    test_EAX("wycheproof-38",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf25298b0929bc356a7",
+        false);
+    test_EAX("wycheproof-39",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf25298b1929ac356a7",
+        false);
+    test_EAX("wycheproof-40",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf25298b19299c356a7",
+        false);
+    test_EAX("wycheproof-41",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf25298b1921bc356a7",
+        false);
+    test_EAX("wycheproof-42",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf25298b1929bc356a6",
+        false);
+    test_EAX("wycheproof-43",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf25298b1929bc356a5",
+        false);
+    test_EAX("wycheproof-44",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf25298b1929bc356e7",
+        false);
+    test_EAX("wycheproof-45",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6dbf25298b1929bc35627",
+        false);
+    test_EAX("wycheproof-46",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e70e7c5013a6dbf25398b1929bc356a7",
+        false);
+    test_EAX("wycheproof-47",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7cd013a6db725298b1929bc356a7",
+        false);
+    test_EAX("wycheproof-48",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e60e7c5013a6db725298b1929bc35627",
+        false);
+    test_EAX("wycheproof-49",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "19f183afec59240dad674e6d643ca958",
+        false);
+    test_EAX("wycheproof-50",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "00000000000000000000000000000000",
+        false);
+    test_EAX("wycheproof-51",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "ffffffffffffffffffffffffffffffff",
+        false);
+    test_EAX("wycheproof-52",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "668efcd093265b72d21831121b43d627",
+        false);
+    test_EAX("wycheproof-53",
+        "000102030405060708090a0b0c0d0e0f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "29a0914fec4bef54babf6613a9f9cd70",
+        "e70f7d5112a7daf35399b0939ac257a6",
+        false);
+
+    /* ivSize=96 keySize=128 */
+    test_EAX("wycheproof-54",
+        "bedcfb5a011ebc84600fcb296c15af0d",
+        "438a547a94ea88dce46c6c85",
+        "",
+        "",
+        "",
+        "9607977cd7556b1dfedf0c73a35a5197",
+        true);
+    test_EAX("wycheproof-55",
+        "384ea416ac3c2f51a76e7d8226346d4e",
+        "b30c084727ad1c592ac21d12",
+        "",
+        "35",
+        "98",
+        "f5d7930952e275beecb998d804c241f0",
+        true);
+    test_EAX("wycheproof-56",
+        "cae31cd9f55526eb038241fc44cac1e5",
+        "b5e006ded553110e6dc56529",
+        "",
+        "d10989f2c52e94ad",
+        "7fd2878318ab0f2b",
+        "ab184ffde523565529a9be111b0c2d6d",
+        true);
+    test_EAX("wycheproof-57",
+        "ffdf4228361ea1f8165852136b3480f7",
+        "0e1666f2dc652f7708fb8f0d",
+        "",
+        "25b12e28ac0ef6ead0226a3b2288c800",
+        "e928622d1e6e798d8665ae732c4c1e5f",
+        "33ab476757ffa42c0f6c276391a46eac",
+        true);
+    test_EAX("wycheproof-58",
+        "a8ee11b26d7ceb7f17eaa1e4b83a2cf6",
+        "fbbc04fd6e025b7193eb57f6",
+        "",
+        "c08f085e6a9e0ef3636280c11ecfadf0c1e72919ffc17eaf",
+        "efd299a43b25ce8cc31b80e5489ef9ce7356ececa91bc7bd",
+        "3c33fc0bcd256b0a8a34ecc8b01e52a6",
+        true);
+    test_EAX("wycheproof-59",
+        "1655bf662f7ee685615701fd3779d628",
+        "42b51388f6f9047a2a994575",
+        "",
+        "857b2f6cd608c9cea0246c740caa4ca19c5f1c7d71cb9273f0d8c8bb65b70a",
+        "356bca9cddd39efd393278e43b4e80266071608036e81d6e924d4e4800fb27",
+        "71f02ba7c6cf3a579e56245025420071",
+        true);
+    test_EAX("wycheproof-60",
+        "42e38abef2dd7573248c5aefb3ecca54",
+        "064b3cfbe04d94d4d5c19b30",
+        "",
+        "2c763b9ec84903bcbb8aec15e678a3a955e4870edbf62d9d3c81c4f9ed6154877875779ca33cce8f73a55ca7af1d8d817fc6baac00ef962c5a0da339ce81427a3d59",
+        "9d911b934a68ce7db322410028bd31bd81bcbdadf26f15676be472bc3821fb68e4728db76930bc0958aeed6faf3e333da7af3d48c480b424ff3d6600cc56a507c8ad",
+        "d679eb9e5d744b62d91dcf6fb6284f41",
+        true);
+
+    /* ivSize=96 keySize=256 */
+    test_EAX("wycheproof-68",
+        "80ba3192c803ce965ea371d5ff073cf0f43b6a2ab576b208426e11409c09b9b0",
+        "4da5bf8dfd5852c1ea12379d",
+        "",
+        "",
+        "",
+        "4d293af9a8fe4ac034f14b14334c16ae",
+        true);
+    test_EAX("wycheproof-69",
+        "cc56b680552eb75008f5484b4cb803fa5063ebd6eab91f6ab6aef4916a766273",
+        "99e23ec48985bccdeeab60f1",
+        "",
+        "2a",
+        "8c",
+        "c460d5ff45235c3c2491c7e6a32491d6",
+        true);
+    test_EAX("wycheproof-70",
+        "51e4bf2bad92b7aff1a4bc05550ba81df4b96fabf41c12c7b00e60e48db7e152",
+        "4f07afedfdc3b6c2361823d3",
+        "",
+        "be3308f72a2c6aed",
+        "6038296421fb5007",
+        "0a91c72219c0b9ad716accd910e04e13",
+        true);
+    test_EAX("wycheproof-71",
+        "59d4eafb4de0cfc7d3db99a8f54b15d7b39f0acc8da69763b019c1699f87674a",
+        "2fcb1b38a99e71b84740ad9b",
+        "",
+        "549b365af913f3b081131ccb6b825588",
+        "c4066e265a948f40e05e37fa400fde1b",
+        "611de27128955c54edd7a4d6d23e78ee",
+        true);
+    test_EAX("wycheproof-72",
+        "0212a8de5007ed87b33f1a7090b6114f9e08cefd9607f2c276bdcfdbc5ce9cd7",
+        "e6b1adf2fd58a8762c65f31b",
+        "",
+        "10f1ecf9c60584665d9ae5efe279e7f7377eea6916d2b111",
+        "f64ffe52cd838cea89dd500662a2ee4b4b450eee68218e84",
+        "ae1e2eda96bed82182240aae08f9fe9c",
+        true);
+    test_EAX("wycheproof-73",
+        "2eb51c469aa8eb9e6c54a8349bae50a20f0e382711bba1152c424f03b6671d71",
+        "04a9be03508a5f31371a6fd2",
+        "",
+        "b053999286a2824f42cc8c203ab24e2c97a685adcc2ad32662558e55a5c729",
+        "01f09a6a136909c158e13502ee5488f592ee24059d6da734acba8c11e9815f",
+        "79e57b518fa6dabe94e0e89cae89976b",
+        true);
+    test_EAX("wycheproof-74",
+        "95e87eda64d0dc2d4e851030c3e1b27cca2265b3464c2c572bd8fc8cfb282d1b",
+        "ce03bbb56778f25d4528350b",
+        "",
+        "2e5acc19acb9940bb74d414b45e71386a409b641490b139493d7d632cbf1674fdf2511c3fad6c27359e6137b4cd52efc4bf871e6623451517d6a3c68240f2a79916a",
+        "72356ce9f1822e30809817a3b91ea13700ab3275b6f3718a845ad0b132bf4bbbb61ee466c1b0a1cb5a26424dbcc8d1b649f22785907a9c0164a2a41a9fc477d6c4dd",
+        "872861d71412e15732f60a83d4b47ee1",
+        true);
+
+    /* ivSize=128 keySize=256 */
+    test_EAX("wycheproof-110",
+        "b4cd11db0b3e0b9b34eafd9fe027746976379155e76116afde1b96d21298e34f",
+        "00c49f4ebb07393f07ebc3825f7b0830",
+        "",
+        "",
+        "",
+        "80d821cde2d6c523b718597b11dd0fa8",
+        true);
+    test_EAX("wycheproof-111",
+        "b7797eb0c1a6089ad5452d81fdb14828c040ddc4589c32b565aad8cb4de3e4a0",
+        "0ad570d8863918fe89124e09d125a271",
+        "",
+        "ed",
+        "25",
+        "4fef9ec45255dbba5631105d00a55767",
+        true);
+    test_EAX("wycheproof-112",
+        "4c010d9561c7234c308c01cea3040c925a9f324dc958ff904ae39b37e60e1e03",
+        "2a55caa137c5b0b66cf3809eb8f730c4",
+        "",
+        "2a093c9ed72b8ff4994201e9f9e010",
+        "cbfcaa3634d6cff5656bc6bda6ab5f",
+        "0144be0643b036a8147e19f4ea9e7af2",
+        true);
+    test_EAX("wycheproof-113",
+        "2f6cfb7a215a7bafb607c273f7e66f9a6d51d57f9c29422ec64699bad0c6f33b",
+        "21cbeff0b123799da74f4daff2e279c5",
+        "",
+        "39dbc71f6838ed6c6e582137436e1c61bbbfb80531f4",
+        "f531097aa1bb35d9f401d459340afbd27f9bdf72c537",
+        "e4e18170dce4e1af90b15eae64355331",
+        true);
+    test_EAX("wycheproof-114",
+        "7517c973a9de3614431e3198f4ddc0f8dc33862654649e9ff7838635bb278231",
+        "42f82085c08afd5b19a9491a79cd8119",
+        "e9ee894ad5b0781d",
+        "d17fbed25ad5f72477580b9e82a7b883",
+        "0b70b24253b2e1c3ef1165925b5c5e57",
+        "45009a2a101877ed70e58f2e5910004f",
+        true);
+    test_EAX("wycheproof-115",
+        "9f5c60fb5df5cf2b1b39254c3fa80e51d30d64e344b3aba59574305b4d2212ad",
+        "d4df79c69f73b26a13598af07eed6a77",
+        "813399ff1e1ef0b58bb2be130ce5d4",
+        "a3ca2ef9bd1fdbaa83db4c7eae6de94e",
+        "65019212ccbbd4cd2f995cc59d46fd27",
+        "4026c486430a1ae2a5fc4081cd665468",
+        true);
+    test_EAX("wycheproof-116",
+        "38f3d880ed6cd605f2eab88027c9a1c21d13e3de1af50ac884723bcf2b70f495",
+        "7078c9239650b8a1a8cf031d460e51c1",
+        "d1544013b885a7083abece9e31d98ebc",
+        "52609620d7f572aa9267565e459ae419",
+        "91b9f4424b68b4af839ce553d10b7dbc",
+        "0541b1a518f4bb585a594f3eab5535c3",
+        true);
+    test_EAX("wycheproof-117",
+        "ec88cec13d8ebae7d62f60197e5486d61c33ee5a50b19f197c1348fbc9e27e8e",
+        "1ec1d18c96ca6cad66690e60b91cf222",
+        "d28d5811d4168a08da54b97831b59200041adb0e2891ea91",
+        "658c6c7d8ea64a48375d69d9a405095a",
+        "e42b53912ce21a3ee7a1fb51194d6fe3",
+        "2bc8cc7f42cac1a121fd9ddff4f2073c",
+        true);
+    test_EAX("wycheproof-118",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e976fdd461c0a0a49971db8d9678acb8",
+        false);
+    test_EAX("wycheproof-119",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "ea76fdd461c0a0a49971db8d9678acb8",
+        false);
+    test_EAX("wycheproof-120",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "6876fdd461c0a0a49971db8d9678acb8",
+        false);
+    test_EAX("wycheproof-121",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e877fdd461c0a0a49971db8d9678acb8",
+        false);
+    test_EAX("wycheproof-122",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fd5461c0a0a49971db8d9678acb8",
+        false);
+    test_EAX("wycheproof-123",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd460c0a0a49971db8d9678acb8",
+        false);
+    test_EAX("wycheproof-124",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd463c0a0a49971db8d9678acb8",
+        false);
+    test_EAX("wycheproof-125",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0249971db8d9678acb8",
+        false);
+    test_EAX("wycheproof-126",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a49871db8d9678acb8",
+        false);
+    test_EAX("wycheproof-127",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a41971db8d9678acb8",
+        false);
+    test_EAX("wycheproof-128",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a49951db8d9678acb8",
+        false);
+    test_EAX("wycheproof-129",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a49971da8d9678acb8",
+        false);
+    test_EAX("wycheproof-130",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a49971db8d9778acb8",
+        false);
+    test_EAX("wycheproof-131",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a49971db8d9478acb8",
+        false);
+    test_EAX("wycheproof-132",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a49971db8d1678acb8",
+        false);
+    test_EAX("wycheproof-133",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a49971db8d9678acb9",
+        false);
+    test_EAX("wycheproof-134",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a49971db8d9678acba",
+        false);
+    test_EAX("wycheproof-135",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a49971db8d9678acf8",
+        false);
+    test_EAX("wycheproof-136",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0a49971db8d9678ac38",
+        false);
+    test_EAX("wycheproof-137",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e976fdd461c0a0a49871db8d9678acb8",
+        false);
+    test_EAX("wycheproof-138",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fd5461c0a0249971db8d9678acb8",
+        false);
+    test_EAX("wycheproof-139",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e876fdd461c0a0249971db8d9678ac38",
+        false);
+    test_EAX("wycheproof-140",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "1789022b9e3f5f5b668e247269875347",
+        false);
+    test_EAX("wycheproof-141",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "00000000000000000000000000000000",
+        false);
+    test_EAX("wycheproof-142",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "ffffffffffffffffffffffffffffffff",
+        false);
+    test_EAX("wycheproof-143",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "68f67d54e140202419f15b0d16f82c38",
+        false);
+    test_EAX("wycheproof-144",
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+        "505152535455565758595a5b5c5d5e5f",
+        "",
+        "202122232425262728292a2b2c2d2e2f",
+        "059e01599f94b38f2435b47a0c7b5c59",
+        "e977fcd560c1a1a59870da8c9779adb9",
+        false);
+
+    /* ivSize=160 keySize=128 */
+    test_EAX("wycheproof-145",
+        "7edabee31897bf9b29394aeca84c4dcc",
+        "ef4886c4fe8b26f045e09ac925ccbbad42d70347",
+        "",
+        "52583c7b11de051c2e5c2114ee20527b",
+        "298e86436ead703a38f869690f020d4c",
+        "f20d2f2d170ebbe1d0ec718eefe632e4",
+        true);
+
+    /* ivSize=256 keySize=128 */
+    test_EAX("wycheproof-146",
+        "e071a62bcde9ee648118ed3b1c629c20",
+        "f23a924d75c57fee8e75defd97be48e8cf3202cd658add0a4f50b24b5af9f013",
+        "",
+        "a0650c4299cf63ec5e28104e9064247f",
+        "487e94228d338acee8e9f5c07e22fb06",
+        "72c99b644664378c88fd1f4ecfd80f76",
+        true);
+
+    /* ivSize=160 keySize=256 */
+    test_EAX("wycheproof-149",
+        "1739fd2876258457e3e4c323dbabd85edda8ecad83a7496d8feb0b88aeab2e74",
+        "989f015e6ab79d5e43eca8364a38c9f6b381dda1",
+        "",
+        "d1b13ceacedad362851dc876d8b1dd20",
+        "5cceb0253bcbd6800d3b316af3a56937",
+        "15186910a0f2a2bc41d32e7fe687f17c",
+        true);
+
+    /* ivSize=256 keySize=256 */
+    test_EAX("wycheproof-150",
+        "aa5429fd3f178b3885f2c696975e88890102455b5d9e42766429e80d4889672a",
+        "e1ed38af5753851b79175e4ae11fd6cf80033f81aec484ecd0448c5e7cc0a27e",
+        "",
+        "7aa8919ebb950f34690acb98651854cb",
+        "1a288496f909036b35f3604b3ecd3493",
+        "62eb49550cbee8c3cf88302c826690a2",
+        true);
+
+    /* ivSize=32 keySize=128 */
+    test_EAX("wycheproof-151",
+        "d83c1d7a97c43f182409a4aa5609c1b1",
+        "7b5faeb2",
+        "",
+        "c8f07ba1d65554a9bd40390c30c5529c",
+        "d324ca1530c68ed86c775ed9bb1d8490",
+        "30062eb9cedbaddf36f93e4219620afa",
+        true);
+
+    /* ivSize=64 keySize=128 */
+    test_EAX("wycheproof-152",
+        "deb62233559b57476602b5adac57c77f",
+        "d084547de55bbc15",
+        "",
+        "d8986df0241ed3297582c0c239c724cb",
+        "3064cf4883703f170bf01e6c2d67259f",
+        "09471c09f897d46216fbb52436e3c4fc",
+        true);
+
+    /* ivSize=32 keySize=256 */
+    test_EAX("wycheproof-155",
+        "093eb12343537ee8e91c1f715b862603f8daf9d4e1d7d67212a9d68e5aac9358",
+        "5110604c",
+        "",
+        "33efb58c91e8c70271870ec00fe2e202",
+        "5aca28621e2bd92d7f182ff653b1e8eb",
+        "8a89a0db74a55f907f8ba115e2e15853",
+        true);
+
+    /* ivSize=64 keySize=256 */
+    test_EAX("wycheproof-156",
+        "115884f693b155563e9bfb3b07cacb2f7f7caa9bfe51f89e23feb5a9468bfdd0",
+        "04102199ef21e1df",
+        "",
+        "82e3e604d2be8fcab74f638d1e70f24c",
+        "df32c13a2278326a3c966dee321a42f6",
+        "b1798b8e4b95df6c620a5cbcbe1238d1",
+        true);
+
+    /* ivSize=0 keySize=128 */
+    test_EAX("wycheproof-157",
+        "8f3f52e3c75c58f5cb261f518f4ad30a",
+        "",
+        "",
+        "",
+        "",
+        "5adbeefc8fa9cae2b9a6db3f5f6c82e9",
+        true);
+    test_EAX("wycheproof-158",
+        "2a4bf90e56b70fdd8649d775c089de3b",
+        "",
+        "",
+        "324ced6cd15ecc5b3741541e22c18ad9",
+        "73b4716f7e44f3bb22a2648069ebbc1e",
+        "3f6ac9672db499324ead0c234b544054",
+        true);
+
+    /* ivSize=0 keySize=256 */
+    test_EAX("wycheproof-161",
+        "3f8ca47b9a940582644e8ecf9c2d44e8138377a8379c5c11aafe7fec19856cf1",
+        "",
+        "",
+        "",
+        "",
+        "b17f6100882e6b419d9fed0c8b7c8d9a",
+        true);
+    test_EAX("wycheproof-162",
+        "7660d10966c6503903a552dde2a809ede9da490e5e5cc3e349da999671809883",
+        "",
+        "",
+        "c314235341debfafa1526bb61044a7f1",
+        "8187621069d3c07b7861bb40e8a56b3a",
+        "c1f0897558300e979ba29b36336a0d06",
+        true);
+
+    printf("All tests succeeded\n");
+    return 0;
+}

--- a/src/test-apps/wrapper-tests/jni/Makefile.in
+++ b/src/test-apps/wrapper-tests/jni/Makefile.in
@@ -542,9 +542,9 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-@WEAVE_WITH_JAVA_FALSE@mostlyclean-local:
 @WEAVE_WITH_JAVA_FALSE@uninstall-local:
 @WEAVE_WITH_JAVA_FALSE@install-data-local:
+@WEAVE_WITH_JAVA_FALSE@mostlyclean-local:
 clean: clean-am
 
 clean-am: clean-generic clean-libtool mostlyclean-am

--- a/src/tools/weave/Makefile.in
+++ b/src/tools/weave/Makefile.in
@@ -1120,8 +1120,8 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-@WEAVE_BUILD_TOOLS_FALSE@install-exec-local:
 @WEAVE_BUILD_TOOLS_FALSE@uninstall-local:
+@WEAVE_BUILD_TOOLS_FALSE@install-exec-local:
 clean: clean-am
 
 clean-am: clean-generic clean-libexecPROGRAMS clean-libtool \

--- a/src/wrappers/jni/security-support/Makefile.in
+++ b/src/wrappers/jni/security-support/Makefile.in
@@ -869,8 +869,8 @@ maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
 @WEAVE_WITH_JAVA_FALSE@mostlyclean-local:
-@WEAVE_WITH_JAVA_FALSE@uninstall-local:
 @WEAVE_WITH_JAVA_FALSE@install-data-local:
+@WEAVE_WITH_JAVA_FALSE@uninstall-local:
 clean: clean-am
 
 clean-am: clean-generic clean-libLTLIBRARIES clean-libtool \

--- a/third_party/openssl/Makefile.in
+++ b/third_party/openssl/Makefile.in
@@ -559,9 +559,9 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
-@WEAVE_WITH_OPENSSL_INTERNAL_FALSE@install-data-local:
 @WEAVE_WITH_OPENSSL_INTERNAL_FALSE@clean-local:
 @WEAVE_WITH_OPENSSL_INTERNAL_FALSE@distclean-local:
+@WEAVE_WITH_OPENSSL_INTERNAL_FALSE@install-data-local:
 clean: clean-am
 
 clean-am: clean-generic clean-libtool clean-local mostlyclean-am


### PR DESCRIPTION
This PR adds an implementation of EAX mode for AES encryption. The implementation encapsulates the existing AES classes (AES128BlockCipherEnc and AES256BlockCipherEnc) and provides support for encrypting and decrypting with EAX mode, with authentication tag creation and verification. Both the additional authenticated data ("header") and the payload can be streamed in chunks. An extra class (EAXSaved) provides support for optimizing processing of several messages that use the same key and the same header.

The EAX mode is then used in WeaveMessageLayer.cpp to support two new encryption formats for messages, called AES128EAX64 and AES128EAX128; these use EAX with a 128-bit key and authentication tags of size 64 and 128 bits, respectively.
