### PR TITLE
Fix BLE virtual test hang in some machines

### DIFF
--- a/src/test-apps/happy/test-templates/WeaveBleCentral.py
+++ b/src/test-apps/happy/test-templates/WeaveBleCentral.py
@@ -56,7 +56,7 @@ class WeaveDeviceManagerConsole(object):
     def __del__(self):
         self.close()
 
-    def chat(self, cmd, timeout=chatTimeout, interrupt_on_timeout=False, force=False, expect=None):
+    def chat(self, cmd, timeout=chatTimeout, interrupt_on_timeout=False, force=True, expect=None):
         self.app.send(cmd)
         if not force:
             self.app.expect_exact(cmd, timeout=2)


### PR DESCRIPTION
In some jenkens machine, cmd check inputting in pexpect is not working somehow. Set force as True to bypass this check.