### PR TITLE
Ensure that the timer handling code processes a bounded number of timers

### DIFF
--- a/src/system/SystemTimer.cpp
+++ b/src/system/SystemTimer.cpp
@@ -295,78 +295,47 @@ exit:
  */
 Error Timer::HandleExpiredTimers(Layer& aLayer)
 {
+    size_t timersHandled = 0;
+
     // expire each timer in turn until an unexpired timer is reached or the timerlist is emptied.
-
-    // The platform timer API has MSEC resolution so expire any timer with less than 1 msec remaining.
-    Epoch currentEpoch = Timer::GetCurrentEpoch() + 1;
-
-    VerifyOrExit(aLayer.mTimerList != NULL, );
-
-    // Verify that there are any timers to be processed
-    if (Timer::IsEarlierEpoch(aLayer.mTimerList->mAwakenEpoch, currentEpoch))
+    while (aLayer.mTimerList)
     {
-        // Bound the number of timers processed to those that are already on the
-        // expired queue. We copy the expired timers onto the queue pointed to
-        // by headTimer, and then reset the timer queue in the system layer to
-        // point to the first unexpired timer.
-        Timer * headTimer = aLayer.mTimerList;
-        Timer * cursorTimer = aLayer.mTimerList;
+        const Epoch kCurrentEpoch = Timer::GetCurrentEpoch();
 
-        while (cursorTimer->mNextTimer != NULL &&
-               Timer::IsEarlierEpoch(cursorTimer->mNextTimer->mAwakenEpoch, currentEpoch))
+        // limit the number of timers handled before the control is returned to the event queue.  The bound is similar to
+        // (though not exactly same) as that on the sockets-based systems.
+
+        // The platform timer API has MSEC resolution so expire any timer with less than 1 msec remaining.
+        if ((timersHandled < Timer::sPool.Size()) && Timer::IsEarlierEpoch(aLayer.mTimerList->mAwakenEpoch, kCurrentEpoch + 1))
         {
-            cursorTimer = cursorTimer->mNextTimer;
-        }
+            Timer& lTimer = *aLayer.mTimerList;
+            aLayer.mTimerList = lTimer.mNextTimer;
+            lTimer.mNextTimer = NULL;
 
-        // unexpired timer list points to the next unexpired timer
-        aLayer.mTimerList = cursorTimer->mNextTimer;
+            aLayer.mTimerComplete = true;
+            lTimer.HandleComplete();
+            aLayer.mTimerComplete = false;
 
-        // list pointed to by the headTimer terminates
-        cursorTimer->mNextTimer = NULL;
-
-        aLayer.mTimerComplete = true;
-
-        while (headTimer != NULL)
-        {
-            cursorTimer = headTimer;
-            headTimer = headTimer->mNextTimer;
-            cursorTimer->mNextTimer = NULL;
-
-            cursorTimer->HandleComplete();
-        }
-        aLayer.mTimerComplete = false;
-    }
-
-    if (aLayer.mTimerList)
-    {
-        // timers still exist so restart the platform timer.
-        uint64_t delayMilliseconds;
-
-        // re-read the timer to account for the time that has elapsed while we
-        // were processing the expired timers
-
-        currentEpoch = Timer::GetCurrentEpoch();
-
-        if (aLayer.mTimerList->mAwakenEpoch < currentEpoch)
-        {
-            delayMilliseconds = 0;
+            timersHandled++;
         }
         else
         {
-            delayMilliseconds = aLayer.mTimerList->mAwakenEpoch - currentEpoch;
-        }
-        /*
-         * StartPlatformTimer() accepts a 32bit value in milliseconds.  Epochs are 64bit numbers.  The only way in which this could
-         * overflow is if time went backwards (e.g. as a result of a time adjustment from time synchronization).  Verify that the
-         * timer can still be executed (even if it is very late) and exit if that is the case.  Note: if the time sync ever ends up
-         * adjusting the clock, we should implement a method that deals with all the timers in the system.
-         */
-        VerifyOrDie(delayMilliseconds <= UINT32_MAX);
+            // timers still exist so restart the platform timer.
+            const uint64_t kDelayMilliseconds = aLayer.mTimerList->mAwakenEpoch - kCurrentEpoch;
 
-        aLayer.StartPlatformTimer(static_cast<uint32_t>(delayMilliseconds));
+            /*
+             * Original kDelayMilliseconds was a 32 bit value.  The only way in which this could overflow is if time went backwards
+             * (e.g. as a result of a time adjustment from time synchronization).  Verify that the timer can still be executed
+             * (even if it is very late) and exit if that is the case.  Note: if the time sync ever ends up adjusting the clock, we
+             * should implement a method that deals with all the timers in the system.
+             */
+            VerifyOrDie(kDelayMilliseconds <= UINT32_MAX);
+
+            aLayer.StartPlatformTimer(static_cast<uint32_t>(kDelayMilliseconds));
+            break; // all remaining timers are still ticking.
+        }
     }
 
-exit:
     return WEAVE_SYSTEM_NO_ERROR;
 }
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP


### PR DESCRIPTION
Previous commit to address the unbounded number of timers was
incomplete -- it neglected to account for assumptions made within
SystemTimer::Cancel(), and within allocating a new timer.  This commit
performs two things:

* It restores the timer code to the state prior to commit
  99f546478fccf259827c9426823dcb9223ffffaa

* It bounds the number of timers executed within the
  Timer::HandleExpiredTimers() by constraining the number of timers
  processed to the size of the timer pool.

This approach offers the following advantages:

* Fallback to the old code with the minimal changes

* No data-structure-related changes as compared with the old code.
  The policies for maintaining all queues are the same as those prior
  to 99f546478fccf259827c9426823dcb9223ffffaa.

As compared with the "eager" bounding of the expired timers, the
principal shortcoming of this commit is that we may prioritize a few
more timers than in the previous method; this may lead to a slightly
longer response event response time.