### PR TITLE
Enable applications to skip providing data for an external event.

### DIFF
--- a/src/lib/profiles/data-management/Current/LoggingManagement.cpp
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.cpp
@@ -386,6 +386,20 @@ exit:
 }
 
 /**
+ * @brief Helper function to skip writing an event corresponding to an allocated
+ *   event id.
+ *
+ * @param[inout] aContext   EventLoadOutContext, initialized with stateful
+ *                          information for the buffer. State is updated
+ *                          and preserved by BlitEvent using this context.
+ *
+ */
+void LoggingManagement::SkipEvent(EventLoadOutContext * aContext)
+{
+    aContext->mCurrentEventID++; // Advance the event id without writing anything
+}
+
+/**
  * @brief Create and initialize the logging management buffers. Must
  *   be called prior to the logging being used.
  *

--- a/src/lib/profiles/data-management/Current/LoggingManagement.cpp
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.cpp
@@ -1278,6 +1278,7 @@ void LoggingManagement::UnthrottleLogger(void)
     }
 }
 
+
 // internal API, used to copy events to external buffers
 WEAVE_ERROR LoggingManagement::CopyEvent(const TLVReader & aReader, TLVWriter & aWriter, EventLoadOutContext * aContext)
 {

--- a/src/lib/profiles/data-management/Current/LoggingManagement.h
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.h
@@ -216,6 +216,8 @@ public:
 #endif // WEAVE_CONFIG_EVENT_LOGGING_EXTERNAL_EVENT_SUPPORT
     WEAVE_ERROR BlitEvent(EventLoadOutContext * aContext, const EventSchema & inSchema, EventWriterFunct inEventWriter,
                           void * inAppData, const EventOptions * inOptions);
+    void SkipEvent(EventLoadOutContext * aContext);
+
 
 #if WEAVE_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
     bool CheckShouldRunWDM(void);
@@ -231,7 +233,6 @@ private:
 
     static WEAVE_ERROR CopyEventsSince(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
     static WEAVE_ERROR EventIterator(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
-    static WEAVE_ERROR FindExternalEvents(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
     static WEAVE_ERROR FetchEventParameters(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
     static WEAVE_ERROR CopyAndAdjustDeltaTime(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
     static WEAVE_ERROR EvictEvent(nl::Weave::TLV::WeaveCircularTLVBuffer & inBuffer, void * inAppData,

--- a/src/lib/profiles/data-management/Current/LoggingManagement.h
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.h
@@ -231,6 +231,7 @@ private:
 
     static WEAVE_ERROR CopyEventsSince(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
     static WEAVE_ERROR EventIterator(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
+    static WEAVE_ERROR FindExternalEvents(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
     static WEAVE_ERROR FetchEventParameters(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
     static WEAVE_ERROR CopyAndAdjustDeltaTime(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
     static WEAVE_ERROR EvictEvent(nl::Weave::TLV::WeaveCircularTLVBuffer & inBuffer, void * inAppData,

--- a/src/test-apps/MockExternalEvents.h
+++ b/src/test-apps/MockExternalEvents.h
@@ -31,9 +31,12 @@
 #include <Weave/Core/WeaveCore.h>
 
 #if WEAVE_CONFIG_EVENT_LOGGING_EXTERNAL_EVENT_SUPPORT
+typedef bool (*ShouldBlitFunct)(nl::Weave::Profiles::DataManagement::event_id_t aEventId);
+
 WEAVE_ERROR LogMockExternalEvents(size_t aNumEvents, int numCallback);
 WEAVE_ERROR LogMockDebugExternalEvents(size_t aNumEvents, int numCallback);
 void ClearMockExternalEvents(int numCallback);
+void SetShouldBlitCallback(ShouldBlitFunct aShouldBlit);
 #endif
 
 #endif /* MOCKEXTERNALEVENTS_H */

--- a/src/test-apps/TestEventLogging.cpp
+++ b/src/test-apps/TestEventLogging.cpp
@@ -44,7 +44,6 @@
 #include <Weave/Profiles/bulk-data-transfer/Development/BDXManagedNamespace.hpp>
 #include <Weave/Profiles/data-management/Current/WdmManagedNamespace.h>
 
-#include "MockExternalEvents.h"
 #include "ToolCommon.h"
 #include "TestEventLoggingSchemaExamples.h"
 #include <InetLayer/Inet.h>
@@ -71,6 +70,7 @@
 #include "schema/nest/test/trait/TestETrait.h"
 #include "schema/nest/test/trait/TestCommon.h"
 
+#include "MockExternalEvents.h"
 #include "MockPlatformClocks.h"
 
 using namespace nl::Weave::TLV;
@@ -3115,6 +3115,86 @@ static void CheckExternalEventsMultipleCallbacks(nlTestSuite * inSuite, void * i
     }
 }
 
+static bool SkipEvenEvents(event_id_t aEventId)
+{
+    return aEventId & 1;
+}
+
+static void CheckSkipExternalEvents(nlTestSuite * inSuite, void * inContext)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    TLVWriter testWriter;
+    TLVReader testReader;
+    event_id_t eid_before, eid_after, eid = 0;
+    int i;
+    TestLoggingContext * context = static_cast<TestLoggingContext *>(inContext);
+
+    InitializeEventLogging(context);
+    SetShouldBlitCallback(SkipEvenEvents);
+
+    for (i = 0; i < 10; i++)
+    {
+        eid_before = nl::Weave::Profiles::DataManagement::LogFreeform(nl::Weave::Profiles::DataManagement::Production,
+                                                                  "Freeform entry %d", i);
+    }
+
+    // register callback
+    err = LogMockExternalEvents(10, 0);
+    NL_TEST_ASSERT(inSuite, err == WEAVE_NO_ERROR);
+
+    for (i = 0; i < 10; i++)
+    {
+        eid_after = nl::Weave::Profiles::DataManagement::LogFreeform(nl::Weave::Profiles::DataManagement::Production,
+                                                                  "Freeform entry %d", i + 10);
+    }
+
+    // Validate event skipping by reading back what was written.
+    {
+        utc_timestamp_t utc_tmp;
+        timestamp_t time_tmp;
+        event_id_t eid_tmp;
+        unsigned count;
+
+        // Fetch gets initial back of free form events and all external events.
+        // Fetching stops after an external events block is complete.
+        eid = 0;
+        testWriter.Init(gLargeMemoryBackingStore, sizeof(gLargeMemoryBackingStore));
+        err = nl::Weave::Profiles::DataManagement::LoggingManagement::GetInstance().FetchEventsSince(
+            testWriter, nl::Weave::Profiles::DataManagement::Production, eid);
+        NL_TEST_ASSERT(inSuite, err == WEAVE_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, eid == eid_before + 11); // Free form events plus external events
+
+        testReader.Init(gLargeMemoryBackingStore, testWriter.GetLengthWritten());
+        count = 0;
+        while (err == WEAVE_NO_ERROR)
+        {
+            err = ReadFirstEventHeader(testReader, time_tmp, utc_tmp, eid_tmp);
+            count++; // Also incremented on error
+        }
+        NL_TEST_ASSERT(inSuite, count == 16); // Initial free form events plus half of external ones
+
+        // Fetch second block of free form events.
+        eid = 20;
+        testWriter.Init(gLargeMemoryBackingStore, sizeof(gLargeMemoryBackingStore));
+        err = nl::Weave::Profiles::DataManagement::LoggingManagement::GetInstance().FetchEventsSince(
+            testWriter, nl::Weave::Profiles::DataManagement::Production, eid);
+        NL_TEST_ASSERT(inSuite, err == WEAVE_END_OF_TLV);
+        NL_TEST_ASSERT(inSuite, eid == eid_after + 1);
+
+        testReader.Init(gLargeMemoryBackingStore, testWriter.GetLengthWritten());
+        err = WEAVE_NO_ERROR;
+        count = 0;
+        while (err == WEAVE_NO_ERROR)
+        {
+            err = ReadFirstEventHeader(testReader, time_tmp, utc_tmp, eid_tmp);
+            count++; // Also incremented on error
+        }
+        NL_TEST_ASSERT(inSuite, count == 11); // Following free form events
+    }
+
+    SetShouldBlitCallback(NULL);
+}
+
 static void RegressionWatchdogBug(nlTestSuite * inSuite, void * inContext)
 {
     WEAVE_ERROR err = WEAVE_NO_ERROR;
@@ -3685,6 +3765,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Check External Events Basic", CheckExternalEvents),
     NL_TEST_DEF("Check External Events Multiple Callbacks", CheckExternalEventsMultipleCallbacks),
     NL_TEST_DEF("Check External Events Multiple Fetches", CheckExternalEventsMultipleFetches),
+    NL_TEST_DEF("Check External Events Skip", CheckSkipExternalEvents),
     NL_TEST_DEF("Check Drop Events", CheckDropEvents),
     NL_TEST_DEF("Regression: watchdog bug", RegressionWatchdogBug),
     NL_TEST_DEF("Regression: external event cleanup", RegressionWatchdogBug_EventRemoval),


### PR DESCRIPTION
Inside an application's fetch event callback, it can call a new
API, LoggingManagement::SkipEvent, instead of
LoggingManagement::BlitEvent if for some reason it is not able
to provide the corresponding event data.

Change-Id: I1ecddb26e7c1aec377a49442a331702221ee9549