### PR TITLE
Added code to abort the mock time sync client connection on failure

### DIFF
--- a/src/test-apps/MockTimeSyncClient.cpp
+++ b/src/test-apps/MockTimeSyncClient.cpp
@@ -329,7 +329,7 @@ void MockTimeSyncClient::CloseConnectionToService(void)
     {
         WeaveLogProgress(TimeService, "App closing connection to service");
 
-        mConnectionToService->Close();
+        mConnectionToService->Abort();
         mConnectionToService = NULL;
     }
 }


### PR DESCRIPTION
Simply closing the connection was leaving a TCP socket retrying
transmissions in a failed case when running with plaid, and that in
turn was being flagged as a resource leak.

Change-Id: Ic25ec1fe16381e74e77c83dc66a35ccc4e519775