### PR TITLE
Ensure Network CPPFLAGS (LwIP in Particular) Are Included for the BLE Platform Library

### DIFF
--- a/src/platform/ble/bluez/Makefile.am
+++ b/src/platform/ble/bluez/Makefile.am
@@ -28,6 +28,8 @@ lib_LIBRARIES                       = libWoBluez.a
 
 libWoBluez_a_CPPFLAGS               = \
     $(BLUEZ_CPPFLAGS)                 \
+    $(LWIP_CPPFLAGS)                  \
+    $(SOCKET_CPPFLAGS)                \
     $(NULL)
 
 libWoBluez_a_SOURCES                = \

--- a/src/platform/ble/bluez/Makefile.in
+++ b/src/platform/ble/bluez/Makefile.in
@@ -503,6 +503,8 @@ top_srcdir = @top_srcdir@
 lib_LIBRARIES = libWoBluez.a
 libWoBluez_a_CPPFLAGS = \
     $(BLUEZ_CPPFLAGS)                 \
+    $(LWIP_CPPFLAGS)                  \
+    $(SOCKET_CPPFLAGS)                \
     $(NULL)
 
 libWoBluez_a_SOURCES = \


### PR DESCRIPTION
There is currently an issue in top-of-tree when building against LwIP with BLE support in which that library cannot find lwip/opt.h.

This addresses the issue by including network CPPFLAGS (LwIP and sockets).