### PR TITLE
ServiceFabricJoin message definition for In-field Joining(IFJ) in Service Provisioning profile.

### DIFF
--- a/src/adaptations/device-layer/ServiceProvisioningServer.cpp
+++ b/src/adaptations/device-layer/ServiceProvisioningServer.cpp
@@ -418,6 +418,12 @@ void ServiceProvisioningServer::HandlePairDeviceToAccountResult(WEAVE_ERROR err,
 
 #endif // !WEAVE_DEVICE_CONFIG_DISABLE_ACCOUNT_PAIRING
 
+#ifdef WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+void ServiceProvisioningServer::HandleIFJServiceFabricJoinResult(WEAVE_ERROR err, uint32_t statusReportProfileId, uint16_t statusReportStatusCode)
+{
+}
+#endif // WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace Weave

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/ServiceProvisioningServer.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/ServiceProvisioningServer.h
@@ -64,6 +64,9 @@ public:
     WEAVE_ERROR HandleUpdateService(::nl::Weave::Profiles::ServiceProvisioning::UpdateServiceMessage& msg) override;
     WEAVE_ERROR HandleUnregisterService(uint64_t serviceId) override;
     void HandlePairDeviceToAccountResult(WEAVE_ERROR localErr, uint32_t serverStatusProfileId, uint16_t serverStatusCode) override;
+#ifdef WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+    void HandleIFJServiceFabricJoinResult(WEAVE_ERROR localErr, uint32_t serverStatusProfileId, uint16_t serverStatusCode) override;
+#endif // WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
 
     // ===== Members that override virtual methods on ServiceProvisioningServer
 

--- a/src/lib/core/WeaveConfig.h
+++ b/src/lib/core/WeaveConfig.h
@@ -2042,6 +2042,17 @@
 #endif // WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
 
 /**
+ * @def WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+ *
+ * @brief Enable the Service Provisioning profile message
+ * for notification of successful in-field joining of the
+ * Weave fabric.
+ */
+#ifndef WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+#define WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN         0
+#endif // WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+
+/**
  * @def WEAVE_NON_PRODUCTION_MARKER
  *
  * @brief Defines the name of a mark symbol whose presence signals that the Weave code

--- a/src/lib/profiles/service-provisioning/ServiceProvisioning.cpp
+++ b/src/lib/profiles/service-provisioning/ServiceProvisioning.cpp
@@ -181,6 +181,48 @@ exit:
     return err;
 }
 
+#ifdef WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+WEAVE_ERROR IFJServiceFabricJoinMessage::Encode(PacketBuffer *msgBuf)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    uint32_t msgLen;
+    uint8_t *p;
+
+    msgLen = 2 + 8 + 8 + DeviceInitDataLen;
+    VerifyOrExit(msgBuf->AvailableDataLength() >= msgLen, err = WEAVE_ERROR_MESSAGE_TOO_LONG);
+
+    p = msgBuf->Start();
+    LittleEndian::Write16(p, DeviceInitDataLen);
+    LittleEndian::Write64(p, ServiceId);
+    LittleEndian::Write64(p, FabricId);
+    memcpy(p, DeviceInitData, DeviceInitDataLen);
+    msgBuf->SetDataLength(msgLen);
+
+exit:
+    return err;
+}
+
+WEAVE_ERROR IFJServiceFabricJoinMessage::Decode(PacketBuffer *msgBuf, IFJServiceFabricJoinMessage& msg)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    uint16_t dataLen = msgBuf->DataLength();
+    const uint8_t *p = msgBuf->Start();
+
+    VerifyOrExit(dataLen >= 2 + 8 + 8, err = WEAVE_ERROR_INVALID_MESSAGE_LENGTH);
+    msg.DeviceInitDataLen = LittleEndian::Read16(p);
+    msg.ServiceId = LittleEndian::Read64(p);
+    msg.FabricId = LittleEndian::Read64(p);
+
+    VerifyOrExit(dataLen == 2 + 8 + 8 + msg.DeviceInitDataLen,
+                 err = WEAVE_ERROR_INVALID_MESSAGE_LENGTH);
+
+    msg.DeviceInitData   = p;
+
+exit:
+    return err;
+}
+#endif // WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+
 NL_DLL_EXPORT WEAVE_ERROR EncodeServiceConfig(WeaveCertificateSet& certSet, const char *dirHostName, uint16_t dirPort, uint8_t *outBuf, uint16_t& outLen)
 {
     WEAVE_ERROR err;

--- a/src/test-apps/MockSPServer.cpp
+++ b/src/test-apps/MockSPServer.cpp
@@ -499,6 +499,35 @@ void MockServiceProvisioningServer::HandlePairDeviceToAccountResult(WEAVE_ERROR 
     }
 }
 
+#ifdef WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+void MockServiceProvisioningServer::HandleIFJServiceFabricJoinResult(WEAVE_ERROR err, uint32_t serverStatusProfileId, uint16_t serverStatusCode)
+{
+    if (mPairingServerBinding)
+    {
+        // The server operation is now complete, so release the binding.
+        mPairingServerBinding->Release();
+        mPairingServerBinding = NULL;
+    }
+
+    // If the IFJServiceFabricJoin request was successful...
+    if (err == WEAVE_NO_ERROR)
+    {
+        printf("Received success response from server\n");
+
+    }
+
+    // Otherwwise, relay the result from the pairing server back to the client.
+    else if (err == WEAVE_ERROR_STATUS_REPORT_RECEIVED)
+    {
+        printf("Received StatusReport from server: %s\n", nl::StatusReportStr(serverStatusProfileId, serverStatusCode));
+    }
+    else
+    {
+        printf("Error talking to server: %s\n", nl::ErrorStr(err));
+    }
+}
+#endif // WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+
 void MockServiceProvisioningServer::EnforceAccessControl(nl::Weave::ExchangeContext *ec, uint32_t msgProfileId, uint8_t msgType,
             const nl::Weave::WeaveMessageInfo *msgInfo, AccessControlResult& result)
 {

--- a/src/test-apps/MockSPServer.h
+++ b/src/test-apps/MockSPServer.h
@@ -60,6 +60,9 @@ protected:
     WEAVE_ERROR HandleUpdateService(UpdateServiceMessage& msg);
     WEAVE_ERROR HandleUnregisterService(uint64_t serviceId);
     void HandlePairDeviceToAccountResult(WEAVE_ERROR localErr, uint32_t serverStatusProfileId, uint16_t serverStatusCode);
+#ifdef WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+    void HandleIFJServiceFabricJoinResult(WEAVE_ERROR localErr, uint32_t serverStatusProfileId, uint16_t serverStatusCode);
+#endif // WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
     virtual void EnforceAccessControl(nl::Weave::ExchangeContext *ec, uint32_t msgProfileId, uint8_t msgType,
                 const nl::Weave::WeaveMessageInfo *msgInfo, AccessControlResult& result);
     virtual bool IsPairedToAccount() const;


### PR DESCRIPTION
Legacy devices in the field would employ IFJ to join the Weave
fabric of the Structure so that they can communicate using Weave
with the rest of the Weave devices in the home.
This message would be used by that device, at the end of IFJ, to
signal successful completion of the process to the Service.
After this communication, the device is formally part of the
Weave fabric of the structure and can assist other new device
pairings as well.