### PR TITLE
Feature/szewczyk/tlv api enhancements

### DIFF
--- a/src/lib/core/WeaveCircularTLVBuffer.cpp
+++ b/src/lib/core/WeaveCircularTLVBuffer.cpp
@@ -43,6 +43,21 @@ namespace TLV {
 
 using namespace nl::Weave::Encoding;
 
+WeaveCircularTLVBuffer::WeaveCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength, uint8_t *inHead)
+{
+    mQueue = inBuffer;
+    mQueueSize = inBufferLength;
+    mQueueLength = 0;
+    mQueueHead = inHead;
+
+    mProcessEvictedElement = NULL;
+    mAppData = NULL;
+
+    // use common as opposed to unspecified, s.t. the reader that
+    // skips over the elements does not complain about implicit
+    // profile tags.
+    mImplicitProfileId = kCommonProfileId;
+}
 /**
  * @brief
  *   WeaveCircularTLVBuffer constructor

--- a/src/lib/core/WeaveCircularTLVBuffer.cpp
+++ b/src/lib/core/WeaveCircularTLVBuffer.cpp
@@ -43,6 +43,16 @@ namespace TLV {
 
 using namespace nl::Weave::Encoding;
 
+/**
+ * @brief
+ *   WeaveCircularTLVBuffer constructor
+ *
+ * @param[in] inBuffer       A pointer to the backing store for the queue
+ *
+ * @param[in] inBufferLength Length, in bytes, of the backing store
+ *
+ * @param[in] inHead         Initial point for the head.  The @a inHead pointer is must fall within the backing store for the circular buffer, i.e. within @a inBuffer and &(@a inBuffer[@a inBufferLength])
+ */
 WeaveCircularTLVBuffer::WeaveCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength, uint8_t *inHead)
 {
     mQueue = inBuffer;
@@ -58,13 +68,14 @@ WeaveCircularTLVBuffer::WeaveCircularTLVBuffer(uint8_t *inBuffer, size_t inBuffe
     // profile tags.
     mImplicitProfileId = kCommonProfileId;
 }
+
 /**
  * @brief
  *   WeaveCircularTLVBuffer constructor
  *
  * @param[in] inBuffer       A pointer to the backing store for the queue
  *
- * @param[in] inBufferLength Length of the backing store
+ * @param[in] inBufferLength Length, in bytes, of the backing store
  */
 WeaveCircularTLVBuffer::WeaveCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength)
 {

--- a/src/lib/core/WeaveCircularTLVBuffer.h
+++ b/src/lib/core/WeaveCircularTLVBuffer.h
@@ -58,16 +58,18 @@ class NL_DLL_EXPORT WeaveCircularTLVBuffer
 {
 public:
     WeaveCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength);
+    WeaveCircularTLVBuffer(uint8_t *inBuffer, size_t inBufferLength, uint8_t *inHead);
 
     WEAVE_ERROR GetNewBuffer(TLVWriter& ioWriter, uint8_t *& outBufStart, uint32_t& outBufLen);
     WEAVE_ERROR FinalizeBuffer(TLVWriter& ioWriter, uint8_t *inBufStart, uint32_t inBufLen);
     WEAVE_ERROR GetNextBuffer(TLVReader& ioReader, const uint8_t *& outBufStart, uint32_t& outBufLen);
 
-    inline uint8_t *QueueHead(void) { return mQueueHead; };
-    inline uint8_t *QueueTail(void) { return mQueue + (((mQueueHead-mQueue) + mQueueLength) % mQueueSize); }
-    inline size_t DataLength(void) { return mQueueLength; }
-    inline size_t AvailableDataLength(void) { return mQueueSize - mQueueLength; }
-    inline size_t GetQueueSize(void) { return mQueueSize; }
+    inline uint8_t *QueueHead(void) const { return mQueueHead; };
+    inline uint8_t *QueueTail(void) const { return mQueue + (((mQueueHead-mQueue) + mQueueLength) % mQueueSize); };
+    inline size_t DataLength(void) const { return mQueueLength; };
+    inline size_t AvailableDataLength(void) const { return mQueueSize - mQueueLength; };
+    inline size_t GetQueueSize(void) const { return mQueueSize; };
+    inline uint8_t *GetQueue(void) const { return mQueue; };
 
     WEAVE_ERROR EvictHead(void);
 

--- a/src/lib/core/WeaveTLV.h
+++ b/src/lib/core/WeaveTLV.h
@@ -141,6 +141,7 @@ public:
     uint32_t GetRemainingLength(void) const { return mMaxLen - mLenRead; }
 
     const uint8_t *GetReadPoint(void) const { return mReadPoint; }
+    uintptr_t GetBufHandle(void) const { return mBufHandle; }
 
     WEAVE_ERROR Skip(void);
 

--- a/src/lib/core/WeaveTLVUtilities.cpp
+++ b/src/lib/core/WeaveTLVUtilities.cpp
@@ -336,6 +336,128 @@ WEAVE_ERROR Find(const TLVReader &aReader, const uint64_t &aTag, TLVReader &aRes
 
     return retval;
 }
+/**
+ *  Search for the specified tag within the provided TLV reader,
+ *  optionally descending into arrays or structures.
+ *
+ *  @param[in]   aReader        A read-only reference to the TLV reader in
+ *                              which to find the specified tag.
+ *  @param[in]   aTag           A read-only reference to the TLV tag to find.
+ *  @param[out]  aResult        A reference to storage to a TLV reader which
+ *                              will be positioned at the specified tag
+ *                              on success.
+ *  @param[in]   aRecurse       A Boolean indicating whether (true) or not (false)
+ *                              any encountered arrays or structures should be
+ *                              descended into.
+ *
+ *  @retval  #WEAVE_NO_ERROR                    On success.
+ *
+ *  @retval  #WEAVE_ERROR_TLV_TAG_NOT_FOUND     If the specified tag @a aTag was not found.
+ *
+ */
+struct FindPredicateContext
+{
+    TLVReader &mResult;
+    IterateHandler mHandler;
+    void * mContext;
+    FindPredicateContext(TLVReader &inReader, IterateHandler inHandler, void *inContext);
+};
+
+FindPredicateContext::FindPredicateContext(TLVReader &inReader, IterateHandler inHandler, void *inContext) :
+        mResult(inReader),
+        mHandler(inHandler),
+        mContext(inContext)
+{
+}
+
+static WEAVE_ERROR FindPredicateHandler(const TLVReader & aReader, size_t aDepth, void *aContext)
+{
+    FindPredicateContext *theContext = static_cast<FindPredicateContext *>(aContext);
+    WEAVE_ERROR err;
+
+    err = theContext->mHandler(aReader, aDepth, theContext->mContext);
+
+    if (err == WEAVE_ERROR_MAX)
+        theContext->mResult.Init(aReader);
+
+    return err;
+}
+
+/**
+ *  Search for the first element matching the predicate within the TLV reader
+ *  descending into arrays or structures. The @ aPredicate is applied
+ *  to each visited TLV element; the @aPredicate shall return WEAVE_ERROR_MAX
+ *  for the matching elements, WEAVE_NO_ERROR for non-matching elements, and any
+ *  other value to terminate the search.
+ *
+ *  @param[in,out] aReader A reference to the TLV reader in which to find the
+ *                         element matching the predicate.  If the element is
+ *                         found, this reader will be positioned on the first
+ *                         matching TLV element.
+ *  @param[in] aPredicate  A predicate to be applied to each TLV element.  To
+ *                         support the code reuse, aPredicate has the
+ *                         IterateHandler type.  The return value of aPredicate
+ *                         controls the search: a WEAVE_ERROR_MAX signals that
+ *                         desired element has been found, WEAVE_NO_ERROR
+ *                         signals that the desired element has not been found,
+ *                         and all other values signal that the saerch should be
+ *                         terminated.
+ *  @param[in] aContext    An optional pointer to caller-provided context data.
+ *
+ *  @retval  #WEAVE_NO_ERROR                    On success.
+ *
+ *  @retval  #WEAVE_ERROR_TLV_TAG_NOT_FOUND     If the specified tag @a aTag was not found.
+ *
+ */
+WEAVE_ERROR Find(TLVReader &aReader, IterateHandler aPredicate, void *aContext)
+{
+    const bool  recurse = true;
+    return Find(aReader, aPredicate, aContext, recurse);
+}
+
+/**
+ *  Search for the first element matching the predicate within the TLV reader
+ *  optionally descending into arrays or structures. The @ aPredicate is applied
+ *  to each visited TLV element; the @aPredicate shall return WEAVE_ERROR_MAX
+ *  for the matching elements, WEAVE_NO_ERROR for non-matching elements, and any
+ *  other value to terminate the search.
+ *
+ *  @param[in,out] aReader A reference to the TLV reader in which to find the
+ *                         element matching the predicate.  If the element is
+ *                         found, this reader will be positioned on the first
+ *                         matching TLV element.
+ *  @param[in] aPredicate  A predicate to be applied to each TLV element.  To
+ *                         support the code reuse, aPredicate has the
+ *                         IterateHandler type.  The return value of aPredicate
+ *                         controls the search: a WEAVE_ERROR_MAX signals that
+ *                         desired element has been found, WEAVE_NO_ERROR
+ *                         signals that the desired element has not been found,
+ *                         and all other values signal that the saerch should be
+ *                         terminated.
+ *  @param[in] aContext    An optional pointer to caller-provided context data.
+ *  @param[in] aRecurse    A Boolean indicating whether (true) or not (false) any
+ *                         encountered arrays or structures should be descended
+ *                         into.
+ *
+ *  @retval  #WEAVE_NO_ERROR                    On success.
+ *
+ *  @retval  #WEAVE_ERROR_TLV_TAG_NOT_FOUND     If the specified tag @a aTag was not found.
+ *
+ */
+WEAVE_ERROR Find(TLVReader &aReader, IterateHandler aPredicate, void *aContext, const bool aRecurse)
+{
+    WEAVE_ERROR retval;
+    FindPredicateContext theContext(aReader, aPredicate, aContext);
+
+    retval = Iterate(aReader, FindPredicateHandler, &theContext, aRecurse);
+
+    if (retval == WEAVE_ERROR_MAX)
+        retval = WEAVE_NO_ERROR;
+    else
+        retval = WEAVE_ERROR_TLV_TAG_NOT_FOUND;
+
+    return retval;
+}
 
 } // namespace Utilities
 

--- a/src/lib/core/WeaveTLVUtilities.cpp
+++ b/src/lib/core/WeaveTLVUtilities.cpp
@@ -336,25 +336,7 @@ WEAVE_ERROR Find(const TLVReader &aReader, const uint64_t &aTag, TLVReader &aRes
 
     return retval;
 }
-/**
- *  Search for the specified tag within the provided TLV reader,
- *  optionally descending into arrays or structures.
- *
- *  @param[in]   aReader        A read-only reference to the TLV reader in
- *                              which to find the specified tag.
- *  @param[in]   aTag           A read-only reference to the TLV tag to find.
- *  @param[out]  aResult        A reference to storage to a TLV reader which
- *                              will be positioned at the specified tag
- *                              on success.
- *  @param[in]   aRecurse       A Boolean indicating whether (true) or not (false)
- *                              any encountered arrays or structures should be
- *                              descended into.
- *
- *  @retval  #WEAVE_NO_ERROR                    On success.
- *
- *  @retval  #WEAVE_ERROR_TLV_TAG_NOT_FOUND     If the specified tag @a aTag was not found.
- *
- */
+
 struct FindPredicateContext
 {
     TLVReader &mResult;
@@ -385,69 +367,71 @@ static WEAVE_ERROR FindPredicateHandler(const TLVReader & aReader, size_t aDepth
 
 /**
  *  Search for the first element matching the predicate within the TLV reader
- *  descending into arrays or structures. The @ aPredicate is applied
- *  to each visited TLV element; the @aPredicate shall return WEAVE_ERROR_MAX
- *  for the matching elements, WEAVE_NO_ERROR for non-matching elements, and any
+ *  descending into arrays or structures. The @a aPredicate is applied
+ *  to each visited TLV element; the @a aPredicate shall return #WEAVE_ERROR_MAX
+ *  for the matching elements, #WEAVE_NO_ERROR for non-matching elements, and any
  *  other value to terminate the search.
  *
- *  @param[in,out] aReader A reference to the TLV reader in which to find the
- *                         element matching the predicate.  If the element is
- *                         found, this reader will be positioned on the first
- *                         matching TLV element.
+ *  @param[in] aReader     A read-only reference to the TLV reader in which to find the
+ *                         element matching the predicate.
  *  @param[in] aPredicate  A predicate to be applied to each TLV element.  To
  *                         support the code reuse, aPredicate has the
  *                         IterateHandler type.  The return value of aPredicate
- *                         controls the search: a WEAVE_ERROR_MAX signals that
- *                         desired element has been found, WEAVE_NO_ERROR
+ *                         controls the search: a #WEAVE_ERROR_MAX signals that
+ *                         desired element has been found, #WEAVE_NO_ERROR
  *                         signals that the desired element has not been found,
  *                         and all other values signal that the saerch should be
  *                         terminated.
  *  @param[in] aContext    An optional pointer to caller-provided context data.
  *
+ *  @param[out] aResult    A reference to storage to a TLV reader which
+ *                         will be positioned at the specified tag
+ *                         on success.
  *  @retval  #WEAVE_NO_ERROR                    On success.
  *
- *  @retval  #WEAVE_ERROR_TLV_TAG_NOT_FOUND     If the specified tag @a aTag was not found.
+ *  @retval  #WEAVE_ERROR_TLV_TAG_NOT_FOUND     If the specified @a aPredicate did not locate the specified element
  *
  */
-WEAVE_ERROR Find(TLVReader &aReader, IterateHandler aPredicate, void *aContext)
+WEAVE_ERROR Find(const TLVReader &aReader, IterateHandler aPredicate, void *aContext, TLVReader &aResult)
 {
     const bool  recurse = true;
-    return Find(aReader, aPredicate, aContext, recurse);
+    return Find(aReader, aPredicate, aContext, aResult, recurse);
 }
 
 /**
  *  Search for the first element matching the predicate within the TLV reader
- *  optionally descending into arrays or structures. The @ aPredicate is applied
- *  to each visited TLV element; the @aPredicate shall return WEAVE_ERROR_MAX
- *  for the matching elements, WEAVE_NO_ERROR for non-matching elements, and any
+ *  optionally descending into arrays or structures. The @a aPredicate is applied
+ *  to each visited TLV element; the @a aPredicate shall return #WEAVE_ERROR_MAX
+ *  for the matching elements, #WEAVE_NO_ERROR for non-matching elements, and any
  *  other value to terminate the search.
  *
- *  @param[in,out] aReader A reference to the TLV reader in which to find the
- *                         element matching the predicate.  If the element is
- *                         found, this reader will be positioned on the first
- *                         matching TLV element.
+ *  @param[in] aReader     A read-only reference to the TLV reader in which to find the
+ *                         element matching the predicate.
  *  @param[in] aPredicate  A predicate to be applied to each TLV element.  To
  *                         support the code reuse, aPredicate has the
- *                         IterateHandler type.  The return value of aPredicate
- *                         controls the search: a WEAVE_ERROR_MAX signals that
- *                         desired element has been found, WEAVE_NO_ERROR
+ *                         @a IterateHandler type.  The return value of aPredicate
+ *                         controls the search: a #WEAVE_ERROR_MAX signals that
+ *                         desired element has been found, #WEAVE_NO_ERROR
  *                         signals that the desired element has not been found,
  *                         and all other values signal that the saerch should be
  *                         terminated.
  *  @param[in] aContext    An optional pointer to caller-provided context data.
- *  @param[in] aRecurse    A Boolean indicating whether (true) or not (false) any
+ *  @param[out] aResult    A reference to storage to a TLV reader which
+ *                         will be positioned at the specified tag
+ *                         on success.
+ *  @param[in] aRecurse    A boolean indicating whether (true) or not (false) any
  *                         encountered arrays or structures should be descended
  *                         into.
  *
  *  @retval  #WEAVE_NO_ERROR                    On success.
  *
- *  @retval  #WEAVE_ERROR_TLV_TAG_NOT_FOUND     If the specified tag @a aTag was not found.
+ *  @retval  #WEAVE_ERROR_TLV_TAG_NOT_FOUND     If the specified @a aPredicate did not locate the specified element
  *
  */
-WEAVE_ERROR Find(TLVReader &aReader, IterateHandler aPredicate, void *aContext, const bool aRecurse)
+WEAVE_ERROR Find(const TLVReader &aReader, IterateHandler aPredicate, void *aContext, TLVReader &aResult, const bool aRecurse)
 {
     WEAVE_ERROR retval;
-    FindPredicateContext theContext(aReader, aPredicate, aContext);
+    FindPredicateContext theContext(aResult, aPredicate, aContext);
 
     retval = Iterate(aReader, FindPredicateHandler, &theContext, aRecurse);
 

--- a/src/lib/core/WeaveTLVUtilities.hpp
+++ b/src/lib/core/WeaveTLVUtilities.hpp
@@ -59,6 +59,8 @@ extern WEAVE_ERROR Count(const TLVReader &aReader, size_t &aCount, const bool aR
 extern WEAVE_ERROR Find(const TLVReader &aReader, const uint64_t &aTag, TLVReader &aResult);
 extern WEAVE_ERROR Find(const TLVReader &aReader, const uint64_t &aTag, TLVReader &aResult, const bool aRecurse);
 
+extern WEAVE_ERROR Find(TLVReader &aReader, IterateHandler aHandler, void *aContext);
+extern WEAVE_ERROR Find(TLVReader &aReader, IterateHandler aHandler, void *aContext, const bool aRecurse);
 } // namespace Utilities
 
 } // namespace TLV

--- a/src/lib/core/WeaveTLVUtilities.hpp
+++ b/src/lib/core/WeaveTLVUtilities.hpp
@@ -59,8 +59,8 @@ extern WEAVE_ERROR Count(const TLVReader &aReader, size_t &aCount, const bool aR
 extern WEAVE_ERROR Find(const TLVReader &aReader, const uint64_t &aTag, TLVReader &aResult);
 extern WEAVE_ERROR Find(const TLVReader &aReader, const uint64_t &aTag, TLVReader &aResult, const bool aRecurse);
 
-extern WEAVE_ERROR Find(TLVReader &aReader, IterateHandler aHandler, void *aContext);
-extern WEAVE_ERROR Find(TLVReader &aReader, IterateHandler aHandler, void *aContext, const bool aRecurse);
+extern WEAVE_ERROR Find(const TLVReader &aReader, IterateHandler aHandler, void *aContext, TLVReader &aResult);
+extern WEAVE_ERROR Find(const TLVReader &aReader, IterateHandler aHandler, void *aContext, TLVReader &aResult, const bool aRecurse);
 } // namespace Utilities
 
 } // namespace TLV

--- a/src/test-apps/TestTLV.cpp
+++ b/src/test-apps/TestTLV.cpp
@@ -1432,6 +1432,38 @@ static WEAVE_ERROR NullIterateHandler(const TLVReader &aReader, size_t aDepth, v
     return WEAVE_NO_ERROR;
 }
 
+static WEAVE_ERROR FindContainerWithElement(const TLVReader &aReader, size_t aDepth, void *aContext)
+{
+    TLVReader reader;
+    TLVReader result;
+    uint64_t * tag = static_cast<uint64_t *>(aContext);
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    TLVType containerType;
+
+    reader.Init(aReader);
+
+    if (TLVTypeIsContainer(reader.GetType()))
+    {
+        err = reader.EnterContainer(containerType);
+        SuccessOrExit(err);
+
+        err = nl::Weave::TLV::Utilities::Find(reader, *tag, result, false);
+
+        // Map a successful find (WEAVE_NO_ERROR) onto a signal that the element has been found.
+        if (err == WEAVE_NO_ERROR)
+        {
+            err = WEAVE_ERROR_MAX;
+        }
+        // Map a failed find attempt to NO_ERROR
+        else if (err == WEAVE_ERROR_TLV_TAG_NOT_FOUND)
+        {
+            err = WEAVE_NO_ERROR;
+        }
+    }
+exit:
+    return err;
+}
+
 /**
  *  Test Weave TLV Utilities
  */
@@ -1459,7 +1491,7 @@ void CheckWeaveTLVUtilities(nlTestSuite *inSuite, void *inContext)
     err = reader1.Next();
     NL_TEST_ASSERT(inSuite, err == WEAVE_NO_ERROR);
 
-    // Find
+    // Find a tag
     TLVReader tagReader;
     err = nl::Weave::TLV::Utilities::Find(reader, ProfileTag(TestProfile_2, 65536), tagReader);
     NL_TEST_ASSERT(inSuite, err == WEAVE_NO_ERROR);
@@ -1472,9 +1504,45 @@ void CheckWeaveTLVUtilities(nlTestSuite *inSuite, void *inContext)
     err = nl::Weave::TLV::Utilities::Find(reader, ProfileTag(TestProfile_2, 1024), tagReader);
     NL_TEST_ASSERT(inSuite, err == WEAVE_ERROR_TLV_TAG_NOT_FOUND);
 
+    // Find with a predicate
+    {
+        uint8_t buf1[74];
+
+        writer.Init(buf1, sizeof(buf1));
+        writer.ImplicitProfileId = TestProfile_2;
+
+        WriteEncoding2(inSuite, writer);
+
+        // Initialize a reader
+        reader1.Init(buf1, writer.GetLengthWritten());
+        reader1.ImplicitProfileId = TestProfile_2;
+
+        // position the reader on the first element
+        reader1.Next();
+        uint64_t tag = ProfileTag(TestProfile_1, 1);
+        err = nl::Weave::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
+        NL_TEST_ASSERT(inSuite, err == WEAVE_ERROR_TLV_TAG_NOT_FOUND);
+
+        tag = ProfileTag(TestProfile_2, 2);
+        err = nl::Weave::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
+        NL_TEST_ASSERT(inSuite, err ==  WEAVE_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, tagReader.GetType() == kTLVType_Structure);
+        NL_TEST_ASSERT(inSuite, tagReader.GetTag() == ProfileTag(TestProfile_1, 1));
+
+        // Position the reader on the second element
+        reader1.Next();
+        err = nl::Weave::TLV::Utilities::Find(reader1, FindContainerWithElement, &tag, tagReader, false);
+        NL_TEST_ASSERT(inSuite, err ==  WEAVE_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, tagReader.GetType() == kTLVType_Structure);
+        NL_TEST_ASSERT(inSuite, tagReader.GetTag() == ProfileTag(TestProfile_2, 1));
+    }
+
     // Count
     size_t count;
     const size_t expectedCount = 17;
+    reader1.Init(reader);
+    reader1.Next();
+
     err = nl::Weave::TLV::Utilities::Count(reader, count);
     NL_TEST_ASSERT(inSuite, err == WEAVE_NO_ERROR);
     NL_TEST_ASSERT(inSuite, count == expectedCount);
@@ -1913,6 +1981,56 @@ void CheckCircularTLVBufferSimple(nlTestSuite *inSuite, void *inContext)
     CircularTLVReader reader;
     TestTLVContext *context = static_cast<TestTLVContext *>(inContext);
     WeaveCircularTLVBuffer buffer(backingStore, 30);
+    writer.Init(&buffer);
+    writer.ImplicitProfileId = TestProfile_2;
+
+    context->mEvictionCount = 0;
+    context->mEvictedBytes = 0;
+
+    buffer.mProcessEvictedElement = CountEvictedMembers;
+    buffer.mAppData = inContext;
+
+    writer.PutBoolean(ProfileTag(TestProfile_1, 2), true);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    WriteEncoding3(inSuite, writer);
+
+    NL_TEST_ASSERT(inSuite, context->mEvictionCount == 2);
+    NL_TEST_ASSERT(inSuite, context->mEvictedBytes == 18);
+    NL_TEST_ASSERT(inSuite, buffer.DataLength() == 22);
+    NL_TEST_ASSERT(inSuite, (buffer.DataLength() + context->mEvictedBytes) ==  writer.GetLengthWritten());
+
+    // At this point the buffer should contain 2 instances of Encoding3.
+    reader.Init(&buffer);
+    reader.ImplicitProfileId = TestProfile_2;
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    ReadEncoding3(inSuite, reader);
+
+    TestNext<TLVReader>(inSuite, reader);
+
+    ReadEncoding3(inSuite, reader);
+
+    // Check that the reader is out of data
+    TestEnd<TLVReader>(inSuite, reader);
+}
+
+void CheckCircularTLVBufferStartMidway(nlTestSuite *inSuite, void *inContext)
+{
+    // Write 40 bytes as 4 separate events into a 30 byte buffer.  On
+    // completion of the test, the buffer should contain 2 elements
+    // and 2 elements should have been evicted in the last call to
+    // WriteEncoding.
+
+    uint8_t backingStore[30];
+    CircularTLVWriter writer;
+    CircularTLVReader reader;
+    TestTLVContext *context = static_cast<TestTLVContext *>(inContext);
+    WeaveCircularTLVBuffer buffer(backingStore, 30, &(backingStore[15]));
     writer.Init(&buffer);
     writer.ImplicitProfileId = TestProfile_2;
 
@@ -3645,6 +3763,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("Weave TLV Updater",                   CheckWeaveUpdater),
     NL_TEST_DEF("Weave TLV Empty Find",                CheckWeaveTLVEmptyFind),
     NL_TEST_DEF("Weave Circular TLV buffer, simple",   CheckCircularTLVBufferSimple),
+    NL_TEST_DEF("Weave Circular TLV buffer, mid-buffer start", CheckCircularTLVBufferStartMidway),
     NL_TEST_DEF("Weave Circular TLV buffer, straddle", CheckCircularTLVBufferEvictStraddlingEvent),
     NL_TEST_DEF("Weave Circular TLV buffer, edge",     CheckCircularTLVBufferEdge),
     NL_TEST_DEF("Weave TLV Printf",                    CheckWeaveTLVPutStringF),


### PR DESCRIPTION
Three minor TLV API enhancements:

* A new constructor to initialize `WeaveCircularTLVBuffer` to start at any offset within the buffer
* A new flavor of `nl::Weave::TLV::Utilities::Find` that is able to find elements based on a predicate
* Added a missing accessor for the underlying buffer in the `TLVReader`

These changes were motivated by the restructuring of the external event storage within event logging