### PR TITLE
DeviceManager.py: Allow add-thread-network with unspecified thread network key.

### DIFF
--- a/src/device-manager/python/weave-device-mgr.py
+++ b/src/device-manager/python/weave-device-mgr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-#    Copyright (c) 2013-2017 Nest Labs, Inc.
+#    Copyright (c) 2013-2018 Nest Labs, Inc.
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -1228,7 +1228,7 @@ class DeviceMgrCmd(Cmd):
             print "Invalid value specified for thread extended PAN id: " + args[1]
             return
 
-        kvstart = 3 if (len(args[2].split('=', 1)) == 1) else 2
+        kvstart = 3 if (len(args) > 2 and len(args[2].split('=', 1)) == 1) else 2
 
         if (kvstart > 2):
             try:


### PR DESCRIPTION
When the add-thread-network command is used in more recently defined pairing workflows, the thread network key may be unspecified. On enabling such a network provision, the Weave device is expected to generate its own new thread network key in that case.