### PR TITLE
First Round of Refactoring for UDPEndPoint

### DIFF
--- a/build/cstyle/cstyle.options
+++ b/build/cstyle/cstyle.options
@@ -1,5 +1,5 @@
 -v
---copyright='^( \*|\/\*|\/\/)    Copyright (\(c\) )*\d{4,}(-\d{4,})* Nest Labs, Inc\.'
+--copyright='^( \*|\/\*|\/\/)    Copyright (\(c\) )*\d{4,}(-\d{4,})* (Nest Labs, Inc\.|Google LLC\.*)'
 --cpp-lines-between-conditionals=20
 --line-length=132
 --tab-size=4

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -156,6 +156,7 @@ $(nl_public_InetLayer_source_dirstem)/InetLayerBasis.h \
 $(nl_public_InetLayer_source_dirstem)/InetLayerEvents.h \
 $(nl_public_InetLayer_source_dirstem)/InetTimer.h \
 $(nl_public_InetLayer_source_dirstem)/IPAddress.h \
+$(nl_public_InetLayer_source_dirstem)/IPEndPointBasis.h \
 $(nl_public_InetLayer_source_dirstem)/IPPrefix.h \
 $(nl_public_InetLayer_source_dirstem)/InetFaultInjection.h \
 $(NULL)

--- a/src/include/Makefile.in
+++ b/src/include/Makefile.in
@@ -731,6 +731,7 @@ $(nl_public_InetLayer_source_dirstem)/InetLayerBasis.h \
 $(nl_public_InetLayer_source_dirstem)/InetLayerEvents.h \
 $(nl_public_InetLayer_source_dirstem)/InetTimer.h \
 $(nl_public_InetLayer_source_dirstem)/IPAddress.h \
+$(nl_public_InetLayer_source_dirstem)/IPEndPointBasis.h \
 $(nl_public_InetLayer_source_dirstem)/IPPrefix.h \
 $(nl_public_InetLayer_source_dirstem)/InetFaultInjection.h \
 $(NULL)

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -1,0 +1,510 @@
+/*
+ *
+ *    Copyright (c) 2018 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This header file implements the <tt>nl::Inet::IPEndPointBasis</tt>
+ *      class, an intermediate, non-instantiable basis class
+ *      supporting other IP-based end points.
+ *
+ */
+
+#include <InetLayer/IPEndPointBasis.h>
+
+#include <string.h>
+
+#include <InetLayer/EndPointBasis.h>
+#include <InetLayer/InetInterface.h>
+#include <InetLayer/InetLayer.h>
+
+#include <Weave/Support/CodeUtils.h>
+
+#if WEAVE_SYSTEM_CONFIG_USE_LWIP
+#include <lwip/init.h>
+#include <lwip/ip.h>
+#include <lwip/netif.h>
+#include <lwip/udp.h>
+#endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
+
+#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+#include <sys/socket.h>
+#include <errno.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#if HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif // HAVE_SYS_SOCKET_H
+#endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+
+namespace nl {
+namespace Inet {
+
+#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+union PeerSockAddr
+{
+    sockaddr     any;
+    sockaddr_in  in;
+    sockaddr_in6 in6;
+};
+#endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+
+using Weave::System::PacketBuffer;
+
+void IPEndPointBasis::Init(InetLayer *aInetLayer)
+{
+    InitEndPointBasis(*aInetLayer);
+
+#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+    mBoundIntfId = INET_NULL_INTERFACEID;
+#endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+}
+
+#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+INET_ERROR IPEndPointBasis::Bind(IPAddressType aAddressType, IPAddress aAddress, uint16_t aPort, InterfaceId aInterfaceId)
+{
+    INET_ERROR lRetval = INET_NO_ERROR;
+
+    if (aAddressType == kIPAddressType_IPv6)
+    {
+        struct sockaddr_in6 sa;
+
+        memset(&sa, 0, sizeof (sa));
+
+        sa.sin6_family   = AF_INET6;
+        sa.sin6_port     = htons(aPort);
+        sa.sin6_flowinfo = 0;
+        sa.sin6_addr     = aAddress.ToIPv6();
+        sa.sin6_scope_id = aInterfaceId;
+
+        if (bind(mSocket, (const sockaddr *) &sa, (unsigned) sizeof (sa)) != 0)
+            lRetval = Weave::System::MapErrorPOSIX(errno);
+
+        // Instruct the kernel that any messages to multicast destinations should be
+        // sent down the interface specified by the caller.
+#ifdef IPV6_MULTICAST_IF
+        if (lRetval == INET_NO_ERROR)
+            setsockopt(mSocket, IPPROTO_IPV6, IPV6_MULTICAST_IF, &aInterfaceId, sizeof (aInterfaceId));
+#endif // defined(IPV6_MULTICAST_IF)
+
+        // Instruct the kernel that any messages to multicast destinations should be
+        // set with the configured hop limit value.
+#ifdef IPV6_MULTICAST_HOPS
+        int hops = INET_CONFIG_IP_MULTICAST_HOP_LIMIT;
+        setsockopt(mSocket, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &hops, sizeof (hops));
+#endif // defined(IPV6_MULTICAST_HOPS)
+    }
+#if INET_CONFIG_ENABLE_IPV4
+    else if (aAddressType == kIPAddressType_IPv4)
+    {
+        struct sockaddr_in sa;
+        int enable = 1;
+
+        memset(&sa, 0, sizeof (sa));
+
+        sa.sin_family = AF_INET;
+        sa.sin_port   = htons(aPort);
+        sa.sin_addr   = aAddress.ToIPv4();
+
+        if (bind(mSocket, (const sockaddr *) &sa, (unsigned) sizeof (sa)) != 0)
+            lRetval = Weave::System::MapErrorPOSIX(errno);
+
+        // Instruct the kernel that any messages to multicast destinations should be
+        // sent down the interface to which the specified IPv4 address is bound.
+#ifdef IP_MULTICAST_IF
+        if (lRetval == INET_NO_ERROR)
+            setsockopt(mSocket, IPPROTO_IP, IP_MULTICAST_IF, &sa, sizeof (sa));
+#endif // defined(IP_MULTICAST_IF)
+
+        // Instruct the kernel that any messages to multicast destinations should be
+        // set with the configured hop limit value.
+#ifdef IP_MULTICAST_TTL
+        int ttl = INET_CONFIG_IP_MULTICAST_HOP_LIMIT;
+        setsockopt(mSocket, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof (ttl));
+#endif // defined(IP_MULTICAST_TTL)
+
+        // Allow socket transmitting broadcast packets.
+        if (lRetval == INET_NO_ERROR)
+            setsockopt(mSocket, SOL_SOCKET, SO_BROADCAST, &enable, sizeof (enable));
+    }
+#endif // INET_CONFIG_ENABLE_IPV4
+    else
+        lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
+
+    return (lRetval);
+}
+
+INET_ERROR IPEndPointBasis::BindInterface(IPAddressType aAddressType, InterfaceId aInterfaceId)
+{
+    INET_ERROR lRetval = INET_NO_ERROR;
+
+#if HAVE_SO_BINDTODEVICE
+    if (aInterfaceId == INET_NULL_INTERFACEID)
+    {
+        //Stop interface-based filtering.
+        if (setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, "", 0) == -1)
+        {
+            lRetval = Weave::System::MapErrorPOSIX(errno);
+        }
+    }
+    else
+    {
+        //Start filtering on the passed interface.
+        char lInterfaceName[IF_NAMESIZE];
+
+        if (if_indextoname(aInterfaceId, lInterfaceName) == NULL)
+        {
+            lRetval = Weave::System::MapErrorPOSIX(errno);
+        }
+
+        if (lRetval == INET_NO_ERROR && setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, lInterfaceName, strlen(lInterfaceName)) == -1)
+        {
+            lRetval = Weave::System::MapErrorPOSIX(errno);
+        }
+    }
+
+    if (lRetval == INET_NO_ERROR)
+        mBoundIntfId = aInterfaceId;
+
+#else // !HAVE_SO_BINDTODEVICE
+    lRetval = INET_ERROR_NOT_IMPLEMENTED;
+#endif // HAVE_SO_BINDTODEVICE
+
+    return (lRetval);
+}
+
+INET_ERROR IPEndPointBasis::SendTo(const IPAddress &aAddress, uint16_t aPort, InterfaceId aInterfaceId, Weave::System::PacketBuffer *aBuffer, uint16_t aSendFlags)
+{
+    INET_ERROR     lRetval = INET_NO_ERROR;
+    PeerSockAddr   lPeerSockAddr;
+    struct iovec   msgIOV;
+    uint8_t        controlData[256];
+    struct msghdr  msgHeader;
+
+    // For now the entire message must fit within a single buffer.
+
+    VerifyOrExit(aBuffer->Next() == NULL, lRetval = INET_ERROR_MESSAGE_TOO_LONG);
+
+    memset(&msgHeader, 0, sizeof (msgHeader));
+
+    msgIOV.iov_base      = aBuffer->Start();
+    msgIOV.iov_len       = aBuffer->DataLength();
+    msgHeader.msg_iov    = &msgIOV;
+    msgHeader.msg_iovlen = 1;
+
+    memset(&lPeerSockAddr, 0, sizeof (lPeerSockAddr));
+
+    msgHeader.msg_name = &lPeerSockAddr;
+
+    if (mAddrType == kIPAddressType_IPv6)
+    {
+        lPeerSockAddr.in6.sin6_family   = AF_INET6;
+        lPeerSockAddr.in6.sin6_port     = htons(aPort);
+        lPeerSockAddr.in6.sin6_flowinfo = 0;
+        lPeerSockAddr.in6.sin6_addr     = aAddress.ToIPv6();
+        lPeerSockAddr.in6.sin6_scope_id = aInterfaceId;
+        msgHeader.msg_namelen           = sizeof (sockaddr_in6);
+    }
+#if INET_CONFIG_ENABLE_IPV4
+    else
+    {
+        lPeerSockAddr.in.sin_family     = AF_INET;
+        lPeerSockAddr.in.sin_port       = htons(aPort);
+        lPeerSockAddr.in.sin_addr       = aAddress.ToIPv4();
+        msgHeader.msg_namelen           = sizeof (sockaddr_in);
+    }
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    // If the endpoint has been bound to a particular interface,
+    // and the caller didn't supply a specific interface to send
+    // on, use the bound interface. This appears to be necessary
+    // for messages to multicast addresses, which under Linux
+    // don't seem to get sent out the correct inferface, despite
+    // the socket being bound.
+
+    if (aInterfaceId == INET_NULL_INTERFACEID)
+        aInterfaceId = mBoundIntfId;
+
+    if (aInterfaceId != INET_NULL_INTERFACEID && false)
+    {
+#if defined(IP_PKTINFO) || defined(IPV6_PKTINFO)
+        memset(controlData, 0, sizeof (controlData));
+        msgHeader.msg_control = controlData;
+        msgHeader.msg_controllen = sizeof (controlData);
+
+        struct cmsghdr *controlHdr = CMSG_FIRSTHDR(&msgHeader);
+
+#if INET_CONFIG_ENABLE_IPV4
+#if defined(IP_PKTINFO)
+        if (mAddrType == kIPAddressType_IPv4)
+        {
+            controlHdr->cmsg_level = IPPROTO_IP;
+            controlHdr->cmsg_type  = IP_PKTINFO;
+            controlHdr->cmsg_len   = CMSG_LEN(sizeof (in_pktinfo));
+
+            struct in_pktinfo *pktInfo = (struct in_pktinfo *)CMSG_DATA(controlHdr);
+            pktInfo->ipi_ifindex = aInterfaceId;
+
+            msgHeader.msg_controllen = CMSG_SPACE(sizeof (in_pktinfo));
+        }
+#endif // defined(IP_PKTINFO)
+#endif // INET_CONFIG_ENABLE_IPV4
+
+#if defined(IPV6_PKTINFO)
+        if (mAddrType == kIPAddressType_IPv6)
+        {
+            controlHdr->cmsg_level = IPPROTO_IP;
+            controlHdr->cmsg_type  = IPV6_PKTINFO;
+            controlHdr->cmsg_len   = CMSG_LEN(sizeof (in6_pktinfo));
+
+            struct in6_pktinfo *pktInfo = (struct in6_pktinfo *)CMSG_DATA(controlHdr);
+            pktInfo->ipi6_ifindex = aInterfaceId;
+
+            msgHeader.msg_controllen = CMSG_SPACE(sizeof (in6_pktinfo));
+        }
+#endif // defined(IPV6_PKTINFO)
+#else // !(defined(IP_PKTINFO) && defined(IPV6_PKTINFO))
+        lRetval = INET_ERROR_NOT_IMPLEMENTED
+#endif // !(defined(IP_PKTINFO) && defined(IPV6_PKTINFO))
+    }
+
+    if (lRetval == INET_NO_ERROR)
+    {
+        // Send IP packet.
+
+        const ssize_t lenSent = sendto(mSocket, msgHeader.msg_iov[0].iov_base, msgHeader.msg_iov[0].iov_len, 0, &lPeerSockAddr.any, msgHeader.msg_namelen);
+
+        if (lenSent == -1)
+            lRetval = Weave::System::MapErrorPOSIX(errno);
+        else if (lenSent != aBuffer->DataLength())
+            lRetval = INET_ERROR_OUTBOUND_MESSAGE_TRUNCATED;
+    }
+
+exit:
+    return (lRetval);
+}
+
+INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int aProtocol)
+{
+    if (mSocket == INET_INVALID_SOCKET_FD)
+    {
+        const int one = 1;
+        int family;
+        int res;
+
+        switch (aAddressType)
+        {
+        case kIPAddressType_IPv6:
+            family = PF_INET6;
+            break;
+
+#if INET_CONFIG_ENABLE_IPV4
+        case kIPAddressType_IPv4:
+            family = PF_INET;
+            break;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+        default:
+            return INET_ERROR_WRONG_ADDRESS_TYPE;
+        }
+
+        mSocket = ::socket(family, aType, aProtocol);
+        if (mSocket == -1)
+            return Weave::System::MapErrorPOSIX(errno);
+
+        mAddrType = aAddressType;
+
+        //
+        // NOTE WELL: the errors returned by setsockopt() here are not returned as Inet layer
+        // Weave::System::MapErrorPOSIX(errno) codes because they are normally expected to fail on some
+        // platforms where the socket option code is defined in the header files but not [yet]
+        // implemented. Certainly, there is room to improve this by connecting the build
+        // configuration logic up to check for implementations of these options and to provide
+        // appropriate HAVE_xxxxx definitions accordingly.
+        //
+
+        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEADDR,  (void*)&one, sizeof (one));
+        static_cast<void>(res);
+
+#ifdef SO_REUSEPORT
+        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEPORT,  (void*)&one, sizeof (one));
+        if (res != 0)
+        {
+            WeaveLogError(Inet, "SO_REUSEPORT: %d", errno);
+        }
+#endif // defined(SO_REUSEPORT)
+
+        // If creating an IPv6 socket, tell the kernel that it will be IPv6 only.  This makes it
+        // posible to bind two sockets to the same port, one for IPv4 and one for IPv6.
+#ifdef IPV6_V6ONLY
+#if INET_CONFIG_ENABLE_IPV4
+        if (aAddressType == kIPAddressType_IPv6)
+#endif // INET_CONFIG_ENABLE_IPV4
+        {
+            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_V6ONLY, (void *) &one, sizeof (one));
+            if (res != 0)
+            {
+                WeaveLogError(Inet, "IPV6_V6ONLY: %d", errno);
+            }
+        }
+#endif // defined(IPV6_V6ONLY)
+
+#if INET_CONFIG_ENABLE_IPV4
+#ifdef IP_PKTINFO
+        res = setsockopt(mSocket, IPPROTO_IP, IP_PKTINFO, (void *) &one, sizeof (one));
+        if (res != 0)
+        {
+            WeaveLogError(Inet, "IP_PKTINFO: %d", errno);
+        }
+#endif // defined(IP_PKTINFO)
+#endif // INET_CONFIG_ENABLE_IPV4
+
+#ifdef IPV6_RECVPKTINFO
+        res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_RECVPKTINFO, (void *) &one, sizeof (one));
+        if (res != 0)
+        {
+            WeaveLogError(Inet, "IPV6_PKTINFO: %d", errno);
+        }
+#endif // defined(IPV6_RECVPKTINFO)
+
+        // On systems that support it, disable the delivery of SIGPIPE signals when writing to a closed
+        // socket.  This is mostly needed on iOS which has the peculiar habit of sending SIGPIPEs on
+        // unconnected UDP sockets.
+#ifdef SO_NOSIGPIPE
+        {
+            res = setsockopt(mSocket, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof (one));
+            if (res != 0)
+            {
+                WeaveLogError(Inet, "SO_NOSIGPIPE: %d", errno);
+            }
+        }
+#endif // defined(SO_NOSIGPIPE)
+
+    }
+    else if (mAddrType != aAddressType)
+    {
+        return INET_ERROR_INCORRECT_STATE;
+    }
+
+    return INET_NO_ERROR;
+}
+
+INET_ERROR IPEndPointBasis::HandlePendingIO(uint16_t aPort, PacketBuffer *&aBuffer, IPPacketInfo &aPacketInfo)
+{
+    INET_ERROR lRetval = INET_NO_ERROR;
+
+    aPacketInfo.Clear();
+    aPacketInfo.DestPort = aPort;
+
+    aBuffer = PacketBuffer::New(0);
+
+    if (aBuffer != NULL)
+    {
+        struct iovec msgIOV;
+        PeerSockAddr lPeerSockAddr;
+        uint8_t controlData[256];
+        struct msghdr msgHeader;
+
+        msgIOV.iov_base = aBuffer->Start();
+        msgIOV.iov_len = aBuffer->AvailableDataLength();
+
+        memset(&lPeerSockAddr, 0, sizeof (lPeerSockAddr));
+
+        memset(&msgHeader, 0, sizeof (msgHeader));
+
+        msgHeader.msg_name = &lPeerSockAddr;
+        msgHeader.msg_namelen = sizeof (lPeerSockAddr);
+        msgHeader.msg_iov = &msgIOV;
+        msgHeader.msg_iovlen = 1;
+        msgHeader.msg_control = controlData;
+        msgHeader.msg_controllen = sizeof (controlData);
+
+        ssize_t rcvLen = recvmsg(mSocket, &msgHeader, MSG_DONTWAIT);
+
+        if (rcvLen < 0)
+        {
+            lRetval = Weave::System::MapErrorPOSIX(errno);
+        }
+        else if (rcvLen > aBuffer->AvailableDataLength())
+        {
+            lRetval = INET_ERROR_INBOUND_MESSAGE_TOO_BIG;
+        }
+        else
+        {
+            aBuffer->SetDataLength((uint16_t) rcvLen);
+
+            if (lPeerSockAddr.any.sa_family == AF_INET6)
+            {
+                aPacketInfo.SrcAddress = IPAddress::FromIPv6(lPeerSockAddr.in6.sin6_addr);
+                aPacketInfo.SrcPort = ntohs(lPeerSockAddr.in6.sin6_port);
+            }
+#if INET_CONFIG_ENABLE_IPV4
+            else if (lPeerSockAddr.any.sa_family == AF_INET)
+            {
+                aPacketInfo.SrcAddress = IPAddress::FromIPv4(lPeerSockAddr.in.sin_addr);
+                aPacketInfo.SrcPort = ntohs(lPeerSockAddr.in.sin_port);
+            }
+#endif // INET_CONFIG_ENABLE_IPV4
+            else
+            {
+                lRetval = INET_ERROR_INCORRECT_STATE;
+            }
+        }
+
+        if (lRetval == INET_NO_ERROR)
+        {
+            for (struct cmsghdr *controlHdr = CMSG_FIRSTHDR(&msgHeader);
+                 controlHdr != NULL;
+                 controlHdr = CMSG_NXTHDR(&msgHeader, controlHdr))
+            {
+#if INET_CONFIG_ENABLE_IPV4
+#ifdef IP_PKTINFO
+                if (controlHdr->cmsg_level == IPPROTO_IP && controlHdr->cmsg_type == IP_PKTINFO)
+                {
+                    struct in_pktinfo *inPktInfo = (struct in_pktinfo *)CMSG_DATA(controlHdr);
+                    aPacketInfo.Interface = inPktInfo->ipi_ifindex;
+                    aPacketInfo.DestAddress = IPAddress::FromIPv4(inPktInfo->ipi_addr);
+                    continue;
+                }
+#endif // defined(IP_PKTINFO)
+#endif // INET_CONFIG_ENABLE_IPV4
+
+#ifdef IPV6_PKTINFO
+                if (controlHdr->cmsg_level == IPPROTO_IPV6 && controlHdr->cmsg_type == IPV6_PKTINFO)
+                {
+                    struct in6_pktinfo *in6PktInfo = (struct in6_pktinfo *)CMSG_DATA(controlHdr);
+                    aPacketInfo.Interface = in6PktInfo->ipi6_ifindex;
+                    aPacketInfo.DestAddress = IPAddress::FromIPv6(in6PktInfo->ipi6_addr);
+                    continue;
+                }
+#endif // defined(IPV6_PKTINFO)
+            }
+        }
+    }
+    else
+    {
+        lRetval = INET_ERROR_NO_MEMORY;
+    }
+
+    return (lRetval);
+}
+#endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+
+} // namespace Inet
+} // namespace nl

--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -1,0 +1,83 @@
+/*
+ *
+ *    Copyright (c) 2018 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This header file defines the <tt>nl::Inet::IPEndPointBasis</tt>
+ *      class, an intermediate, non-instantiable basis class
+ *      supporting other IP-based end points.
+ *
+ */
+
+#ifndef IPENDPOINTBASIS_H
+#define IPENDPOINTBASIS_H
+
+#include <InetLayer/EndPointBasis.h>
+
+#include <SystemLayer/SystemPacketBuffer.h>
+
+namespace nl {
+namespace Inet {
+
+class InetLayer;
+class IPPacketInfo;
+
+/**
+ * @class IPEndPointBasis
+ *
+ * @brief Objects of this class represent non-instantiable IP protocol
+ *        endpoints.
+ *
+ */
+class NL_DLL_EXPORT IPEndPointBasis : public EndPointBasis
+{
+    friend class InetLayer;
+
+public:
+    /**
+     * @brief   Transmit option flags for the \c SendTo methods.
+     */
+    enum {
+        /** Do not destructively queue the message directly. Queue a copy. */
+        kSendFlag_RetainBuffer = 0x0040
+    };
+
+protected:
+    void Init(InetLayer *aInetLayer);
+
+#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+protected:
+    InterfaceId mBoundIntfId;
+
+    INET_ERROR Bind(IPAddressType aAddressType, IPAddress aAddress, uint16_t aPort, InterfaceId aInterfaceId);
+    INET_ERROR BindInterface(IPAddressType aAddressType, InterfaceId aInterfaceId);
+    INET_ERROR SendTo(const IPAddress &aAddress, uint16_t aPort, InterfaceId aInterfaceId, Weave::System::PacketBuffer *aBuffer, uint16_t aSendFlags);
+    INET_ERROR GetSocket(IPAddressType aAddressType, int aType, int aProtocol);
+    INET_ERROR HandlePendingIO(uint16_t aPort, Weave::System::PacketBuffer *&aBuffer, IPPacketInfo &aPacketInfo);
+#endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+
+private:
+    IPEndPointBasis(void);                     // not defined
+    IPEndPointBasis(const IPEndPointBasis &);  // not defined
+    ~IPEndPointBasis(void);                    // not defined
+};
+
+} // namespace Inet
+} // namespace nl
+
+#endif // !defined(IPENDPOINT_H)

--- a/src/inet/InetLayer.am
+++ b/src/inet/InetLayer.am
@@ -28,6 +28,7 @@ nl_InetLayer_sources                                       = \
     @top_builddir@/src/inet/EndPointBasis.cpp                \
     @top_builddir@/src/inet/IPAddress-StringFuncts.cpp       \
     @top_builddir@/src/inet/IPAddress.cpp                    \
+    @top_builddir@/src/inet/IPEndPointBasis.cpp              \
     @top_builddir@/src/inet/IPPrefix.cpp                     \
     @top_builddir@/src/inet/InetInterface.cpp                \
     @top_builddir@/src/inet/InetLayer.cpp                    \

--- a/src/inet/Makefile.in
+++ b/src/inet/Makefile.in
@@ -215,6 +215,7 @@ am__libInetLayer_a_SOURCES_DIST =  \
 	@top_builddir@/src/inet/EndPointBasis.cpp \
 	@top_builddir@/src/inet/IPAddress-StringFuncts.cpp \
 	@top_builddir@/src/inet/IPAddress.cpp \
+	@top_builddir@/src/inet/IPEndPointBasis.cpp \
 	@top_builddir@/src/inet/IPPrefix.cpp \
 	@top_builddir@/src/inet/InetInterface.cpp \
 	@top_builddir@/src/inet/InetLayer.cpp \
@@ -239,6 +240,7 @@ am__dirstamp = $(am__leading_dot)dirstamp
 am__objects_8 = @top_builddir@/src/inet/libInetLayer_a-EndPointBasis.$(OBJEXT) \
 	@top_builddir@/src/inet/libInetLayer_a-IPAddress-StringFuncts.$(OBJEXT) \
 	@top_builddir@/src/inet/libInetLayer_a-IPAddress.$(OBJEXT) \
+	@top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.$(OBJEXT) \
 	@top_builddir@/src/inet/libInetLayer_a-IPPrefix.$(OBJEXT) \
 	@top_builddir@/src/inet/libInetLayer_a-InetInterface.$(OBJEXT) \
 	@top_builddir@/src/inet/libInetLayer_a-InetLayer.$(OBJEXT) \
@@ -566,6 +568,7 @@ top_srcdir = @top_srcdir@
 nl_InetLayer_sources = @top_builddir@/src/inet/EndPointBasis.cpp \
 	@top_builddir@/src/inet/IPAddress-StringFuncts.cpp \
 	@top_builddir@/src/inet/IPAddress.cpp \
+	@top_builddir@/src/inet/IPEndPointBasis.cpp \
 	@top_builddir@/src/inet/IPPrefix.cpp \
 	@top_builddir@/src/inet/InetInterface.cpp \
 	@top_builddir@/src/inet/InetLayer.cpp \
@@ -680,6 +683,9 @@ clean-libLIBRARIES:
 @top_builddir@/src/inet/libInetLayer_a-IPAddress.$(OBJEXT):  \
 	@top_builddir@/src/inet/$(am__dirstamp) \
 	@top_builddir@/src/inet/$(DEPDIR)/$(am__dirstamp)
+@top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.$(OBJEXT):  \
+	@top_builddir@/src/inet/$(am__dirstamp) \
+	@top_builddir@/src/inet/$(DEPDIR)/$(am__dirstamp)
 @top_builddir@/src/inet/libInetLayer_a-IPPrefix.$(OBJEXT):  \
 	@top_builddir@/src/inet/$(am__dirstamp) \
 	@top_builddir@/src/inet/$(DEPDIR)/$(am__dirstamp)
@@ -737,6 +743,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-EndPointBasis.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPAddress-StringFuncts.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPAddress.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPEndPointBasis.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPPrefix.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-InetFaultInjection.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-InetInterface.Po@am__quote@
@@ -814,6 +821,20 @@ distclean-compile:
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='@top_builddir@/src/inet/IPAddress.cpp' object='@top_builddir@/src/inet/libInetLayer_a-IPAddress.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libInetLayer_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o @top_builddir@/src/inet/libInetLayer_a-IPAddress.obj `if test -f '@top_builddir@/src/inet/IPAddress.cpp'; then $(CYGPATH_W) '@top_builddir@/src/inet/IPAddress.cpp'; else $(CYGPATH_W) '$(srcdir)/@top_builddir@/src/inet/IPAddress.cpp'; fi`
+
+@top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.o: @top_builddir@/src/inet/IPEndPointBasis.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libInetLayer_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT @top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.o -MD -MP -MF @top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPEndPointBasis.Tpo -c -o @top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.o `test -f '@top_builddir@/src/inet/IPEndPointBasis.cpp' || echo '$(srcdir)/'`@top_builddir@/src/inet/IPEndPointBasis.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) @top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPEndPointBasis.Tpo @top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPEndPointBasis.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='@top_builddir@/src/inet/IPEndPointBasis.cpp' object='@top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libInetLayer_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o @top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.o `test -f '@top_builddir@/src/inet/IPEndPointBasis.cpp' || echo '$(srcdir)/'`@top_builddir@/src/inet/IPEndPointBasis.cpp
+
+@top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.obj: @top_builddir@/src/inet/IPEndPointBasis.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libInetLayer_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT @top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.obj -MD -MP -MF @top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPEndPointBasis.Tpo -c -o @top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.obj `if test -f '@top_builddir@/src/inet/IPEndPointBasis.cpp'; then $(CYGPATH_W) '@top_builddir@/src/inet/IPEndPointBasis.cpp'; else $(CYGPATH_W) '$(srcdir)/@top_builddir@/src/inet/IPEndPointBasis.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) @top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPEndPointBasis.Tpo @top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPEndPointBasis.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='@top_builddir@/src/inet/IPEndPointBasis.cpp' object='@top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libInetLayer_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o @top_builddir@/src/inet/libInetLayer_a-IPEndPointBasis.obj `if test -f '@top_builddir@/src/inet/IPEndPointBasis.cpp'; then $(CYGPATH_W) '@top_builddir@/src/inet/IPEndPointBasis.cpp'; else $(CYGPATH_W) '$(srcdir)/@top_builddir@/src/inet/IPEndPointBasis.cpp'; fi`
 
 @top_builddir@/src/inet/libInetLayer_a-IPPrefix.o: @top_builddir@/src/inet/IPPrefix.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libInetLayer_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT @top_builddir@/src/inet/libInetLayer_a-IPPrefix.o -MD -MP -MF @top_builddir@/src/inet/$(DEPDIR)/libInetLayer_a-IPPrefix.Tpo -c -o @top_builddir@/src/inet/libInetLayer_a-IPPrefix.o `test -f '@top_builddir@/src/inet/IPPrefix.cpp' || echo '$(srcdir)/'`@top_builddir@/src/inet/IPPrefix.cpp

--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -1,6 +1,7 @@
 /*
  *
- *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    Copyright (c) 2018 Google LLC.
+ *    Copyright (c) 2013-2018 Nest Labs, Inc.
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,9 +31,6 @@
 
 #include <string.h>
 
-// TODO: remove me
-#include <stdio.h>
-
 #include <InetLayer/UDPEndPoint.h>
 #include <InetLayer/InetLayer.h>
 #include <InetLayer/InetFaultInjection.h>
@@ -55,6 +53,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <net/if.h>
+#include <netinet/in.h>
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
 #include "arpa-inet-compatibility.h"
@@ -146,68 +145,7 @@ INET_ERROR UDPEndPoint::Bind(IPAddressType addrType, IPAddress addr, uint16_t po
 
     if (res == INET_NO_ERROR)
     {
-        if (addrType == kIPAddressType_IPv6)
-        {
-            struct sockaddr_in6 sa;
-            memset(&sa, 0, sizeof(sa));
-            sa.sin6_family = AF_INET6;
-            sa.sin6_port = htons(port);
-            sa.sin6_flowinfo = 0;
-            sa.sin6_addr = addr.ToIPv6();
-            sa.sin6_scope_id = intfId;
-
-            if (res == INET_NO_ERROR && bind(mSocket, (const sockaddr *) &sa, (unsigned) sizeof(sa)) != 0)
-                res = Weave::System::MapErrorPOSIX(errno);
-
-            // Instruct the kernel that any messages to multicast destinations should be
-            // sent down the interface specified by the caller.
-#ifdef IPV6_MULTICAST_IF
-            if (res == INET_NO_ERROR)
-                setsockopt(mSocket, IPPROTO_IPV6, IPV6_MULTICAST_IF, &intfId, sizeof(intfId));
-#endif // defined(IPV6_MULTICAST_IF)
-
-            // Instruct the kernel that any messages to multicast destinations should be
-            // set with the configured hop limit value.
-#ifdef IPV6_MULTICAST_HOPS
-            int hops = INET_CONFIG_IP_MULTICAST_HOP_LIMIT;
-            setsockopt(mSocket, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &hops, sizeof(hops));
-#endif // defined(IPV6_MULTICAST_HOPS)
-        }
-#if INET_CONFIG_ENABLE_IPV4
-        else if (addrType == kIPAddressType_IPv4)
-        {
-            struct sockaddr_in sa;
-            int enable = 1;
-
-            memset(&sa, 0, sizeof(sa));
-            sa.sin_family = AF_INET;
-            sa.sin_port = htons(port);
-            sa.sin_addr = addr.ToIPv4();
-
-            if (bind(mSocket, (const sockaddr *) &sa, (unsigned) sizeof(sa)) != 0)
-                res = Weave::System::MapErrorPOSIX(errno);
-
-            // Instruct the kernel that any messages to multicast destinations should be
-            // sent down the interface to which the specified IPv4 address is bound.
-#ifdef IP_MULTICAST_IF
-            if (res == INET_NO_ERROR)
-                setsockopt(mSocket, IPPROTO_IP, IP_MULTICAST_IF, &sa, sizeof(sa));
-#endif // defined(IP_MULTICAST_IF)
-
-            // Instruct the kernel that any messages to multicast destinations should be
-            // set with the configured hop limit value.
-#ifdef IP_MULTICAST_TTL
-            int ttl = INET_CONFIG_IP_MULTICAST_HOP_LIMIT;
-            setsockopt(mSocket, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl));
-#endif // defined(IP_MULTICAST_TTL)
-
-            // Allow socket transmitting broadcast packets.
-            if (res == INET_NO_ERROR)
-                setsockopt(mSocket, SOL_SOCKET, SO_BROADCAST, &enable, sizeof(enable));
-        }
-#endif // INET_CONFIG_ENABLE_IPV4
-        else
-            res = INET_ERROR_WRONG_ADDRESS_TYPE;
+        res = IPEndPointBasis::Bind(addrType, addr, port, intfId);
 
         if (res == INET_NO_ERROR)
         {
@@ -224,7 +162,7 @@ INET_ERROR UDPEndPoint::Bind(IPAddressType addrType, IPAddress addr, uint16_t po
     return res;
 }
 
-INET_ERROR UDPEndPoint::Listen()
+INET_ERROR UDPEndPoint::Listen(void)
 {
     INET_ERROR res = INET_NO_ERROR;
 
@@ -236,7 +174,9 @@ INET_ERROR UDPEndPoint::Listen()
         return INET_NO_ERROR;
 
     if (mState != kState_Bound)
+    {
         return INET_ERROR_INCORRECT_STATE;
+    }
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
 
@@ -259,7 +199,7 @@ INET_ERROR UDPEndPoint::Listen()
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
-    // Wake the thread calling select so that it recognizes the new socket.
+    // Wake the thread calling select so that it starts selecting on the new socket.
     lSystemLayer.WakeSelect();
 
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
@@ -270,7 +210,7 @@ INET_ERROR UDPEndPoint::Listen()
     return res;
 }
 
-void UDPEndPoint::Close()
+void UDPEndPoint::Close(void)
 {
     if (mState != kState_Closed)
     {
@@ -290,7 +230,7 @@ void UDPEndPoint::Close()
 
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
-# if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
         if (mSocket != INET_INVALID_SOCKET_FD)
         {
@@ -312,7 +252,7 @@ void UDPEndPoint::Close()
     }
 }
 
-void UDPEndPoint::Free()
+void UDPEndPoint::Free(void)
 {
     Close();
 
@@ -344,7 +284,6 @@ INET_ERROR UDPEndPoint::SendTo(IPAddress addr, uint16_t port, InterfaceId intfId
             );
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
-
     if (sendFlags & kSendFlag_RetainBuffer)
     {
         // when retaining a buffer, the caller expects the msg to be
@@ -430,115 +369,12 @@ INET_ERROR UDPEndPoint::SendTo(IPAddress addr, uint16_t port, InterfaceId intfId
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
-
     // Make sure we have the appropriate type of socket based on the destination address.
     res = GetSocket(addr.Type());
 
-    // For now the entire message must fit within a single buffer.
-    if (res == INET_NO_ERROR && msg->Next() != NULL)
-        res = INET_ERROR_MESSAGE_TOO_LONG;
-
     if (res == INET_NO_ERROR)
     {
-        struct iovec msgIOV;
-        union
-        {
-            sockaddr any;
-            sockaddr_in in;
-            sockaddr_in6 in6;
-        } peerSockAddr;
-        uint8_t controlData[256];
-        struct msghdr msgHeader;
-
-        memset(&msgHeader, 0, sizeof(msgHeader));
-
-        msgIOV.iov_base = msg->Start();
-        msgIOV.iov_len = msg->DataLength();
-        msgHeader.msg_iov = &msgIOV;
-        msgHeader.msg_iovlen = 1;
-
-        memset(&peerSockAddr, 0, sizeof(peerSockAddr));
-        msgHeader.msg_name = &peerSockAddr;
-        if (mAddrType == kIPAddressType_IPv6)
-        {
-            peerSockAddr.in6.sin6_family = AF_INET6;
-            peerSockAddr.in6.sin6_port = htons(port);
-            peerSockAddr.in6.sin6_flowinfo = 0;
-            peerSockAddr.in6.sin6_addr = addr.ToIPv6();
-            peerSockAddr.in6.sin6_scope_id = intfId;
-            msgHeader.msg_namelen = sizeof(sockaddr_in6);
-        }
-#if INET_CONFIG_ENABLE_IPV4
-        else
-        {
-            peerSockAddr.in.sin_family = AF_INET;
-            peerSockAddr.in.sin_port = htons(port);
-            peerSockAddr.in.sin_addr = addr.ToIPv4();
-            msgHeader.msg_namelen = sizeof(sockaddr_in);
-        }
-#endif // INET_CONFIG_ENABLE_IPV4
-
-        // If the endpoint has been bound to a particular interface, and the caller didn't supply
-        // a specific interface to send on, use the bound interface. This appears to be necessary
-        // for messages to multicast addresses, which under linux don't seem to get sent out the
-        // correct inferface, despite the socket being bound.
-        if (intfId == INET_NULL_INTERFACEID)
-            intfId = mBoundIntfId;
-
-        if (intfId != INET_NULL_INTERFACEID && false)
-        {
-#if defined(IP_PKTINFO) || defined(IPV6_PKTINFO)
-            memset(controlData, 0, sizeof(controlData));
-            msgHeader.msg_control = controlData;
-            msgHeader.msg_controllen = sizeof(controlData);
-
-            struct cmsghdr *controlHdr = CMSG_FIRSTHDR(&msgHeader);
-
-#if INET_CONFIG_ENABLE_IPV4
-#if defined(IP_PKTINFO)
-            if (mAddrType == kIPAddressType_IPv4)
-            {
-                controlHdr->cmsg_level = IPPROTO_IP;
-                controlHdr->cmsg_type = IP_PKTINFO;
-                controlHdr->cmsg_len = CMSG_LEN(sizeof(in_pktinfo));
-
-                struct in_pktinfo *pktInfo = (struct in_pktinfo *)CMSG_DATA(controlHdr);
-                pktInfo->ipi_ifindex = intfId;
-
-                msgHeader.msg_controllen = CMSG_SPACE(sizeof(in_pktinfo));
-            }
-#endif // defined(IP_PKTINFO)
-#endif // INET_CONFIG_ENABLE_IPV4
-
-#if defined(IPV6_PKTINFO)
-            if (mAddrType == kIPAddressType_IPv6)
-            {
-                controlHdr->cmsg_level = IPPROTO_IP;
-                controlHdr->cmsg_type = IPV6_PKTINFO;
-                controlHdr->cmsg_len = CMSG_LEN(sizeof(in6_pktinfo));
-
-                struct in6_pktinfo *pktInfo = (struct in6_pktinfo *)CMSG_DATA(controlHdr);
-                pktInfo->ipi6_ifindex = intfId;
-
-                msgHeader.msg_controllen = CMSG_SPACE(sizeof(in6_pktinfo));
-            }
-#endif // defined(IPV6_PKTINFO)
-#else // !(defined(IP_PKTINFO) && defined(IPV6_PKTINFO))
-            res = INET_ERROR_NOT_IMPLEMENTED
-#endif // !(defined(IP_PKTINFO) && defined(IPV6_PKTINFO))
-        }
-
-        if (res == INET_NO_ERROR)
-        {
-            // Send UDP packet.
-//            ssize_t lenSent = sendmsg(mSocket, &msgHeader, 0);
-
-            ssize_t lenSent = sendto(mSocket, msgHeader.msg_iov[0].iov_base, msgHeader.msg_iov[0].iov_len, 0, &peerSockAddr.any, msgHeader.msg_namelen);
-            if (lenSent == -1)
-                res = Weave::System::MapErrorPOSIX(errno);
-            else if (lenSent != msg->DataLength())
-                res = INET_ERROR_OUTBOUND_MESSAGE_TRUNCATED;
-        }
+        res = IPEndPointBasis::SendTo(addr, port, intfId, msg, sendFlags);
     }
 
     if ((sendFlags & kSendFlag_RetainBuffer) == 0)
@@ -554,7 +390,7 @@ INET_ERROR UDPEndPoint::SendTo(IPAddress addr, uint16_t port, InterfaceId intfId
 //A lock is required because the LwIP thread may be referring to intf_filter,
 //while this code running in the Inet application is potentially modifying it.
 //NOTE: this only supports LwIP interfaces whose number is no bigger than 9.
-INET_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intf)
+INET_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intfId)
 {
     INET_ERROR err = INET_NO_ERROR;
 
@@ -568,7 +404,7 @@ INET_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intf)
     err = GetPCB(addrType);
     if (err == INET_NO_ERROR)
     {
-        if ( !IsInterfaceIdPresent(intf) )
+        if ( !IsInterfaceIdPresent(intfId) )
         { //Stop interface-based filtering.
             mUDP->intf_filter = NULL;
         }
@@ -577,7 +413,7 @@ INET_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intf)
             struct netif *netifPtr;
             for (netifPtr = netif_list; netifPtr != NULL; netifPtr = netifPtr->next)
             {
-                if (netifPtr == intf)
+                if (netifPtr == intfId)
                 {
                     break;
                 }
@@ -598,43 +434,11 @@ INET_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intf)
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
-#if HAVE_SO_BINDTODEVICE
-
     // Make sure we have the appropriate type of socket.
     err = GetSocket(addrType);
 
     if (err == INET_NO_ERROR)
-    {
-        if (intf == INET_NULL_INTERFACEID)
-        {//Stop interface-based filtering.
-            if (setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, "", 0) == -1)
-            {
-                err = Weave::System::MapErrorPOSIX(errno);
-            }
-        }
-        else
-        {    //Start filtering on the passed interface.
-            char intfName[IF_NAMESIZE];
-            if (if_indextoname(intf, intfName) == NULL)
-            {
-                err = Weave::System::MapErrorPOSIX(errno);
-            }
-
-            if (err == INET_NO_ERROR && setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, intfName, strlen(intfName)) == -1)
-            {
-                err = Weave::System::MapErrorPOSIX(errno);
-            }
-        }
-    }
-
-    if (err == INET_NO_ERROR)
-        mBoundIntfId = intf;
-
-#else // !HAVE_SO_BINDTODEVICE
-
-    err = INET_ERROR_NOT_IMPLEMENTED;
-
-#endif // HAVE_SO_BINDTODEVICE
+        err = IPEndPointBasis::BindInterface(addrType, intfId);
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
     if (err == INET_NO_ERROR)
@@ -645,11 +449,7 @@ INET_ERROR UDPEndPoint::BindInterface(IPAddressType addrType, InterfaceId intf)
 
 void UDPEndPoint::Init(InetLayer *inetLayer)
 {
-    InitEndPointBasis(*inetLayer);
-
-#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
-    mBoundIntfId = INET_NULL_INTERFACEID;
-#endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+    IPEndPointBasis::Init(inetLayer);
 }
 
 InterfaceId UDPEndPoint::GetBoundInterface (void)
@@ -835,104 +635,15 @@ void UDPEndPoint::LwIPReceiveUDPMessage(void *arg, struct udp_pcb *pcb, struct p
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
-
-INET_ERROR UDPEndPoint::GetSocket(IPAddressType addrType)
+INET_ERROR UDPEndPoint::GetSocket(IPAddressType aAddressType)
 {
-    if (mSocket == INET_INVALID_SOCKET_FD)
-    {
-        int one = 1;
-        int family;
-        int res;
+    const int lType = (SOCK_DGRAM | SOCK_FLAGS);
+    const int lProtocol = 0;
 
-        if (addrType == kIPAddressType_IPv6)
-            family = PF_INET6;
-#if INET_CONFIG_ENABLE_IPV4
-        else if (addrType == kIPAddressType_IPv4)
-            family = PF_INET;
-#endif // INET_CONFIG_ENABLE_IPV4
-        else
-            return INET_ERROR_WRONG_ADDRESS_TYPE;
-
-        mSocket = ::socket(family, SOCK_DGRAM | SOCK_FLAGS, 0);
-        if (mSocket == -1)
-            return Weave::System::MapErrorPOSIX(errno);
-        mAddrType = addrType;
-
-        //
-        // NOTE WELL: the errors returned by setsockopt() here are not returned as Inet layer
-        // Weave::System::MapErrorPOSIX(errno) codes because they are normally expected to fail on some
-        // platforms where the socket option code is defined in the header files but not [yet]
-        // implemented. Certainly, there is room to improve this by connecting the build
-        // configuration logic up to check for implementations of these options and to provide
-        // appropriate HAVE_xxxxx definitions accordingly.
-        //
-
-        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEADDR,  (void*)&one, sizeof(one));
-        static_cast<void>(res);
-
-#ifdef SO_REUSEPORT
-        res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEPORT,  (void*)&one, sizeof(one));
-        if (res != 0)
-        {
-            WeaveLogError(Inet, "SO_REUSEPORT: %d", errno);
-        }
-#endif // defined(SO_REUSEPORT)
-
-        // If creating an IPv6 socket, tell the kernel that it will be IPv6 only.  This makes it
-        // posible to bind two sockets to the same port, one for IPv4 and one for IPv6.
-#ifdef IPV6_V6ONLY
-#if INET_CONFIG_ENABLE_IPV4
-        if (addrType == kIPAddressType_IPv6)
-#endif // INET_CONFIG_ENABLE_IPV4
-        {
-            res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_V6ONLY, (void *) &one, sizeof(one));
-            if (res != 0)
-            {
-                WeaveLogError(Inet, "IPV6_V6ONLY: %d", errno);
-            }
-        }
-#endif // defined(IPV6_V6ONLY)
-
-#if INET_CONFIG_ENABLE_IPV4
-#ifdef IP_PKTINFO
-        res = setsockopt(mSocket, IPPROTO_IP, IP_PKTINFO, (void *) &one, sizeof(one));
-        if (res != 0)
-        {
-            WeaveLogError(Inet, "IP_PKTINFO: %d", errno);
-        }
-#endif // defined(IP_PKTINFO)
-#endif // INET_CONFIG_ENABLE_IPV4
-
-#ifdef IPV6_RECVPKTINFO
-        res = setsockopt(mSocket, IPPROTO_IPV6, IPV6_RECVPKTINFO, (void *) &one, sizeof(one));
-        if (res != 0)
-        {
-            WeaveLogError(Inet, "IPV6_PKTINFO: %d", errno);
-        }
-#endif // defined(IPV6_RECVPKTINFO)
-
-        // On systems that support it, disable the delivery of SIGPIPE signals when writing to a closed
-        // socket.  This is mostly needed on iOS which has the peculiar habit of sending SIGPIPEs on
-        // unconnected UDP sockets.
-#ifdef SO_NOSIGPIPE
-        {
-            one = 1;
-            res = setsockopt(mSocket, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
-            if (res != 0)
-            {
-                WeaveLogError(Inet, "SO_NOSIGPIPE: %d", errno);
-            }
-        }
-#endif // defined(SO_NOSIGPIPE)
-
-    }
-    else if (mAddrType != addrType)
-        return INET_ERROR_INCORRECT_STATE;
-
-    return INET_NO_ERROR;
+    return (IPEndPointBasis::GetSocket(aAddressType, lType, lProtocol));
 }
 
-SocketEvents UDPEndPoint::PrepareIO()
+SocketEvents UDPEndPoint::PrepareIO(void)
 {
     SocketEvents res;
 
@@ -942,114 +653,27 @@ SocketEvents UDPEndPoint::PrepareIO()
     return res;
 }
 
-void UDPEndPoint::HandlePendingIO()
+void UDPEndPoint::HandlePendingIO(void)
 {
-    INET_ERROR err = INET_NO_ERROR;
+    INET_ERROR      lStatus = INET_NO_ERROR;
+    PacketBuffer *  lBuffer = NULL;
+    IPPacketInfo    lPacketInfo;
 
     if (mState == kState_Listening && OnMessageReceived != NULL && mPendingIO.IsReadable())
     {
-        IPPacketInfo pktInfo;
-        pktInfo.Clear();
-        pktInfo.DestPort = mBoundPort;
+        const uint16_t lPort = mBoundPort;
 
-        PacketBuffer *buf = PacketBuffer::New(0);
+        lStatus = IPEndPointBasis::HandlePendingIO(lPort, lBuffer, lPacketInfo);
 
-        if (buf != NULL)
-        {
-            struct iovec msgIOV;
-            union
-            {
-                sockaddr any;
-                sockaddr_in in;
-                sockaddr_in6 in6;
-            } peerSockAddr;
-            uint8_t controlData[256];
-            struct msghdr msgHeader;
-
-            msgIOV.iov_base = buf->Start();
-            msgIOV.iov_len = buf->AvailableDataLength();
-
-            memset(&peerSockAddr, 0, sizeof(peerSockAddr));
-
-            memset(&msgHeader, 0, sizeof(msgHeader));
-            msgHeader.msg_name = &peerSockAddr;
-            msgHeader.msg_namelen = sizeof(peerSockAddr);
-            msgHeader.msg_iov = &msgIOV;
-            msgHeader.msg_iovlen = 1;
-            msgHeader.msg_control = controlData;
-            msgHeader.msg_controllen = sizeof(controlData);
-
-            ssize_t rcvLen = recvmsg(mSocket, &msgHeader, MSG_DONTWAIT);
-
-            if (rcvLen < 0)
-                err = Weave::System::MapErrorPOSIX(errno);
-
-            else if (rcvLen > buf->AvailableDataLength())
-                err = INET_ERROR_INBOUND_MESSAGE_TOO_BIG;
-
-            else
-            {
-                buf->SetDataLength((uint16_t) rcvLen);
-
-                if (peerSockAddr.any.sa_family == AF_INET6)
-                {
-                    pktInfo.SrcAddress = IPAddress::FromIPv6(peerSockAddr.in6.sin6_addr);
-                    pktInfo.SrcPort = ntohs(peerSockAddr.in6.sin6_port);
-                }
-#if INET_CONFIG_ENABLE_IPV4
-                else if (peerSockAddr.any.sa_family == AF_INET)
-                {
-                    pktInfo.SrcAddress = IPAddress::FromIPv4(peerSockAddr.in.sin_addr);
-                    pktInfo.SrcPort = ntohs(peerSockAddr.in.sin_port);
-                }
-#endif // INET_CONFIG_ENABLE_IPV4
-                else
-                    err = INET_ERROR_INCORRECT_STATE;
-            }
-
-            if (err == INET_NO_ERROR)
-            {
-                for (struct cmsghdr *controlHdr = CMSG_FIRSTHDR(&msgHeader);
-                     controlHdr != NULL;
-                     controlHdr = CMSG_NXTHDR(&msgHeader, controlHdr))
-                {
-#if INET_CONFIG_ENABLE_IPV4
-#ifdef IP_PKTINFO
-                    if (controlHdr->cmsg_level == IPPROTO_IP && controlHdr->cmsg_type == IP_PKTINFO)
-                    {
-                        struct in_pktinfo *inPktInfo = (struct in_pktinfo *)CMSG_DATA(controlHdr);
-                        pktInfo.Interface = inPktInfo->ipi_ifindex;
-                        pktInfo.DestAddress = IPAddress::FromIPv4(inPktInfo->ipi_addr);
-                        continue;
-                    }
-#endif // defined(IP_PKTINFO)
-#endif // INET_CONFIG_ENABLE_IPV4
-
-#ifdef IPV6_PKTINFO
-                    if (controlHdr->cmsg_level == IPPROTO_IPV6 && controlHdr->cmsg_type == IPV6_PKTINFO)
-                    {
-                        struct in6_pktinfo *in6PktInfo = (struct in6_pktinfo *)CMSG_DATA(controlHdr);
-                        pktInfo.Interface = in6PktInfo->ipi6_ifindex;
-                        pktInfo.DestAddress = IPAddress::FromIPv6(in6PktInfo->ipi6_addr);
-                        continue;
-                    }
-#endif // defined(IPV6_PKTINFO)
-                }
-            }
-        }
-
-        else
-            err = INET_ERROR_NO_MEMORY;
-
-        if (err == INET_NO_ERROR)
-            OnMessageReceived(this, buf, &pktInfo);
+        if (lStatus == INET_NO_ERROR)
+            OnMessageReceived(this, lBuffer, &lPacketInfo);
         else
         {
-            PacketBuffer::Free(buf);
+            PacketBuffer::Free(lBuffer);
             if (OnReceiveError != NULL
-                && err != Weave::System::MapErrorPOSIX(EAGAIN)
+                && lStatus != Weave::System::MapErrorPOSIX(EAGAIN)
             )
-                OnReceiveError(this, err, NULL);
+                OnReceiveError(this, lStatus, NULL);
         }
     }
 

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -1,5 +1,6 @@
 /*
  *
+ *    Copyright (c) 2018 Google LLC
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -28,7 +29,7 @@
 #ifndef UDPENDPOINT_H
 #define UDPENDPOINT_H
 
-#include <InetLayer/EndPointBasis.h>
+#include <InetLayer/IPEndPointBasis.h>
 #include <InetLayer/IPAddress.h>
 
 #include <SystemLayer/SystemPacketBuffer.h>
@@ -47,7 +48,7 @@ class IPPacketInfo;
  *  endpoints (SOCK_DGRAM sockets on Linux and BSD-derived systems) or LwIP
  *  UDP protocol control blocks, as the system is configured accordingly.
  */
-class NL_DLL_EXPORT UDPEndPoint : public EndPointBasis
+ class NL_DLL_EXPORT UDPEndPoint : public IPEndPointBasis
 {
     friend class InetLayer;
 
@@ -74,14 +75,6 @@ public:
     } mState;
 
     /**
-     * @brief   Transmit option flags for the \c SendTo methods.
-     */
-    enum {
-        /** Do not destructively queue the message directly. Queue a copy. */
-        kSendFlag_RetainBuffer = 0x0040
-    };
-
-    /**
      * @brief   Bind the endpoint to an interface IP address.
      *
      * @param[in]   addrType    the protocol version of the IP address
@@ -106,6 +99,10 @@ public:
      *
      * @retval  other                   another system or platform error
      *
+     * @details
+     *  Binds the endpoint to the specified network interface IP address.
+     *
+     *  On LwIP, this method must not be called with the LwIP stack lock
      *  already acquired.
      */
     INET_ERROR Bind(IPAddressType addrType, IPAddress addr, uint16_t port, InterfaceId intfId = INET_NULL_INTERFACEID);
@@ -118,7 +115,7 @@ public:
      *
      * @details
      *  If \c State is already \c kState_Listening, then no operation is
-     *  performed, otherwise the \c State is set to \c kState_Listening and
+     *  performed, otherwise the \c mState is set to \c kState_Listening and
      *  the endpoint is prepared to received UDP messages, according to the
      *  semantics of the platform.
      *
@@ -181,7 +178,8 @@ public:
     /**
      * @brief   Bind the endpoint to a network interface.
      *
-     * @param[in]   addrType    the protocol version of the IP address
+     * @param[in]   addrType    the protocol version of the IP address.
+	 *
      * @param[in]   intf        indicator of the network interface.
      *
      * @retval  INET_NO_ERROR               success: endpoint bound to address
@@ -285,7 +283,6 @@ private:
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
     uint16_t mBoundPort;
-    InterfaceId mBoundIntfId;
 
     INET_ERROR GetSocket(IPAddressType addrType);
     SocketEvents PrepareIO(void);

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -424,6 +424,7 @@ am__libWeave_a_SOURCES_DIST =  \
 	@top_builddir@/src/inet/EndPointBasis.cpp \
 	@top_builddir@/src/inet/IPAddress-StringFuncts.cpp \
 	@top_builddir@/src/inet/IPAddress.cpp \
+	@top_builddir@/src/inet/IPEndPointBasis.cpp \
 	@top_builddir@/src/inet/IPPrefix.cpp \
 	@top_builddir@/src/inet/InetInterface.cpp \
 	@top_builddir@/src/inet/InetLayer.cpp \
@@ -616,6 +617,7 @@ am__objects_10 =  \
 	@top_builddir@/src/inet/libWeave_a-EndPointBasis.$(OBJEXT) \
 	@top_builddir@/src/inet/libWeave_a-IPAddress-StringFuncts.$(OBJEXT) \
 	@top_builddir@/src/inet/libWeave_a-IPAddress.$(OBJEXT) \
+	@top_builddir@/src/inet/libWeave_a-IPEndPointBasis.$(OBJEXT) \
 	@top_builddir@/src/inet/libWeave_a-IPPrefix.$(OBJEXT) \
 	@top_builddir@/src/inet/libWeave_a-InetInterface.$(OBJEXT) \
 	@top_builddir@/src/inet/libWeave_a-InetLayer.$(OBJEXT) \
@@ -1117,6 +1119,7 @@ nl_SystemLayer_sources = @top_builddir@/src/system/SystemClock.cpp \
 nl_InetLayer_sources = @top_builddir@/src/inet/EndPointBasis.cpp \
 	@top_builddir@/src/inet/IPAddress-StringFuncts.cpp \
 	@top_builddir@/src/inet/IPAddress.cpp \
+	@top_builddir@/src/inet/IPEndPointBasis.cpp \
 	@top_builddir@/src/inet/IPPrefix.cpp \
 	@top_builddir@/src/inet/InetInterface.cpp \
 	@top_builddir@/src/inet/InetLayer.cpp \
@@ -1446,6 +1449,9 @@ clean-libLIBRARIES:
 	@top_builddir@/src/inet/$(am__dirstamp) \
 	@top_builddir@/src/inet/$(DEPDIR)/$(am__dirstamp)
 @top_builddir@/src/inet/libWeave_a-IPAddress.$(OBJEXT):  \
+	@top_builddir@/src/inet/$(am__dirstamp) \
+	@top_builddir@/src/inet/$(DEPDIR)/$(am__dirstamp)
+@top_builddir@/src/inet/libWeave_a-IPEndPointBasis.$(OBJEXT):  \
 	@top_builddir@/src/inet/$(am__dirstamp) \
 	@top_builddir@/src/inet/$(DEPDIR)/$(am__dirstamp)
 @top_builddir@/src/inet/libWeave_a-IPPrefix.$(OBJEXT):  \
@@ -2149,6 +2155,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libWeave_a-EndPointBasis.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPAddress-StringFuncts.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPAddress.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPEndPointBasis.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPPrefix.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libWeave_a-InetFaultInjection.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@@top_builddir@/src/inet/$(DEPDIR)/libWeave_a-InetInterface.Po@am__quote@
@@ -2512,6 +2519,20 @@ distclean-compile:
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='@top_builddir@/src/inet/IPAddress.cpp' object='@top_builddir@/src/inet/libWeave_a-IPAddress.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o @top_builddir@/src/inet/libWeave_a-IPAddress.obj `if test -f '@top_builddir@/src/inet/IPAddress.cpp'; then $(CYGPATH_W) '@top_builddir@/src/inet/IPAddress.cpp'; else $(CYGPATH_W) '$(srcdir)/@top_builddir@/src/inet/IPAddress.cpp'; fi`
+
+@top_builddir@/src/inet/libWeave_a-IPEndPointBasis.o: @top_builddir@/src/inet/IPEndPointBasis.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT @top_builddir@/src/inet/libWeave_a-IPEndPointBasis.o -MD -MP -MF @top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPEndPointBasis.Tpo -c -o @top_builddir@/src/inet/libWeave_a-IPEndPointBasis.o `test -f '@top_builddir@/src/inet/IPEndPointBasis.cpp' || echo '$(srcdir)/'`@top_builddir@/src/inet/IPEndPointBasis.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) @top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPEndPointBasis.Tpo @top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPEndPointBasis.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='@top_builddir@/src/inet/IPEndPointBasis.cpp' object='@top_builddir@/src/inet/libWeave_a-IPEndPointBasis.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o @top_builddir@/src/inet/libWeave_a-IPEndPointBasis.o `test -f '@top_builddir@/src/inet/IPEndPointBasis.cpp' || echo '$(srcdir)/'`@top_builddir@/src/inet/IPEndPointBasis.cpp
+
+@top_builddir@/src/inet/libWeave_a-IPEndPointBasis.obj: @top_builddir@/src/inet/IPEndPointBasis.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT @top_builddir@/src/inet/libWeave_a-IPEndPointBasis.obj -MD -MP -MF @top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPEndPointBasis.Tpo -c -o @top_builddir@/src/inet/libWeave_a-IPEndPointBasis.obj `if test -f '@top_builddir@/src/inet/IPEndPointBasis.cpp'; then $(CYGPATH_W) '@top_builddir@/src/inet/IPEndPointBasis.cpp'; else $(CYGPATH_W) '$(srcdir)/@top_builddir@/src/inet/IPEndPointBasis.cpp'; fi`
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) @top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPEndPointBasis.Tpo @top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPEndPointBasis.Po
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='@top_builddir@/src/inet/IPEndPointBasis.cpp' object='@top_builddir@/src/inet/libWeave_a-IPEndPointBasis.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o @top_builddir@/src/inet/libWeave_a-IPEndPointBasis.obj `if test -f '@top_builddir@/src/inet/IPEndPointBasis.cpp'; then $(CYGPATH_W) '@top_builddir@/src/inet/IPEndPointBasis.cpp'; else $(CYGPATH_W) '$(srcdir)/@top_builddir@/src/inet/IPEndPointBasis.cpp'; fi`
 
 @top_builddir@/src/inet/libWeave_a-IPPrefix.o: @top_builddir@/src/inet/IPPrefix.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libWeave_a_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT @top_builddir@/src/inet/libWeave_a-IPPrefix.o -MD -MP -MF @top_builddir@/src/inet/$(DEPDIR)/libWeave_a-IPPrefix.Tpo -c -o @top_builddir@/src/inet/libWeave_a-IPPrefix.o `test -f '@top_builddir@/src/inet/IPPrefix.cpp' || echo '$(srcdir)/'`@top_builddir@/src/inet/IPPrefix.cpp


### PR DESCRIPTION
This is the first in a series of refactorings that migrates common BSD-socket-specific implementation out of the UDPEndPoint class and into a new, intermediate IPEndPoint basis class from which the UDPEndPoint class will now derive.

The intent of this is two fold:

1. The intermediate IPEndPoint basis class will serve as a future home for forthcoming new common, expanded IP multicast implementation, particularly for BSD sockets, but also for LwIP.
2. The intermediate IPEndPoint basis class will serve as a point to further unify and harmonize IP datagram operations between RawEndPoint and UDPEndPoint, including unifying IPPacketInfo, since these two classes are more similar than different.