### PR TITLE
Second Round of Refactoring for RawEndPoint 

### DIFF
--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -302,11 +302,12 @@ exit:
 
 INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int aProtocol)
 {
+    INET_ERROR res = INET_NO_ERROR;
+
     if (mSocket == INET_INVALID_SOCKET_FD)
     {
         const int one = 1;
         int family;
-        int res;
 
         switch (aAddressType)
         {
@@ -330,14 +331,14 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
 
         mAddrType = aAddressType;
 
-        //
-        // NOTE WELL: the errors returned by setsockopt() here are not returned as Inet layer
-        // Weave::System::MapErrorPOSIX(errno) codes because they are normally expected to fail on some
-        // platforms where the socket option code is defined in the header files but not [yet]
-        // implemented. Certainly, there is room to improve this by connecting the build
-        // configuration logic up to check for implementations of these options and to provide
-        // appropriate HAVE_xxxxx definitions accordingly.
-        //
+        // NOTE WELL: the errors returned by setsockopt() here are not
+        // returned as Inet layer Weave::System::MapErrorPOSIX(errno)
+        // codes because they are normally expected to fail on some
+        // platforms where the socket option code is defined in the
+        // header files but not [yet] implemented. Certainly, there is
+        // room to improve this by connecting the build configuration
+        // logic up to check for implementations of these options and
+        // to provide appropriate HAVE_xxxxx definitions accordingly.
 
         res = setsockopt(mSocket, SOL_SOCKET, SO_REUSEADDR,  (void*)&one, sizeof (one));
         static_cast<void>(res);
@@ -350,8 +351,10 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
         }
 #endif // defined(SO_REUSEPORT)
 
-        // If creating an IPv6 socket, tell the kernel that it will be IPv6 only.  This makes it
-        // posible to bind two sockets to the same port, one for IPv4 and one for IPv6.
+        // If creating an IPv6 socket, tell the kernel that it will be
+        // IPv6 only.  This makes it posible to bind two sockets to
+        // the same port, one for IPv4 and one for IPv6.
+
 #ifdef IPV6_V6ONLY
 #if INET_CONFIG_ENABLE_IPV4
         if (aAddressType == kIPAddressType_IPv6)
@@ -383,9 +386,10 @@ INET_ERROR IPEndPointBasis::GetSocket(IPAddressType aAddressType, int aType, int
         }
 #endif // defined(IPV6_RECVPKTINFO)
 
-        // On systems that support it, disable the delivery of SIGPIPE signals when writing to a closed
-        // socket.  This is mostly needed on iOS which has the peculiar habit of sending SIGPIPEs on
-        // unconnected UDP sockets.
+        // On systems that support it, disable the delivery of SIGPIPE
+        // signals when writing to a closed socket.  This is mostly
+        // needed on iOS which has the peculiar habit of sending
+        // SIGPIPEs on unconnected UDP sockets.
 #ifdef SO_NOSIGPIPE
         {
             res = setsockopt(mSocket, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof (one));

--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -31,6 +31,11 @@
 
 #include <SystemLayer/SystemPacketBuffer.h>
 
+#if WEAVE_SYSTEM_CONFIG_USE_LWIP
+#include <lwip/init.h>
+#include <lwip/netif.h>
+#endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
+
 namespace nl {
 namespace Inet {
 
@@ -50,6 +55,30 @@ class NL_DLL_EXPORT IPEndPointBasis : public EndPointBasis
 
 public:
     /**
+     * @brief   Basic dynamic state of the underlying endpoint.
+     *
+     * @details
+     *  Objects are initialized in the "ready" state, proceed to the "bound"
+     *  state after binding to a local interface address, then proceed to the
+     *  "listening" state when they have continuations registered for handling
+     *  events for reception of ICMP messages.
+     *
+     * @note
+     *  The \c kBasisState_Closed state enumeration is mapped to \c
+     *  kState_Ready for historical binary-compatibility reasons. The
+     *  existing \c kState_Closed exists to identify separately the
+     *  distinction between "not opened yet" and "previously opened
+     *  now closed" that existed previously in the \c kState_Ready and
+     *  \c kState_Closed states.
+     */
+    enum {
+        kState_Ready        = kBasisState_Closed,   /**< Endpoint initialized, but not open. */
+        kState_Bound        = 1,                    /**< Endpoint bound, but not listening. */
+        kState_Listening    = 2,                    /**< Endpoint receiving datagrams. */
+        kState_Closed       = 3                     /**< Endpoint closed, ready for release. */
+    } mState;
+
+    /**
      * @brief   Transmit option flags for the \c SendTo methods.
      */
     enum {
@@ -59,6 +88,26 @@ public:
 
 protected:
     void Init(InetLayer *aInetLayer);
+
+#if WEAVE_SYSTEM_CONFIG_USE_LWIP
+public:
+    static inline struct netif *FindNetifFromInterfaceId(InterfaceId aInterfaceId)
+    {
+            struct netif *lRetval = NULL;
+
+#if LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
+            NETIF_FOREACH(lRetval)
+            {
+                if (lRetval == aInterfaceid)
+                    break;
+            }
+#else // LWIP_VERSION_MAJOR < 2 || !defined(NETIF_FOREACH)
+            for (lRetval = netif_list; lRetval != NULL && lRetval != aInterfaceId; lRetval = lRetval->next);
+#endif // LWIP_VERSION_MAJOR >= 2 && LWIP_VERSION_MINOR >= 0 && defined(NETIF_FOREACH)
+
+            return (lRetval);
+    }
+#endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 protected:

--- a/src/inet/RawEndPoint.cpp
+++ b/src/inet/RawEndPoint.cpp
@@ -1,6 +1,7 @@
 /*
  *
- *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    Copyright (c) 2018 Google LLC.
+ *    Copyright (c) 2013-2018 Nest Labs, Inc.
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,41 +21,42 @@
  *    @file
  *      This file implements the <tt>nl::Inet::RawEndPoint</tt> class,
  *      where the Nest Inet Layer encapsulates methods for interacting
- *      with PF_RAW sockets (on Linux and BSD-derived systems) or LwIP
- *      raw protocol control blocks, as the system is configured
- *      accordingly.
+ *      interacting with IP network endpoints (SOCK_RAW sockets
+ *      on Linux and BSD-derived systems) or LwIP raw protocol
+ *      control blocks, as the system is configured accordingly.
  *
  */
 
+#define __APPLE_USE_RFC_3542
+
 #include <string.h>
-#include <stdio.h>
 
 #include <InetLayer/RawEndPoint.h>
 #include <InetLayer/InetLayer.h>
+#include <InetLayer/InetFaultInjection.h>
+#include <SystemLayer/SystemFaultInjection.h>
 
 #include <Weave/Support/CodeUtils.h>
+#include <Weave/Support/logging/WeaveLogging.h>
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
-#include <lwip/ip.h>
-#include <lwip/tcpip.h>
 #include <lwip/raw.h>
-#include <lwip/netif.h>
+#include <lwip/tcpip.h>
+#include <lwip/ip.h>
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
-#include <sys/socket.h>
 #include <sys/select.h>
+#if HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif // HAVE_SYS_SOCKET_H
 #include <errno.h>
 #include <unistd.h>
-#include <netinet/in.h>
 #include <net/if.h>
 #include <sys/ioctl.h>
 #if HAVE_NETINET_ICMP6_H
 #include <netinet/icmp6.h>
 #endif // HAVE_NETINET_ICMP6_H
-#if HAVE_SYS_SOCKET_H
-#include <sys/socket.h>
-#endif // HAVE_SYS_SOCKET_H
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
 // SOCK_CLOEXEC not defined on all platforms, e.g. iOS/MacOS:
@@ -67,6 +69,8 @@
 namespace nl {
 namespace Inet {
 
+using Weave::System::PacketBuffer;
+
 class SenderInfo
 {
 public:
@@ -75,28 +79,21 @@ public:
 
 Weave::System::ObjectPool<RawEndPoint, INET_CONFIG_NUM_RAW_ENDPOINTS> RawEndPoint::sPool;
 
-/**
- * Bind the raw endpoint to an IP address of the specified type.
- *
- * @param[in]   addrType    An IPAddressType to identify the type of the address.
- *
- * @param[in]   addr        An IPAddress object required to be of the specified type.
- *
- * @return INET_NO_ERROR on success, or a mapped OS error on failure. An invalid
- * parameter list can result in INET_ERROR_WRONG_ADDRESS_TYPE. If the raw endpoint
- * is already bound or is listening, then returns INET_ERROR_INCORRECT_STATE.
- */
-INET_ERROR RawEndPoint::Bind(IPAddressType addrType, IPAddress addr)
+INET_ERROR RawEndPoint::Bind(IPAddressType addrType, IPAddress addr, InterfaceId intfId)
 {
-    INET_ERROR res;
-    IPAddressType addrTypeInfer;
+    INET_ERROR res = INET_NO_ERROR;
 
-    if (mState != kState_Closed)
-        return INET_ERROR_INCORRECT_STATE;
+    if (mState != kState_Ready && mState != kState_Bound)
+	{
+        res = INET_ERROR_INCORRECT_STATE;
+        goto exit;
+    }
 
-    addrTypeInfer = addr.Type();
-    if (addrTypeInfer != kIPAddressType_Any && addrType != addrTypeInfer)
-        return INET_ERROR_WRONG_ADDRESS_TYPE;
+    if ((addr != IPAddress::Any) && (addr.Type() != kIPAddressType_Any) && (addr.Type() != addrType))
+    {
+        res = INET_ERROR_WRONG_ADDRESS_TYPE;
+        goto exit;
+    }
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
 
@@ -104,19 +101,19 @@ INET_ERROR RawEndPoint::Bind(IPAddressType addrType, IPAddress addr)
     LOCK_TCPIP_CORE();
 
     // Make sure we have the appropriate type of PCB.
-    res = GetPCB();
+    res = GetPCB(addrType);
 
     // Bind the PCB to the specified address.
     if (res == INET_NO_ERROR)
     {
-#if LWIP_VERSION_MAJOR > 1
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
         ip_addr_t ipAddr = addr.ToLwIPAddr();
-
-        if (IP_GET_TYPE(&ipAddr) == IPADDR_TYPE_ANY)
-            res = INET_ERROR_WRONG_ADDRESS_TYPE;
-        else
-            res = Weave::System::MapErrorLwIP(raw_bind(mRaw, &ipAddr));
-#else // LWIP_VERSION_MAJOR <= 1
+#if INET_CONFIG_ENABLE_IPV4
+        lwip_ip_addr_type lType = IPAddress::ToLwIPAddrType(addrType);
+        IP_SET_TYPE_VAL(ipAddr, lType);
+#endif // INET_CONFIG_ENABLE_IPV4
+        res = Weave::System::MapErrorLwIP(raw_bind(mRaw, &ipAddr));
+#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
         if (addrType == kIPAddressType_IPv6)
         {
             ip6_addr_t ipv6Addr = addr.ToIPv6();
@@ -125,13 +122,28 @@ INET_ERROR RawEndPoint::Bind(IPAddressType addrType, IPAddress addr)
 #if INET_CONFIG_ENABLE_IPV4
         else if (addrType == kIPAddressType_IPv4)
         {
-            ip_addr_t ipv4Addr = addr.ToIPv4();
+            ip4_addr_t ipv4Addr = addr.ToIPv4();
             res = Weave::System::MapErrorLwIP(raw_bind(mRaw, &ipv4Addr));
         }
 #endif // INET_CONFIG_ENABLE_IPV4
         else
             res = INET_ERROR_WRONG_ADDRESS_TYPE;
-#endif // LWIP_VERSION_MAJOR <= 1
+#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
+    }
+
+    if (res == INET_NO_ERROR)
+    {
+        if (!IsInterfaceIdPresent(intfId))
+            mRaw->intf_filter = NULL;
+        else
+        {
+            struct netif *netifp = IPEndPointBasis::FindNetifFromInterfaceId(intfId);
+
+            if (netifp == NULL)
+                res = INET_ERROR_UNKNOWN_INTERFACE;
+            else
+                mRaw->intf_filter = netifp;
+        }
     }
 
     // Unlock LwIP stack
@@ -140,42 +152,22 @@ INET_ERROR RawEndPoint::Bind(IPAddressType addrType, IPAddress addr)
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
-
     // Make sure we have the appropriate type of socket.
     res = GetSocket(addrType);
-    if (res == INET_NO_ERROR)
-    {
-        if (addrType == kIPAddressType_IPv6)
-        {
-            struct sockaddr_in6 sa;
-            sa.sin6_family = AF_INET6;
-            sa.sin6_flowinfo = 0;
-            sa.sin6_addr = addr.ToIPv6();
-            sa.sin6_scope_id = 0;
+    SuccessOrExit(res);
 
-            if (bind(mSocket, (const sockaddr *) &sa, (unsigned) sizeof(sa)) != 0)
-                res = Weave::System::MapErrorPOSIX(errno);
-        }
-#if INET_CONFIG_ENABLE_IPV4
-        else if (addrType == kIPAddressType_IPv4)
-        {
-            struct sockaddr_in sa;
-            sa.sin_family = AF_INET;
-            sa.sin_addr = addr.ToIPv4();
+    res = IPEndPointBasis::Bind(addrType, addr, 0, intfId);
+    SuccessOrExit(res);
 
-            if (bind(mSocket, (const sockaddr *) &sa, (unsigned) sizeof(sa)) != 0)
-                res = Weave::System::MapErrorPOSIX(errno);
-        }
-#endif // INET_CONFIG_ENABLE_IPV4
-        else
-            res = INET_ERROR_WRONG_ADDRESS_TYPE;
-    }
-
+    mBoundIntfId = intfId;
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
     if (res == INET_NO_ERROR)
+    {
         mState = kState_Bound;
+    }
 
+exit:
     return res;
 }
 
@@ -200,15 +192,15 @@ INET_ERROR RawEndPoint::BindIPv6LinkLocal(InterfaceId intf, IPAddress addr)
     const int lIfIndex = static_cast<int>(intf);
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
-    if (!addr.IsIPv6LinkLocal())
+    if (mState != kState_Ready && mState != kState_Bound)
     {
-        res = INET_ERROR_WRONG_ADDRESS_TYPE;
+        res = INET_ERROR_INCORRECT_STATE;
         goto ret;
     }
 
-    if (mState != kState_Closed)
+    if (!addr.IsIPv6LinkLocal())
     {
-        res = INET_ERROR_INCORRECT_STATE;
+        res = INET_ERROR_WRONG_ADDRESS_TYPE;
         goto ret;
     }
 
@@ -218,7 +210,7 @@ INET_ERROR RawEndPoint::BindIPv6LinkLocal(InterfaceId intf, IPAddress addr)
     LOCK_TCPIP_CORE();
 
     // Make sure we have the appropriate type of PCB.
-    res = GetPCB();
+    res = GetPCB(addr.Type());
 
     // Bind the PCB to the specified address.
     if (res == INET_NO_ERROR)
@@ -289,7 +281,7 @@ ret:
     return res;
 }
 
-INET_ERROR RawEndPoint::Listen()
+INET_ERROR RawEndPoint::Listen(void)
 {
     INET_ERROR res = INET_NO_ERROR;
 
@@ -298,24 +290,30 @@ INET_ERROR RawEndPoint::Listen()
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
     if (mState == kState_Listening)
-        return INET_NO_ERROR;
+    {
+        res = INET_NO_ERROR;
+        goto exit;
+    }
 
     if (mState != kState_Bound)
-        return INET_ERROR_INCORRECT_STATE;
+    {
+        res = INET_ERROR_INCORRECT_STATE;
+        goto exit;
+    }
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
 
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
 
-#if LWIP_VERSION_MAJOR > 1
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
     raw_recv(mRaw, LwIPReceiveRawMessage, this);
-#else // LWIP_VERSION_MAJOR <= 1
+#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
     if (PCB_ISIPV6(mRaw))
         raw_recv_ip6(mRaw, LwIPReceiveRawMessage, this);
     else
         raw_recv(mRaw, LwIPReceiveRawMessage, this);
-#endif // LWIP_VERSION_MAJOR <= 1
+#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
 
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
@@ -330,12 +328,15 @@ INET_ERROR RawEndPoint::Listen()
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
     if (res == INET_NO_ERROR)
+    {
         mState = kState_Listening;
+    }
 
+ exit:
     return res;
 }
 
-void RawEndPoint::Close()
+void RawEndPoint::Close(void)
 {
     if (mState != kState_Closed)
     {
@@ -344,9 +345,13 @@ void RawEndPoint::Close()
         // Lock LwIP stack
         LOCK_TCPIP_CORE();
 
+        // Since Raw PCB is released synchronously here, but UDP endpoint itself might have to wait
+        // for destruction asynchronously, there could be more allocated UDP endpoints than UDP PCBs.
         if (mRaw != NULL)
-        raw_remove(mRaw);
-        mRaw = NULL;
+        {
+            raw_remove(mRaw);
+            mRaw = NULL;
+        }
 
         // Unlock LwIP stack
         UNLOCK_TCPIP_CORE();
@@ -375,46 +380,103 @@ void RawEndPoint::Close()
     }
 }
 
-void RawEndPoint::Free()
+void RawEndPoint::Free(void)
 {
     Close();
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
-    DeferredFree(kReleaseDeferralErrorTactic_Release);
+    DeferredFree(kReleaseDeferralErrorTactic_Die);
 #else // !WEAVE_SYSTEM_CONFIG_USE_LWIP
     Release();
 #endif // !WEAVE_SYSTEM_CONFIG_USE_LWIP
 }
 
-INET_ERROR RawEndPoint::SendTo(IPAddress addr, Weave::System::PacketBuffer *msg)
+INET_ERROR RawEndPoint::SendTo(IPAddress addr, Weave::System::PacketBuffer *msg, uint16_t sendFlags)
+{
+    return SendTo(addr, INET_NULL_INTERFACEID, msg, sendFlags);
+}
+
+INET_ERROR RawEndPoint::SendTo(IPAddress addr, InterfaceId intfId, Weave::System::PacketBuffer *msg, uint16_t sendFlags)
 {
     INET_ERROR res = INET_NO_ERROR;
 
-#if INET_CONFIG_ENABLE_IPV4
-    if (IPVer == kIPVersion_4 && addr.Type() != kIPAddressType_IPv4)
+    INET_FAULT_INJECT(FaultInjection::kFault_Send,
+            if ((sendFlags & kSendFlag_RetainBuffer) == 0)
+                PacketBuffer::Free(msg);
+            return INET_ERROR_UNKNOWN_INTERFACE;
+            );
+    INET_FAULT_INJECT(FaultInjection::kFault_SendNonCritical,
+            if ((sendFlags & kSendFlag_RetainBuffer) == 0)
+                PacketBuffer::Free(msg);
+            return INET_ERROR_NO_MEMORY;
+            );
+
+    // Do not allow sending an IPv4 address on an IPv6 end point and
+    // vice versa.
+
+    if (IPVer == kIPVersion_6 && addr.Type() != kIPAddressType_IPv6)
     {
-        res = INET_ERROR_WRONG_ADDRESS_TYPE;
-        goto finalize;
+        return INET_ERROR_WRONG_ADDRESS_TYPE;
+    }
+#if INET_CONFIG_ENABLE_IPV4
+    else if (IPVer == kIPVersion_4 && addr.Type() != kIPAddressType_IPv4)
+    {
+        return INET_ERROR_WRONG_ADDRESS_TYPE;
     }
 #endif // INET_CONFIG_ENABLE_IPV4
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
 
+    if (sendFlags & kSendFlag_RetainBuffer)
+    {
+        // when retaining a buffer, the caller expects the msg to be
+        // unmodified.  LwIP stack will normally prepend the packet
+        // headers as the packet traverses the IP/netif layers,
+        // which normally modifies the packet.  We prepend a small
+        // pbuf to the beginning of the pbuf chain, s.t. all headers
+        // are added to the temporary space, just large enough to hold
+        // the transport headers. Careful reader will note:
+        //
+        // * we're actually oversizing the reserved space, the
+        //   transport header is large enough for the TCP header which
+        //   is larger than the UDP header, but it seemed cleaner than
+        //   the combination of PBUF_IP for reserve space, UDP_HLEN
+        //   for payload, and post allocation adjustment of the header
+        //   space).
+        //
+        // * the code deviates from the existing PacketBuffer
+        //   abstractions and needs to reach into the underlying pbuf
+        //   code.  The code in PacketBuffer also forces us to perform
+        //   (effectively) a reinterpret_cast rather than a
+        //   static_cast.  JIRA WEAV-811 is filed to track the
+        //   re-architecting of the memory management.
+
+        pbuf *msgCopy = pbuf_alloc(PBUF_TRANSPORT, 0, PBUF_RAM);
+
+        if (msgCopy == NULL)
+        {
+            return INET_ERROR_NO_MEMORY;
+        }
+
+        pbuf_chain(msgCopy, (pbuf *) msg);
+        msg = (PacketBuffer *)msgCopy;
+    }
+
     // Lock LwIP stack
     LOCK_TCPIP_CORE();
 
     // Make sure we have the appropriate type of PCB based on the destination address.
-    res = GetPCB();
+    res = GetPCB(addr.Type());
+	SuccessOrExit(res);
 
-    // Send the message to the specified address.
-    if (res == INET_NO_ERROR)
+    // Send the message to the specified address/port.
     {
-        err_t lwipErr = ERR_OK;
+        err_t lwipErr = ERR_VAL;
 
-#if LWIP_VERSION_MAJOR > 1
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
         ip_addr_t ipAddr = addr.ToLwIPAddr();
         lwipErr = raw_sendto(mRaw, (pbuf *)msg, &ipAddr);
-#else // LWIP_VERSION_MAJOR <= 1
+#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
         if (PCB_ISIPV6(mRaw))
         {
             ip6_addr_t ipv6Addr = addr.ToIPv6();
@@ -423,11 +485,11 @@ INET_ERROR RawEndPoint::SendTo(IPAddress addr, Weave::System::PacketBuffer *msg)
 #if INET_CONFIG_ENABLE_IPV4
         else
         {
-            ip_addr_t ipv4Addr = addr.ToIPv4();
+            ip4_addr_t ipv4Addr = addr.ToIPv4();
             lwipErr = raw_sendto(mRaw, (pbuf *)msg, &ipv4Addr);
         }
 #endif // INET_CONFIG_ENABLE_IPV4
-#endif // LWIP_VERSION_MAJOR <= 1
+#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
 
         if (lwipErr != ERR_OK)
             res = Weave::System::MapErrorLwIP(lwipErr);
@@ -436,60 +498,25 @@ INET_ERROR RawEndPoint::SendTo(IPAddress addr, Weave::System::PacketBuffer *msg)
     // Unlock LwIP stack
     UNLOCK_TCPIP_CORE();
 
+    PacketBuffer::Free(msg);
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+    // Make sure we have the appropriate type of socket based on the
+    // destination address.
 
-    // Make sure we have the appropriate type of socket based on the destination address.
     res = GetSocket(addr.Type());
+    SuccessOrExit(res);
 
-    // For now the entire message must fit within a single buffer.
-    if (res == INET_NO_ERROR && msg->Next() != NULL)
-        res = INET_ERROR_MESSAGE_TOO_LONG;
+    res = IPEndPointBasis::SendTo(addr, 0, intfId, msg, sendFlags);
 
-    if (res == INET_NO_ERROR)
-    {
-        union
-        {
-            sockaddr any;
-            sockaddr_in in;
-            sockaddr_in6 in6;
-        } sa;
-
-        if (mAddrType == kIPAddressType_IPv6)
-        {
-            sa.in6.sin6_family = AF_INET6;
-            sa.in6.sin6_port = 0; //FIXME
-            sa.in6.sin6_flowinfo = 0;
-            sa.in6.sin6_addr = addr.ToIPv6();
-            sa.in6.sin6_scope_id = 0;
-        }
-#if INET_CONFIG_ENABLE_IPV4
-        else
-        {
-            sa.in.sin_family = AF_INET;
-            sa.in.sin_port = 0; //FIXME
-            sa.in.sin_addr = addr.ToIPv4();
-        }
-#endif // INET_CONFIG_ENABLE_IPV4
-
-        uint16_t msgLen = msg->DataLength();
-
-        // Send Raw packet.
-        ssize_t lenSent = sendto(mSocket, msg->Start(), msgLen, 0, &sa.any, sizeof(sa));
-        if (lenSent == -1)
-            res = Weave::System::MapErrorPOSIX(errno);
-        else if (lenSent != msgLen)
-            res = INET_ERROR_OUTBOUND_MESSAGE_TRUNCATED;
-    }
-
+    if ((sendFlags & kSendFlag_RetainBuffer) == 0)
+        PacketBuffer::Free(msg);
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
-#if INET_CONFIG_ENABLE_IPV4
-finalize:
-#endif // INET_CONFIG_ENABLE_IPV4
+exit:
+    WEAVE_SYSTEM_FAULT_INJECT_ASYNC_EVENT();
 
-    Weave::System::PacketBuffer::Free(msg);
     return res;
 }
 
@@ -547,40 +574,32 @@ exit:
 //A lock is required because the LwIP thread may be referring to intf_filter,
 //while this code running in the Inet application is potentially modifying it.
 //NOTE: this only supports LwIP interfaces whose number is no bigger than 9.
-INET_ERROR RawEndPoint::BindInterface(InterfaceId intf)
+INET_ERROR RawEndPoint::BindInterface(IPAddressType addrType, InterfaceId intfId)
 {
     INET_ERROR err = INET_NO_ERROR;
+
+    if (mState != kState_Ready && mState != kState_Bound)
+        return INET_ERROR_INCORRECT_STATE;
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
     LOCK_TCPIP_CORE();
 
     // Make sure we have the appropriate type of PCB.
-    err = GetPCB();
-    if (err == INET_NO_ERROR)
+    err = GetPCB(addrType);
+	SuccessOrExit(err);
+
+    if (!IsInterfaceIdPresent(intfId))
+    { //Stop interface-based filtering.
+        mRaw->intf_filter = NULL;
+    }
+    else
     {
-        if ( !IsInterfaceIdPresent(intf) )
-        { //Stop interface-based filtering.
-            mRaw->intf_filter = NULL;
-        }
+        struct netif *netifp = IPEndPointBasis::FindNetifFromInterfaceId(intfId);
+
+        if (netifp == NULL)
+            err = INET_ERROR_UNKNOWN_INTERFACE;
         else
-        {
-            struct netif *netifPtr;
-            for (netifPtr = netif_list; netifPtr != NULL; netifPtr = netifPtr->next)
-            {
-                if (netifPtr == intf)
-                {
-                    break;
-                }
-            }
-            if (netifPtr == NULL)
-            {
-                err = INET_ERROR_UNKNOWN_INTERFACE;
-            }
-            else
-            {
-                mRaw->intf_filter = netifPtr;
-            }
-        }
+            mRaw->intf_filter = netifp;
     }
 
     UNLOCK_TCPIP_CORE();
@@ -588,53 +607,45 @@ INET_ERROR RawEndPoint::BindInterface(InterfaceId intf)
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
-#if HAVE_SO_BINDTODEVICE
+    // Make sure we have the appropriate type of socket.
+    err = GetSocket(addrType);
+	SuccessOrExit(err);
 
-    if ( !IsInterfaceIdPresent(intf) )
-    {//Stop interface-based filtering.
-        if (setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, "", 0) == -1)
-        {
-            err = Weave::System::MapErrorPOSIX(errno);
-        }
-    }
-    else
-    {//Start filtering on the passed interface.
-        char intfName[IF_NAMESIZE];
-        if (if_indextoname(intf, intfName) == NULL)
-        {
-            err = Weave::System::MapErrorPOSIX(errno);
-        }
-
-        if (err == INET_NO_ERROR && setsockopt(mSocket, SOL_SOCKET, SO_BINDTODEVICE, intfName, strlen(intfName)) == -1)
-        {
-            err = Weave::System::MapErrorPOSIX(errno);
-        }
-    }
-
-#else // !HAVE_SO_BINDTODEVICE
-
-    err = INET_ERROR_NOT_IMPLEMENTED;
-
-#endif // HAVE_SO_BINDTODEVICE
+    err = IPEndPointBasis::BindInterface(addrType, intfId);
+	SuccessOrExit(err);
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
     if (err == INET_NO_ERROR)
+    {
         mState = kState_Bound;
+    }
 
+exit:
     return err;
 }
 
 void RawEndPoint::Init(InetLayer *inetLayer, IPVersion ipVer, IPProtocol ipProto)
 {
-    InitEndPointBasis(*inetLayer);
+    IPEndPointBasis::Init(inetLayer);
 
     IPVer = ipVer;
     IPProto = ipProto;
 }
 
+InterfaceId RawEndPoint::GetBoundInterface (void)
+{
+#if WEAVE_SYSTEM_CONFIG_USE_LWIP
+    return mRaw->intf_filter;
+#endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
+
+#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+    return mBoundIntfId;
+#endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+}
+
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
 
-void RawEndPoint::HandleDataReceived(Weave::System::PacketBuffer *msg)
+void RawEndPoint::HandleDataReceived(PacketBuffer *msg)
 {
     if (mState == kState_Listening && OnMessageReceived != NULL)
     {
@@ -642,28 +653,104 @@ void RawEndPoint::HandleDataReceived(Weave::System::PacketBuffer *msg)
         OnMessageReceived(this, msg, senderInfo->Address);
     }
     else
-        Weave::System::PacketBuffer::Free(msg);
+        PacketBuffer::Free(msg);
 }
 
-INET_ERROR RawEndPoint::GetPCB()
+INET_ERROR RawEndPoint::GetPCB(IPAddressType addrType)
 {
+    INET_ERROR lRetval = INET_NO_ERROR;
+
     // IMPORTANT: This method MUST be called with the LwIP stack LOCKED!
 
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
+    if (mRaw == NULL)
+    {
+        switch (addrType)
+        {
+        case kIPAddressType_IPv6:
+#if INET_CONFIG_ENABLE_IPV4
+        case kIPAddressType_IPv4:
+#endif // INET_CONFIG_ENABLE_IPV4
+            mRaw = raw_new_ip_type(IPAddress::ToLwIPAddrType(addrType), IPProto);
+            break;
+
+        default:
+            lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
+            goto exit;
+        }
+
+        if (mRaw == NULL)
+        {
+            WeaveLogError(Inet, "raw_new_ip_type failed");
+            lRetval = INET_ERROR_NO_MEMORY;
+            goto exit;
+        }
+    }
+    else
+    {
+        const lwip_ip_addr_type lLwIPAddrType = static_cast<lwip_ip_addr_type>(IP_GET_TYPE(&mRaw->local_ip));
+
+        switch (lLwIPAddrType)
+        {
+        case IPADDR_TYPE_V6:
+            VerifyOrExit(addrType == kIPAddressType_IPv6, lRetval = INET_ERROR_WRONG_ADDRESS_TYPE);
+            break;
+
+#if INET_CONFIG_ENABLE_IPV4
+        case IPADDR_TYPE_V4:
+            VerifyOrExit(addrType == kIPAddressType_IPv4, lRetval = INET_ERROR_WRONG_ADDRESS_TYPE);
+            break;
+#endif // INET_CONFIG_ENABLE_IPV4
+
+        default:
+            break;
+        }
+    }
+#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
     if (mRaw == NULL)
     {
         if (IPVer == kIPVersion_6)
+        {
             mRaw = raw_new_ip6(IPProto);
+            if (mRaw != NULL)
+                ip_set_option(mRaw, SOF_REUSEADDR);
+        }
 #if INET_CONFIG_ENABLE_IPV4
         else if (IPVer == kIPVersion_4)
+        {
             mRaw = raw_new(IPProto);
+        }
 #endif // INET_CONFIG_ENABLE_IPV4
         else
-            return INET_ERROR_WRONG_ADDRESS_TYPE;
-        if (mRaw == NULL)
-            return INET_ERROR_NO_MEMORY;
-    }
+        {
+            lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
+            goto exit;
+        }
 
-    return INET_NO_ERROR;
+        if (mRaw == NULL)
+        {
+            WeaveLogError(Inet, "raw_new failed");
+            lRetval = INET_ERROR_NO_MEMORY;
+            goto exit;
+        }
+    }
+    else
+    {
+#if INET_CONFIG_ENABLE_IPV4
+        const IPAddressType pcbType = PCB_ISIPV6(mRaw) ? kIPAddressType_IPv6 : kIPAddressType_IPv4;
+#else // !INET_CONFIG_ENABLE_IPV4
+        const IPAddressType pcbType = kIPAddressType_IPv6;
+#endif // !INET_CONFIG_ENABLE_IPV4
+
+        if (addrType != pcbType) {
+            lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
+            goto exit;
+        }
+    }
+#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
+
+exit:
+    return (lRetval);
 }
 
 SenderInfo *RawEndPoint::GetSenderInfo(Weave::System::PacketBuffer *buf)
@@ -686,15 +773,16 @@ SenderInfo *RawEndPoint::GetSenderInfo(Weave::System::PacketBuffer *buf)
  * - this fn() runs in the LwIP thread (and the lock has already been taken)
  * - SetICMPFilter() runs in the Inet thread.
  */
-#if LWIP_VERSION_MAJOR > 1
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 u8_t RawEndPoint::LwIPReceiveRawMessage(void *arg, struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *addr)
-#else // LWIP_VERSION_MAJOR <= 1
+#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
 u8_t RawEndPoint::LwIPReceiveRawMessage(void *arg, struct raw_pcb *pcb, struct pbuf *p, ip_addr_t *addr)
-#endif // LWIP_VERSION_MAJOR <= 1
+#endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 {
-    RawEndPoint *ep = (RawEndPoint *)arg;
-    Weave::System::PacketBuffer *buf = (Weave::System::PacketBuffer *)p;
-    uint8_t enqueue = 1;
+    RawEndPoint*            ep              = static_cast<RawEndPoint*>(arg);
+    PacketBuffer*           buf             = reinterpret_cast<PacketBuffer*>(static_cast<void*>(p));
+    Weave::System::Layer&   lSystemLayer    = ep->SystemLayer();
+    uint8_t                 enqueue         = 1;
 
     //Filtering based on the saved ICMP6 types (the only protocol currently supported.)
     if ((ep->IPVer == kIPVersion_6) &&
@@ -719,14 +807,13 @@ u8_t RawEndPoint::LwIPReceiveRawMessage(void *arg, struct raw_pcb *pcb, struct p
             }
         }
     }
+
     if (enqueue)
     {
-        Weave::System::Layer& lSystemLayer = ep->SystemLayer();
-
         buf->SetStart(buf->Start() + ip_current_header_tot_len());
         SenderInfo *senderInfo = GetSenderInfo(buf);
 
-#if LWIP_VERSION_MAJOR > 1
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
         senderInfo->Address = IPAddress::FromLwIPAddr(*addr);
 #else // LWIP_VERSION_MAJOR <= 1
         if (PCB_ISIPV6(pcb))
@@ -742,51 +829,46 @@ u8_t RawEndPoint::LwIPReceiveRawMessage(void *arg, struct raw_pcb *pcb, struct p
 #endif // LWIP_VERSION_MAJOR <= 1
 
         if (lSystemLayer.PostEvent(*ep, kInetEvent_RawDataReceived, (uintptr_t)buf) != INET_NO_ERROR)
-            Weave::System::PacketBuffer::Free(buf);
+            PacketBuffer::Free(buf);
     }
+
     return enqueue;
 }
 
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
-
-INET_ERROR RawEndPoint::GetSocket(IPAddressType addrType)
+INET_ERROR RawEndPoint::GetSocket(IPAddressType aAddressType)
 {
-    int sock, pf, proto;
+    INET_ERROR lRetval = INET_NO_ERROR;
+    const int lType = (SOCK_RAW | SOCK_FLAGS);
+    int lProtocol;
 
-    if (mState == kState_Closed)
+    switch (aAddressType)
     {
-        switch (addrType)
-        {
-        case kIPAddressType_IPv6:
-            pf = PF_INET6;
-            proto = IPPROTO_ICMPV6;
-            break;
+    case kIPAddressType_IPv6:
+        lProtocol = IPPROTO_ICMPV6;
+        break;
 
 #if INET_CONFIG_ENABLE_IPV4
-        case kIPAddressType_IPv4:
-            pf = PF_INET;
-            proto = IPPROTO_ICMP;
-            break;
+    case kIPAddressType_IPv4:
+        lProtocol = IPPROTO_ICMP;
+        break;
 #endif // INET_CONFIG_ENABLE_IPV4
 
-        default:
-            return INET_ERROR_WRONG_ADDRESS_TYPE;
-        }
-
-        sock = ::socket(pf, SOCK_RAW | SOCK_FLAGS, proto);
-        if (sock == -1)
-            return Weave::System::MapErrorPOSIX(errno);
-
-        mSocket = sock;
-        mAddrType = addrType;
+    default:
+        lRetval = INET_ERROR_WRONG_ADDRESS_TYPE;
+        goto exit;
     }
 
-    return INET_NO_ERROR;
+    lRetval = IPEndPointBasis::GetSocket(aAddressType, lType, lProtocol);
+    SuccessOrExit(lRetval);
+
+exit:
+    return (lRetval);
 }
 
-SocketEvents RawEndPoint::PrepareIO()
+SocketEvents RawEndPoint::PrepareIO(void)
 {
     SocketEvents res;
 
@@ -796,7 +878,7 @@ SocketEvents RawEndPoint::PrepareIO()
     return res;
 }
 
-void RawEndPoint::HandlePendingIO()
+void RawEndPoint::HandlePendingIO(void)
 {
     INET_ERROR err = INET_NO_ERROR;
 
@@ -850,7 +932,7 @@ void RawEndPoint::HandlePendingIO()
             OnMessageReceived(this, buf, senderAddr); //FIXME
         else
         {
-            Weave::System::PacketBuffer::Free(buf);
+            PacketBuffer::Free(buf);
             if (OnReceiveError != NULL)
                 OnReceiveError(this, err, senderAddr); //FIXME
         }

--- a/src/inet/RawEndPoint.h
+++ b/src/inet/RawEndPoint.h
@@ -1,5 +1,6 @@
 /*
  *
+ *    Copyright (c) 2018 Google LLC
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -20,15 +21,17 @@
  *    @file
  *      This header file defines the <tt>nl::Inet::RawEndPoint</tt>
  *      class, where the Nest Inet Layer encapsulates methods for
- *      interacting with PF_RAW sockets (on Linux and BSD-derived
- *      systems) or LwIP raw protocol control blocks, as the system
- *      is configured accordingly.
+ *      interacting with IP network endpoints (SOCK_RAW sockets
+ *      on Linux and BSD-derived systems) or LwIP raw protocol
+ *      control blocks, as the system is configured accordingly.
  */
 
 #ifndef RAWENDPOINT_H
 #define RAWENDPOINT_H
 
-#include <InetLayer/EndPointBasis.h>
+#include <InetLayer/IPEndPointBasis.h>
+#include <InetLayer/IPAddress.h>
+
 #include <SystemLayer/SystemPacketBuffer.h>
 
 namespace nl {
@@ -38,14 +41,14 @@ class InetLayer;
 class SenderInfo;
 
 /**
- * @brief   Objects of this class represent raw IP protocol endpoints.
+ * @brief   Objects of this class represent raw IP network endpoints.
  *
  * @details
- *  Nest Inet Layer encapsulates methods for interacting with PF_RAW
- *  sockets (on Linux and BSD-derived systems) or LwIP raw protocol control
- *  blocks, as the system is configured accordingly.
+ *  Nest Inet Layer encapsulates methods for interacting with IP network
+ *  endpoints (SOCK_RAW sockets on Linux and BSD-derived systems) or LwIP
+ *  raw protocol control blocks, as the system is configured accordingly.
  */
-class NL_DLL_EXPORT RawEndPoint : public EndPointBasis
+class NL_DLL_EXPORT RawEndPoint : public IPEndPointBasis
 {
     friend class InetLayer;
 
@@ -69,29 +72,19 @@ public:
     IPProtocol IPProto; // This data member is read-only
 
     /**
-     * @brief   Basic dynamic state of the underlying endpoint.
-     *
-     * @details
-     *  Objects are initialized in the "closed" state, proceed to the "bound"
-     *  state after binding to a local interface address, then proceed to the
-     *  "listening" state when they have continuations registered for handling
-     *  events for reception of ICMP messages.
-     */
-    enum {
-        kState_Closed = kBasisState_Closed, /**< Endpoint initialized, but not bound. */
-        kState_Bound,                       /**< Endpoint bound, but not listening. */
-        kState_Listening                    /**< Endpoint receiving ICMP messages. */
-    } mState;
-
-    /**
      * @brief   Bind the endpoint to an interface IP address.
      *
      * @param[in]   addrType    the protocol version of the IP address
      * @param[in]   addr        the IP address (must be an interface address)
+     * @param[in]   intfId      an optional network interface indicator
      *
      * @retval  INET_NO_ERROR               success: endpoint bound to address
      * @retval  INET_ERROR_INCORRECT_STATE  endpoint has been bound previously
      * @retval  INET_NO_MEMORY              insufficient memory for endpoint
+     *
+     * @retval  INET_ERROR_UNKNOWN_INTERFACE
+     *      On some platforms, the optionally specified interface is not
+     *      present.
      *
      * @retval  INET_ERROR_WRONG_PROTOCOL_TYPE
      *      \c addrType does not match \c IPVer.
@@ -108,7 +101,7 @@ public:
      *  On LwIP, this method must not be called with the LwIP stack lock
      *  already acquired.
      */
-    INET_ERROR Bind(IPAddressType addrType, IPAddress addr);
+    INET_ERROR Bind(IPAddressType addrType, IPAddress addr, InterfaceId intfId = INET_NULL_INTERFACEID);
 
     /**
      * @brief   Bind the endpoint to an interface IPv6 link-local address.
@@ -155,32 +148,53 @@ public:
     INET_ERROR Listen(void);
 
     /**
+     *  A synonym for <tt>SendTo(addr, INET_NULL_INTERFACEID, msg,
+     *  sendFlags)</tt>.
+     */
+    INET_ERROR SendTo(IPAddress addr, Weave::System::PacketBuffer *msg, uint16_t sendFlags = 0);
+
+    /**
      * @brief   Send an ICMP message to the specified destination address.
      *
-     * @param[in]   addr    the destination address
-     * @param[in]   msg     the packet buffer containing the ICMP message
+     * @param[in]   addr        the destination IP address
+     * @param[in]   intfId      an optional network interface indicator
+     * @param[in]   msg         the packet buffer containing the UDP message
+     * @param[in]   sendFlags   optional transmit option flags
      *
      * @retval  INET_NO_ERROR       success: \c msg is queued for transmit.
+     * @retval  INET_ERROR_NOT_IMPLEMENTED  system implementation not complete.
      *
      * @retval  INET_ERROR_WRONG_ADDRESS_TYPE
      *      the destination address and the bound interface address do not
      *      have matching protocol versions or address type.
      *
      * @retval  INET_ERROR_MESSAGE_TOO_LONG
-     *      Returned on some platforms, \c msg does not contain the whole ICMP
-     *      message.
+     *      \c msg does not contain the whole ICMP message.
      *
      * @retval  INET_ERROR_OUTBOUND_MESSAGE_TRUNCATED
-     *      Returned on some platforms, only a truncated portion of \c msg was
-     *      queued for transmit.
+     *      On some platforms, only a truncated portion of \c msg was queued
+     *      for transmit.
      *
      * @retval  other                   another system or platform error
      *
      * @details
-     *      Sends the ICMP message if possible. Always calls
-     *      <tt>Weave::System::PacketBuffer::Free</tt> on behalf of the caller.
+     *      If possible, then this method sends the ICMP message \c msg to the
+     *      destination \c addr with the transmit option flags encoded
+     *      in \c sendFlags.
+     *
+     *      Where <tt>(sendFlags & kSendFlag_RetainBuffer) != 0</tt>, calls
+     *      <tt>Weave::System::PacketBuffer::Free</tt> on behalf of the caller, otherwise this
+     *      method deep-copies \c msg into a fresh object, and queues that for
+     *      transmission, leaving the original \c msg available after return.
      */
-    INET_ERROR SendTo(IPAddress addr, Weave::System::PacketBuffer *msg);
+    INET_ERROR SendTo(IPAddress addr, InterfaceId intfId, Weave::System::PacketBuffer *msg, uint16_t sendFlags = 0);
+
+    /**
+     * Get the bound interface on this endpoint.
+     *
+     * @return InterfaceId   The bound interface id.
+     */
+    InterfaceId GetBoundInterface(void);
 
     /**
      * @brief   Set the ICMP6 filter parameters in the network stack.
@@ -204,13 +218,16 @@ public:
     /**
      * @brief   Bind the endpoint to a network interface.
      *
-     * @param[in]   intf    indicator of the network interface.
+     * @param[in]   addrType    the protocol version of the IP address.
+	 *
+     * @param[in]   intf        indicator of the network interface.
      *
      * @retval  INET_NO_ERROR               success: endpoint bound to address
      * @retval  INET_NO_MEMORY              insufficient memory for endpoint
+     * @retval  INET_ERROR_NOT_IMPLEMENTED  system implementation not complete.
      *
      * @retval  INET_ERROR_UNKNOWN_INTERFACE
-     *      On LwIP systems, the interface is not present.
+     *      On some platforms, the interface is not present.
      *
      * @retval  other                   another system or platform error
      *
@@ -220,7 +237,19 @@ public:
      *  On LwIP, this method must not be called with the LwIP stack lock
      *  already acquired.
      */
-    INET_ERROR BindInterface(InterfaceId intf);
+    INET_ERROR BindInterface(IPAddressType addrType, InterfaceId intf);
+
+    /**
+     * @brief   Close the endpoint.
+     *
+     * @details
+     *  If <tt>mState != kState_Closed</tt>, then closes the endpoint, removing
+     *  it from the set of endpoints eligible for communication events.
+     *
+     *  On LwIP systems, this method must not be called with the LwIP stack
+     *  lock already acquired.
+     */
+    void Close(void);
 
     /**
      * @brief   Close the endpoint and recycle its memory.
@@ -230,9 +259,8 @@ public:
      *  <tt>InetLayerBasis::Release</tt> method to return the object to its
      *  memory pool.
      *
-     *  On LwIP systems, an event handler is dispatched to release the object
-     *  within the context of the LwIP thread. This method must not be
-     *  called with the LwIP stack lock already acquired.
+     *  On LwIP systems, this method must not be called with the LwIP stack
+     *  lock already acquired.
      */
     void Free(void);
 
@@ -277,28 +305,27 @@ private:
     static Weave::System::ObjectPool<RawEndPoint, INET_CONFIG_NUM_RAW_ENDPOINTS> sPool;
 
     void Init(InetLayer *inetLayer, IPVersion ipVer, IPProtocol ipProto);
-    void Close(void);
-
-#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
-    INET_ERROR GetSocket(IPAddressType addrType);
-    SocketEvents PrepareIO(void);
-    void HandlePendingIO(void);
-#endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
     uint8_t NumICMPTypes;
     const uint8_t *ICMPTypes;
 
     void HandleDataReceived(Weave::System::PacketBuffer *msg);
-    INET_ERROR GetPCB(void);
+    INET_ERROR GetPCB(IPAddressType addrType);
     static SenderInfo *GetSenderInfo(Weave::System::PacketBuffer *buf);
 
-#if LWIP_VERSION_MAJOR > 1
+#if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
     static u8_t LwIPReceiveRawMessage(void *arg, struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *addr);
-#else // LWIP_VERSION_MAJOR <= 1
+#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
     static u8_t LwIPReceiveRawMessage(void *arg, struct raw_pcb *pcb, struct pbuf *p, ip_addr_t *addr);
-#endif // LWIP_VERSION_MAJOR <= 1
+#endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
+
+#if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
+    INET_ERROR GetSocket(IPAddressType addrType);
+    SocketEvents PrepareIO(void);
+    void HandlePendingIO(void);
+#endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 };
 
 } // namespace Inet

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -54,27 +54,6 @@ class IPPacketInfo;
 
 public:
     /**
-     * @brief   Basic dynamic state of the underlying endpoint.
-     *
-     * @details
-     *  Objects are initialized in the "ready" state, proceed to the "bound"
-     *  state after binding to a local interface address, then proceed to the
-     *  "listening" state when they have continuations registered for handling
-     *  events for reception of UDP messages.
-     *
-     * @note
-     *  The \c kBasisState_Closed state enumeration is mapped to \c kState_Ready for historical binary-compatibility reasons. The
-     *  existing \c kState_Closed exists to identify separately the distinction between "not opened yet" and "previously opened now
-     *  closed" that existed previously in the \c kState_Ready and \c kState_Closed states.
-     */
-    enum {
-        kState_Ready        = kBasisState_Closed,   /**< Endpoint initialized, but not open. */
-        kState_Bound        = 1,                    /**< Endpoint bound, but not listening. */
-        kState_Listening    = 2,                    /**< Endpoint receiving datagrams. */
-        kState_Closed       = 3                     /**< Endpoint closed, ready for release. */
-    } mState;
-
-    /**
      * @brief   Bind the endpoint to an interface IP address.
      *
      * @param[in]   addrType    the protocol version of the IP address
@@ -276,9 +255,9 @@ private:
     static IPPacketInfo *GetPacketInfo(Weave::System::PacketBuffer *buf);
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
     static void LwIPReceiveUDPMessage(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port);
-#else // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
+#else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5
     static void LwIPReceiveUDPMessage(void *arg, struct udp_pcb *pcb, struct pbuf *p, ip_addr_t *addr, u16_t port);
-#endif // LWIP_VERSION_MAJOR <= 1 || LWIP_VERSION_MINOR >= 5
+#endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS

--- a/src/test-apps/TestInetEndPoint.cpp
+++ b/src/test-apps/TestInetEndPoint.cpp
@@ -321,9 +321,9 @@ static void TestInetEndPoint(nlTestSuite *inSuite, void *inContext)
 #endif // INET_CONFIG_ENABLE_IPV4
     err = testRaw6EP->BindIPv6LinkLocal((InterfaceId)-1, addr);
     NL_TEST_ASSERT(inSuite, err != INET_NO_ERROR);
-    err = testRaw6EP->BindInterface((InterfaceId)-1);
+    err = testRaw6EP->BindInterface(kIPAddressType_Unknown, (InterfaceId)-1);
     NL_TEST_ASSERT(inSuite, err != INET_NO_ERROR);
-    err = testRaw6EP->BindInterface(INET_NULL_INTERFACEID);
+    err = testRaw6EP->BindInterface(kIPAddressType_Unknown, INET_NULL_INTERFACEID);
     NL_TEST_ASSERT(inSuite, err != INET_NO_ERROR);
 
     // A bind should succeed with appropriate permissions but will

--- a/src/test-apps/TestInetLayer.cpp
+++ b/src/test-apps/TestInetLayer.cpp
@@ -306,7 +306,7 @@ void StartTest()
             InterfaceId intfId;
             err = InterfaceNameToId(IntfFilterName, intfId);
             FAIL_ERROR(err, "InterfaceNameToId failed");
-            err = Raw6EP->BindInterface(intfId);
+            err = Raw6EP->BindInterface(kIPAddressType_IPv6, intfId);
             FAIL_ERROR(err, "RawEndPoint::BindInterface (IPv6) failed");
         }
         Raw6EP->OnMessageReceived = HandleRawMessageReceived;
@@ -322,7 +322,7 @@ void StartTest()
             InterfaceId intfId;
             err = InterfaceNameToId(IntfFilterName, intfId);
             FAIL_ERROR(err, "InterfaceNameToId failed");
-            err = Raw4EP->BindInterface(intfId);
+            err = Raw4EP->BindInterface(kIPAddressType_IPv4, intfId);
             FAIL_ERROR(err, "RawEndPoint::BindInterface (IPv4) failed");
         }
         Raw4EP->OnMessageReceived = HandleRawMessageReceived;


### PR DESCRIPTION
This is the second round of refactoring of common IP datagram endpoint implementation, this time mostly focusing on rebasing the raw IP endpoint implementation atop of the common implementation and harmonizing, where possible, the raw IP and UDP endpoint implementations.