### PR TITLE
Third Round of Refactoring Raw and UDP End Points

### DIFF
--- a/src/inet/IPEndPointBasis.h
+++ b/src/inet/IPEndPointBasis.h
@@ -86,6 +86,39 @@ public:
         kSendFlag_RetainBuffer = 0x0040
     };
 
+    /**
+     * @brief   Type of message text reception event handling function.
+     *
+     * @param[in]   endPoint    The endpoint associated with the event.
+     * @param[in]   msg         The message text received.
+     * @param[in]   senderAddr  The IP address of the sender.
+     *
+     * @details
+     *  Provide a function of this type to the \c OnMessageReceived delegate
+     *  member to process message text reception events on \c endPoint where
+     *  \c msg is the message text received from the sender at \c senderAddr.
+     */
+    typedef void (*OnMessageReceivedFunct)(IPEndPointBasis *endPoint, Weave::System::PacketBuffer *msg, const IPPacketInfo *pktInfo);
+
+    /** The endpoint's message reception event handling function delegate. */
+    OnMessageReceivedFunct OnMessageReceived;
+
+    /**
+     * @brief   Type of reception error event handling function.
+     *
+     * @param[in]   endPoint    The endpoint associated with the event.
+     * @param[in]   err         The reason for the error.
+     *
+     * @details
+     *  Provide a function of this type to the \c OnReceiveError delegate
+     *  member to process reception error events on \c endPoint. The \c err
+     *  argument provides specific detail about the type of the error.
+     */
+    typedef void (*OnReceiveErrorFunct)(IPEndPointBasis *endPoint, INET_ERROR err, const IPPacketInfo *pktInfo);
+
+    /** The endpoint's receive error event handling function delegate. */
+    OnReceiveErrorFunct OnReceiveError;
+
 protected:
     void Init(InetLayer *aInetLayer);
 
@@ -107,6 +140,11 @@ public:
 
             return (lRetval);
     }
+
+protected:
+    void HandleDataReceived(Weave::System::PacketBuffer *aBuffer);
+
+    static IPPacketInfo *GetPacketInfo(Weave::System::PacketBuffer *buf);
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS
@@ -117,7 +155,8 @@ protected:
     INET_ERROR BindInterface(IPAddressType aAddressType, InterfaceId aInterfaceId);
     INET_ERROR SendTo(const IPAddress &aAddress, uint16_t aPort, InterfaceId aInterfaceId, Weave::System::PacketBuffer *aBuffer, uint16_t aSendFlags);
     INET_ERROR GetSocket(IPAddressType aAddressType, int aType, int aProtocol);
-    INET_ERROR HandlePendingIO(uint16_t aPort, Weave::System::PacketBuffer *&aBuffer, IPPacketInfo &aPacketInfo);
+    SocketEvents PrepareIO(void);
+    void HandlePendingIO(uint16_t aPort);
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS
 
 private:

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -433,7 +433,7 @@ inline void InetLayer::WakeSelect(void)
  *
  *   @warning
  *     Do not alter the contents of this class without first reading and understanding
- *     the code/comments in UDPEndPoint::GetPacketInfo().
+ *     the code/comments in IPEndPointBasis::GetPacketInfo().
  */
 class IPPacketInfo
 {

--- a/src/inet/RawEndPoint.h
+++ b/src/inet/RawEndPoint.h
@@ -38,7 +38,7 @@ namespace nl {
 namespace Inet {
 
 class InetLayer;
-class SenderInfo;
+class IPPacketInfo;
 
 /**
  * @brief   Objects of this class represent raw IP network endpoints.
@@ -264,39 +264,6 @@ public:
      */
     void Free(void);
 
-    /**
-     * @brief   Type of message text reception event handling function.
-     *
-     * @param[in]   endPoint    The raw endpoint associated with the event.
-     * @param[in]   msg         The message text received.
-     * @param[in]   senderAddr  The IP address of the sender.
-     *
-     * @details
-     *  Provide a function of this type to the \c OnMessageReceived delegate
-     *  member to process message text reception events on \c endPoint where
-     *  \c msg is the message text received from the sender at \c senderAddr.
-     */
-    typedef void (*OnMessageReceivedFunct)(RawEndPoint *endPoint, Weave::System::PacketBuffer *msg, IPAddress senderAddr);
-
-    /** The endpoint's message reception event handling function delegate. */
-    OnMessageReceivedFunct OnMessageReceived;
-
-    /**
-     * @brief   Type of reception error event handling function.
-     *
-     * @param[in]   endPoint    The raw endpoint associated with the event.
-     * @param[in]   err         The reason for the error.
-     *
-     * @details
-     *  Provide a function of this type to the \c OnReceiveError delegate
-     *  member to process reception error events on \c endPoint. The \c err
-     *  argument provides specific detail about the type of the error.
-     */
-    typedef void (*OnReceiveErrorFunct)(RawEndPoint *endPoint, INET_ERROR err, IPAddress senderAddr);
-
-    /** The endpoint's receive error event handling function delegate. */
-    OnReceiveErrorFunct OnReceiveError;
-
 private:
     RawEndPoint(void);                          // not defined
     RawEndPoint(const RawEndPoint&);            // not defined
@@ -312,7 +279,6 @@ private:
 
     void HandleDataReceived(Weave::System::PacketBuffer *msg);
     INET_ERROR GetPCB(IPAddressType addrType);
-    static SenderInfo *GetSenderInfo(Weave::System::PacketBuffer *buf);
 
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
     static u8_t LwIPReceiveRawMessage(void *arg, struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *addr);

--- a/src/inet/TunEndPoint.h
+++ b/src/inet/TunEndPoint.h
@@ -204,7 +204,6 @@ private:
     INET_ERROR TunDevOpen(void);
     void HandleDataReceived(Weave::System::PacketBuffer *msg);
 
-    static IPPacketInfo *GetPacketInfo(Weave::System::PacketBuffer *buf);
     static err_t LwIPPostToInetEventQ(struct netif *netif, struct pbuf *p);
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
 #if LWIP_IPV4

--- a/src/inet/UDPEndPoint.h
+++ b/src/inet/UDPEndPoint.h
@@ -203,43 +203,6 @@ public:
      */
     void Free(void);
 
-    /**
-     * @brief   Type of message text reception event handling function.
-     *
-     * @param[in]   endPoint    The UDP endpoint associated with the event.
-     * @param[in]   msg         The message text received.
-     * @param[in]   pktInfo     The ancillary packet information.
-     *
-     * @details
-     *  Provide a function of this type to the \c OnMessageReceived delegate
-     *  member to process message text reception events on \c endPoint where
-     *  \c msg is the message text and \c pktInfo is the ancillary packet
-     *  information for it.
-     */
-    typedef void (*OnMessageReceivedFunct)(UDPEndPoint *endPoint, Weave::System::PacketBuffer *msg, const IPPacketInfo *pktInfo);
-
-    /** The endpoint's message reception event handling function delegate. */
-    OnMessageReceivedFunct OnMessageReceived;
-
-    /**
-     * @brief   Type of reception error event handling function.
-     *
-     * @param[in]   endPoint    The raw endpoint associated with the event.
-     * @param[in]   err         The reason for the error.
-     * @param[in]   pktInfo     The ancillary packet information.
-     *
-     * @details
-     *  Provide a function of this type to the \c OnReceiveError delegate
-     *  member to process reception acceptance error events on \c endPoint. The
-     *  \c err argument provides specific detail about the type of the error,
-     *  and \c pktInfo is the ancillary packet information associated with the
-     *  reception event.
-     */
-    typedef void (*OnReceiveErrorFunct)(UDPEndPoint *endPoint, INET_ERROR err, const IPPacketInfo *pktInfo);
-
-    /** The endpoint's receive error event handling function delegate. */
-    OnReceiveErrorFunct OnReceiveError;
-
 private:
     UDPEndPoint(void);                                  // not defined
     UDPEndPoint(const UDPEndPoint&);                    // not defined
@@ -252,7 +215,6 @@ private:
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
     void HandleDataReceived(Weave::System::PacketBuffer *msg);
     INET_ERROR GetPCB(IPAddressType addrType4);
-    static IPPacketInfo *GetPacketInfo(Weave::System::PacketBuffer *buf);
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
     static void LwIPReceiveUDPMessage(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port);
 #else // LWIP_VERSION_MAJOR <= 1 && LWIP_VERSION_MINOR < 5

--- a/src/lib/core/WeaveMessageLayer.cpp
+++ b/src/lib/core/WeaveMessageLayer.cpp
@@ -1927,8 +1927,8 @@ WEAVE_ERROR WeaveMessageLayer::RefreshEndpoints()
             WeaveBindLog("Listening on general purpose IPv4 UDP endpoint");
 
             mIPv4UDP->AppState = this;
-            mIPv4UDP->OnMessageReceived = HandleUDPMessage;
-            mIPv4UDP->OnReceiveError = HandleUDPReceiveError;
+            mIPv4UDP->OnMessageReceived = reinterpret_cast<IPEndPointBasis::OnMessageReceivedFunct>(HandleUDPMessage);
+            mIPv4UDP->OnReceiveError = reinterpret_cast<IPEndPointBasis::OnReceiveErrorFunct>(HandleUDPReceiveError);
             res = mIPv4UDP->Listen();
             if (res != WEAVE_NO_ERROR)
                 goto exit;
@@ -1961,8 +1961,8 @@ WEAVE_ERROR WeaveMessageLayer::RefreshEndpoints()
             WeaveBindLog("Listening on general purpose IPv6 UDP endpoint");
 
             mIPv6UDP->AppState = this;
-            mIPv6UDP->OnMessageReceived = HandleUDPMessage;
-            mIPv6UDP->OnReceiveError = HandleUDPReceiveError;
+            mIPv6UDP->OnMessageReceived = reinterpret_cast<IPEndPointBasis::OnMessageReceivedFunct>(HandleUDPMessage);
+            mIPv6UDP->OnReceiveError = reinterpret_cast<IPEndPointBasis::OnReceiveErrorFunct>(HandleUDPReceiveError);
             res = mIPv6UDP->Listen();
             if (res != WEAVE_NO_ERROR)
                 goto exit;
@@ -2000,8 +2000,8 @@ WEAVE_ERROR WeaveMessageLayer::RefreshEndpoints()
 
             // Enable reception of incoming messages.
             mIPv6UDPMulticastRcv->AppState = this;
-            mIPv6UDPMulticastRcv->OnMessageReceived = HandleUDPMessage;
-            mIPv6UDPMulticastRcv->OnReceiveError = HandleUDPReceiveError;
+            mIPv6UDPMulticastRcv->OnMessageReceived = reinterpret_cast<IPEndPointBasis::OnMessageReceivedFunct>(HandleUDPMessage);
+            mIPv6UDPMulticastRcv->OnReceiveError = reinterpret_cast<IPEndPointBasis::OnReceiveErrorFunct>(HandleUDPReceiveError);
             res = mIPv6UDPMulticastRcv->Listen();
             if (res != WEAVE_NO_ERROR)
                 goto exit;
@@ -2081,8 +2081,8 @@ WEAVE_ERROR WeaveMessageLayer::RefreshEndpoints()
                 if (epErr == WEAVE_NO_ERROR)
                 {
                     ep->AppState = this;
-                    ep->OnMessageReceived = HandleUDPMessage;
-                    ep->OnReceiveError = HandleUDPReceiveError;
+                    ep->OnMessageReceived = reinterpret_cast<IPEndPointBasis::OnMessageReceivedFunct>(HandleUDPMessage);
+                    ep->OnReceiveError = reinterpret_cast<IPEndPointBasis::OnReceiveErrorFunct>(HandleUDPReceiveError);
                     epErr = ep->Listen();
                 }
 

--- a/src/ra-daemon/RADaemon.h
+++ b/src/ra-daemon/RADaemon.h
@@ -79,10 +79,10 @@ private:
     };
 
     static void MulticastRA(InetLayer* inet, void* appState, INET_ERROR err);
-    static void HandleMessageReceived2(RawEndPoint *RawEPListen, PacketBuffer *msg, IPAddress senderAddr);
-    static void HandleReceiveError2(RawEndPoint *endPoint, INET_ERROR err, IPAddress senderAddr);
-    static void HandleMessageReceived(RawEndPoint *RawEPListen, PacketBuffer *msg, IPAddress senderAddr);
-    static void HandleReceiveError(RawEndPoint *endPoint, INET_ERROR err, IPAddress senderAddr);
+    static void HandleMessageReceived2(RawEndPoint *RawEPListen, PacketBuffer *msg, const IPPacketInfo *pktInfo);
+    static void HandleReceiveError2(RawEndPoint *endPoint, INET_ERROR err, const IPPacketInfo *pktInfo);
+    static void HandleMessageReceived(RawEndPoint *RawEPListen, PacketBuffer *msg, const IPPacketInfo *pktInfo);
+    static void HandleReceiveError(RawEndPoint *endPoint, INET_ERROR err, const IPPacketInfo *pktInfo);
     static void BuildRA(PacketBuffer *RAPacket, LinkInformation *linkInfo, const IPAddress &destAddr);
     static uint16_t CalculateChecksum(uint16_t *startpos, uint16_t checklen);
     static void MulticastPeriodicRA(Weave::System::Layer* aSystemLayer, void* aAppState, Weave::System::Error aError);

--- a/src/test-apps/TestInetLayer.cpp
+++ b/src/test-apps/TestInetLayer.cpp
@@ -309,8 +309,8 @@ void StartTest()
             err = Raw6EP->BindInterface(kIPAddressType_IPv6, intfId);
             FAIL_ERROR(err, "RawEndPoint::BindInterface (IPv6) failed");
         }
-        Raw6EP->OnMessageReceived = HandleRawMessageReceived;
-        Raw6EP->OnReceiveError = HandleRawReceiveError;
+        Raw6EP->OnMessageReceived = reinterpret_cast<IPEndPointBasis::OnMessageReceivedFunct>(HandleRawMessageReceived);
+        Raw6EP->OnReceiveError = reinterpret_cast<IPEndPointBasis::OnReceiveErrorFunct>(HandleRawReceiveError);
     }
 #if INET_CONFIG_ENABLE_IPV4
     else if (UseRaw4)
@@ -325,8 +325,8 @@ void StartTest()
             err = Raw4EP->BindInterface(kIPAddressType_IPv4, intfId);
             FAIL_ERROR(err, "RawEndPoint::BindInterface (IPv4) failed");
         }
-        Raw4EP->OnMessageReceived = HandleRawMessageReceived;
-        Raw4EP->OnReceiveError = HandleRawReceiveError;
+        Raw4EP->OnMessageReceived = reinterpret_cast<IPEndPointBasis::OnMessageReceivedFunct>(HandleRawMessageReceived);
+        Raw4EP->OnReceiveError = reinterpret_cast<IPEndPointBasis::OnReceiveErrorFunct>(HandleRawReceiveError);
     }
 #endif // INET_CONFIG_ENABLE_IPV4
     else if (!UseTCP)
@@ -341,8 +341,8 @@ void StartTest()
             err = UDPEP->BindInterface(kIPAddressType_IPv6, intfId);
             FAIL_ERROR(err, "RawEndPoint::BindInterface (IPv4) failed");
         }
-        UDPEP->OnMessageReceived = HandleUDPMessageReceived;
-        UDPEP->OnReceiveError = HandleUDPReceiveError;
+        UDPEP->OnMessageReceived = reinterpret_cast<IPEndPointBasis::OnMessageReceivedFunct>(HandleUDPMessageReceived);
+        UDPEP->OnReceiveError = reinterpret_cast<IPEndPointBasis::OnReceiveErrorFunct>(HandleUDPReceiveError);
     }
 
     if (Listen)


### PR DESCRIPTION
This is the third round of refactoring of common IP datagram endpoint implementation, this time mostly focusing on harmonizing the OnMessageReceived callback function API between the two end points, passing IPPacketInfo as the third parameter for both.