### PR TITLE
Warn in Test Output about Skipped Happy Tests Due to LwIP Conifiguration

### DIFF
--- a/src/test-apps/happy/tests/service/pairing/test_weave_pairing_01.py
+++ b/src/test-apps/happy/tests/service/pairing/test_weave_pairing_01.py
@@ -135,6 +135,7 @@ class test_weave_pairing_01(unittest.TestCase):
     def test_weave_pairing(self):
         # TODO: Once LwIP bugs are fix, enable this test on LwIP
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
+            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")            
             return
 
         # topology has nodes: ThreadNode, BorderRouter, onhub and NestService instance

--- a/src/test-apps/happy/tests/standalone/inet/test_weave_inet_01.py
+++ b/src/test-apps/happy/tests/standalone/inet/test_weave_inet_01.py
@@ -74,6 +74,7 @@ class test_weave_inet_01(unittest.TestCase):
     def test_weave_inet(self):
         # TODO: Once LwIP bugs are fix, enable this test on LwIP
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
+            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")
             return
 
         options = happy.HappyNodeList.option()

--- a/src/test-apps/happy/tests/standalone/pairing/test_weave_pairing_01.py
+++ b/src/test-apps/happy/tests/standalone/pairing/test_weave_pairing_01.py
@@ -70,6 +70,7 @@ class test_weave_pairing_01(unittest.TestCase):
     def test_weave_pairing(self):
         # TODO: Once LwIP bugs are fix, enable this test on LwIP
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
+            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")            
             return
 
         # topology has nodes: node01(mobile), node02(device) and node03

--- a/src/test-apps/happy/tests/standalone/servicedir/test_service_directory_01.py
+++ b/src/test-apps/happy/tests/standalone/servicedir/test_service_directory_01.py
@@ -76,6 +76,7 @@ class test_service_directory_01(unittest.TestCase):
     def test_service_directory(self):
         # TODO: Once LwIP bugs are fix, enable this test on LwIP
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
+            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")            
             return
 
         num_tests = 0

--- a/src/test-apps/happy/tests/standalone/tunnel/test_weave_tunnel_01.py
+++ b/src/test-apps/happy/tests/standalone/tunnel/test_weave_tunnel_01.py
@@ -76,6 +76,7 @@ class test_weave_tunnel_01(unittest.TestCase):
     def test_weave_tunnel(self):
         # TODO: Once LwIP bugs are fix, enable this test on LwIP
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
+            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")            
             return
 
         # topology has nodes: ThreadNode, BorderRouter, onhub and cloud

--- a/src/test-apps/happy/tests/standalone/tunnel/test_weave_tunnel_02.py
+++ b/src/test-apps/happy/tests/standalone/tunnel/test_weave_tunnel_02.py
@@ -76,6 +76,7 @@ class test_weave_tunnel_02(unittest.TestCase):
     def test_weave_tunnel(self):
         # TODO: Once LwIP bugs are fix, enable this test on LwIP
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
+            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")            
             return
 
         # topology has nodes: ThreadNode, BorderRouter, onhub and cloud

--- a/src/test-apps/happy/tests/standalone/tunnel/test_weave_tunnel_03.py
+++ b/src/test-apps/happy/tests/standalone/tunnel/test_weave_tunnel_03.py
@@ -69,6 +69,7 @@ class test_weave_tunnel_03(unittest.TestCase):
     def test_weave_tunnel(self):
         # TODO: Once LwIP bugs are fixed, enable this test on LwIP
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
+            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")        
             return
 
         # topology has nodes: ThreadNode, BorderRouter, onhub and cloud

--- a/src/test-apps/happy/tests/standalone/tunnel/test_weave_tunnel_04.py
+++ b/src/test-apps/happy/tests/standalone/tunnel/test_weave_tunnel_04.py
@@ -77,6 +77,7 @@ class test_weave_tunnel_04(unittest.TestCase):
     def test_weave_tunnel(self):
         # TODO: Once LwIP bugs are fix, enable this test on LwIP
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
+            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")
             return
 
         # topology has nodes: ThreadNode, BorderRouter, onhub and cloud

--- a/src/test-apps/happy/tests/standalone/tunnel/test_weave_tunnel_faults.py
+++ b/src/test-apps/happy/tests/standalone/tunnel/test_weave_tunnel_faults.py
@@ -99,6 +99,7 @@ class test_weave_tunnel_faults(unittest.TestCase):
     def test_weave_tunnel(self):
         # TODO: Once LwIP bugs are fix, enable this test on LwIP
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
+            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")
             return
 
         # topology has nodes: ThreadNode, BorderRouter, onhub and cloud

--- a/src/test-apps/happy/tests/standalone/wrmp/test_weave_wrmp_01.py
+++ b/src/test-apps/happy/tests/standalone/wrmp/test_weave_wrmp_01.py
@@ -78,6 +78,7 @@ class test_weave_wrmp(unittest.TestCase):
     def test_weave_wrmp_among_all_nodes(self):
         # TODO: Once LwIP bugs are fix, enable this test on LwIP
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
+            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")            
             return
 
         options = happy.HappyNodeList.option()


### PR DESCRIPTION
To date, there are a number of functional tests that are intentionally and programmatically skipped when Weave is configured for LwIP. Make these omissions more clear by emitted red-highlighted warnings in test log output.