### PR TITLE
Add Set of Upstream Patches to Get Generalized IPv6 Multicast Working in LwIP

### DIFF
--- a/third_party/lwip/repo/lwip/src/api/if.c
+++ b/third_party/lwip/repo/lwip/src/api/if.c
@@ -1,0 +1,77 @@
+/**
+ * @file
+ * Interface Identification APIs from:
+ *              RFC 3493: Basic Socket Interface Extensions for IPv6
+ *                  Section 4: Interface Identification
+ */
+
+/*
+ * Copyright (c) 2017 Joel Cunningham <joel.cunningham@me.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modificat
+ion,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO E
+VENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREM
+ENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARIS
+ING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ * Author: Joel Cunningham <joel.cunningham@me.com>
+ *
+ */
+#include "lwip/opt.h"
+
+#if LWIP_SOCKET
+
+#include "lwip/netifapi.h"
+
+char *
+lwip_if_indextoname(unsigned ifindex, char *ifname)
+{
+  err_t err;
+  if (ifindex > 0xff) {
+    return NULL;
+  }
+  
+  err = netifapi_netif_index_to_name((u8_t)ifindex, ifname);
+  if (!err && ifname[0] != '\0') {
+    return ifname;
+  }
+  return NULL;
+}
+
+unsigned int
+lwip_if_nametoindex(const char *ifname)
+{
+  err_t err;
+  u8_t index;
+  
+  err = netifapi_netif_name_to_index(ifname, &index);
+  if (!err) {
+    return index;
+  }
+  return 0; /* invalid index */
+}
+
+#endif /* LWIP_SOCKET */

--- a/third_party/lwip/repo/lwip/src/api/netifapi.c
+++ b/third_party/lwip/repo/lwip/src/api/netifapi.c
@@ -46,6 +46,8 @@
 #include "lwip/memp.h"
 #include "lwip/priv/tcpip_priv.h"
 
+#include <string.h> /* strncpy */
+
 #define NETIFAPI_VAR_REF(name)      API_VAR_REF(name)
 #define NETIFAPI_VAR_DECLARE(name)  API_VAR_DECLARE(struct netifapi_msg, name)
 #define NETIFAPI_VAR_ALLOC(name)    API_VAR_ALLOC(struct netifapi_msg, MEMP_NETIFAPI_MSG, name, ERR_MEM)
@@ -94,6 +96,37 @@ netifapi_do_netif_set_addr(struct tcpip_api_call_data *m)
   return ERR_OK;
 }
 #endif /* LWIP_IPV4 */
+
+/**
+* Call netif_name_to_index() inside the tcpip_thread context.
+*/
+static err_t
+netifapi_do_name_to_index(struct tcpip_api_call_data *m)
+{
+  /* cast through void* to silence alignment warnings.
+   * We know it works because the structs have been instantiated as struct netifapi_msg */
+  struct netifapi_msg *msg = (struct netifapi_msg*)(void*)m;
+
+  msg->msg.ifs.index = netif_name_to_index(msg->msg.ifs.name);
+  return ERR_OK;
+}
+
+/**
+* Call netif_index_to_name() inside the tcpip_thread context.
+*/
+static err_t
+netifapi_do_index_to_name(struct tcpip_api_call_data *m)
+{
+  /* cast through void* to silence alignment warnings.
+   * We know it works because the structs have been instantiated as struct netifapi_msg */
+  struct netifapi_msg *msg = (struct netifapi_msg*)(void*)m;
+
+  if (!netif_index_to_name(msg->msg.ifs.index, msg->msg.ifs.name)) {
+    /* return failure via empty name */
+    msg->msg.ifs.name[0] = '\0';
+  }
+  return ERR_OK;
+}
 
 /**
  * Call the "errtfunc" (or the "voidfunc" if "errtfunc" is NULL) inside the
@@ -214,6 +247,68 @@ netifapi_netif_common(struct netif *netif, netifapi_void_fn voidfunc,
   NETIFAPI_VAR_REF(msg).msg.common.voidfunc = voidfunc;
   NETIFAPI_VAR_REF(msg).msg.common.errtfunc = errtfunc;
   err = tcpip_api_call(netifapi_do_netif_common, &API_VAR_REF(msg).call);
+  NETIFAPI_VAR_FREE(msg);
+  return err;
+}
+
+/**
+* @ingroup netifapi_netif
+* Call netif_name_to_index() in a thread-safe way by running that function inside the
+* tcpip_thread context.
+*
+* @param name the interface name of the netif
+* @param index output index of the found netif
+*/
+err_t
+netifapi_netif_name_to_index(const char *name, u8_t *index)
+{
+  err_t err;
+  NETIFAPI_VAR_DECLARE(msg);
+  NETIFAPI_VAR_ALLOC(msg);
+
+  *index = 0;
+
+#if LWIP_MPU_COMPATIBLE
+  strncpy(NETIFAPI_VAR_REF(msg).msg.ifs.name, name, IF_NAMESIZE - 1);
+  NETIFAPI_VAR_REF(msg).msg.ifs.name[IF_NAMESIZE - 1] = '\0';
+#else
+  NETIFAPI_VAR_REF(msg).msg.ifs.name = (char *)name;
+#endif /* LWIP_MPU_COMPATIBLE */
+  err = tcpip_api_call(netifapi_do_name_to_index, &API_VAR_REF(msg).call);
+  if (!err) {
+    *index = NETIFAPI_VAR_REF(msg).msg.ifs.index;
+  }
+  NETIFAPI_VAR_FREE(msg);
+  return err;
+}
+
+/**
+* @ingroup netifapi_netif
+* Call netif_index_to_name() in a thread-safe way by running that function inside the
+* tcpip_thread context.
+*
+* @param index the interface index of the netif
+* @param name output name of the found netif, empty '\0' string if netif not found.
+*             name should be of at least IF_NAMESIZE bytes
+*/
+err_t
+netifapi_netif_index_to_name(u8_t index, char *name)
+{
+  err_t err;
+  NETIFAPI_VAR_DECLARE(msg);
+  NETIFAPI_VAR_ALLOC(msg);
+
+  NETIFAPI_VAR_REF(msg).msg.ifs.index = index;
+#if !LWIP_MPU_COMPATIBLE
+  NETIFAPI_VAR_REF(msg).msg.ifs.name = name;
+#endif /* LWIP_MPU_COMPATIBLE */
+  err = tcpip_api_call(netifapi_do_index_to_name, &API_VAR_REF(msg).call);
+#if LWIP_MPU_COMPATIBLE
+  if (!err) {
+    strncpy(name, NETIFAPI_VAR_REF(msg).msg.ifs.name, IF_NAMESIZE - 1);
+    name[IF_NAMESIZE - 1] = '\0';
+  }
+#endif /* LWIP_MPU_COMPATIBLE */
   NETIFAPI_VAR_FREE(msg);
   return err;
 }

--- a/third_party/lwip/repo/lwip/src/api/sockets.c
+++ b/third_party/lwip/repo/lwip/src/api/sockets.c
@@ -2028,7 +2028,7 @@ lwip_getsockopt_impl(int s, int level, int optname, void *optval, socklen_t *opt
       LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IP, IP_TOS) = %d\n",
                   s, *(int *)optval));
       break;
-#if LWIP_MULTICAST_TX_OPTIONS
+#if LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP
     case IP_MULTICAST_TTL:
       LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB(sock, *optlen, u8_t);
       if (NETCONNTYPE_GROUP(netconn_type(sock->conn)) != NETCONN_UDP) {
@@ -2057,7 +2057,7 @@ lwip_getsockopt_impl(int s, int level, int optname, void *optval, socklen_t *opt
       LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IP, IP_MULTICAST_LOOP) = %d\n",
                   s, *(int *)optval));
       break;
-#endif /* LWIP_MULTICAST_TX_OPTIONS */
+#endif /* LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP */
     default:
       LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_getsockopt(%d, IPPROTO_IP, UNIMPL: optname=0x%x, ..)\n",
                   s, optname));
@@ -2397,7 +2397,7 @@ lwip_setsockopt_impl(int s, int level, int optname, const void *optval, socklen_
       LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_setsockopt(%d, IPPROTO_IP, IP_TOS, ..)-> %d\n",
                   s, sock->conn->pcb.ip->tos));
       break;
-#if LWIP_MULTICAST_TX_OPTIONS
+#if LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP
     case IP_MULTICAST_TTL:
       LWIP_SOCKOPT_CHECK_OPTLEN_CONN_PCB_TYPE(sock, optlen, u8_t, NETCONN_UDP);
       udp_set_multicast_ttl(sock->conn->pcb.udp, (u8_t)(*(const u8_t*)optval));
@@ -2418,7 +2418,7 @@ lwip_setsockopt_impl(int s, int level, int optname, const void *optval, socklen_
         udp_setflags(sock->conn->pcb.udp, udp_flags(sock->conn->pcb.udp) & ~UDP_FLAGS_MULTICAST_LOOP);
       }
       break;
-#endif /* LWIP_MULTICAST_TX_OPTIONS */
+#endif /* LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS && LWIP_UDP */
 #if LWIP_IGMP
     case IP_ADD_MEMBERSHIP:
     case IP_DROP_MEMBERSHIP:

--- a/third_party/lwip/repo/lwip/src/api/tcpip.c
+++ b/third_party/lwip/repo/lwip/src/api/tcpip.c
@@ -93,6 +93,8 @@ tcpip_thread(void *arg)
   int finish = 0;
   LWIP_UNUSED_ARG(arg);
 
+  LWIP_MARK_TCPIP_THREAD();
+
   if (tcpip_init_done != NULL) {
     tcpip_init_done(tcpip_init_done_arg);
   }

--- a/third_party/lwip/repo/lwip/src/core/init.c
+++ b/third_party/lwip/repo/lwip/src/core/init.c
@@ -96,7 +96,7 @@ PACK_STRUCT_END
   #error "If you want to use DHCP, you have to define LWIP_UDP=1 in your lwipopts.h"
 #endif
 #if (!LWIP_UDP && LWIP_MULTICAST_TX_OPTIONS)
-  #error "If you want to use IGMP/LWIP_MULTICAST_TX_OPTIONS, you have to define LWIP_UDP=1 in your lwipopts.h"
+#error "If you want to use LWIP_MULTICAST_TX_OPTIONS, you have to define LWIP_UDP=1 and/or LWIP_RAW=1 in your lwipopts.h"
 #endif
 #if (!LWIP_UDP && LWIP_DNS)
   #error "If you want to use DNS, you have to define LWIP_UDP=1 in your lwipopts.h"
@@ -122,9 +122,6 @@ PACK_STRUCT_END
 #endif
 #if (LWIP_IGMP && !LWIP_IPV4)
   #error "IGMP needs LWIP_IPV4 enabled in your lwipopts.h"
-#endif
-#if (LWIP_MULTICAST_TX_OPTIONS && !LWIP_IPV4)
-  #error "LWIP_MULTICAST_TX_OPTIONS needs LWIP_IPV4 enabled in your lwipopts.h"
 #endif
 #if ((LWIP_NETCONN || LWIP_SOCKET) && (MEMP_NUM_TCPIP_MSG_API<=0))
   #error "If you want to use Sequential API, you have to define MEMP_NUM_TCPIP_MSG_API>=1 in your lwipopts.h"

--- a/third_party/lwip/repo/lwip/src/core/init.c
+++ b/third_party/lwip/repo/lwip/src/core/init.c
@@ -95,8 +95,8 @@ PACK_STRUCT_END
 #if (!LWIP_UDP && LWIP_DHCP)
   #error "If you want to use DHCP, you have to define LWIP_UDP=1 in your lwipopts.h"
 #endif
-#if (!LWIP_UDP && LWIP_MULTICAST_TX_OPTIONS)
-#error "If you want to use LWIP_MULTICAST_TX_OPTIONS, you have to define LWIP_UDP=1 and/or LWIP_RAW=1 in your lwipopts.h"
+#if (!LWIP_UDP && !LWIP_RAW && LWIP_MULTICAST_TX_OPTIONS)
+  #error "If you want to use LWIP_MULTICAST_TX_OPTIONS, you have to define LWIP_UDP=1 and/or LWIP_RAW=1 in your lwipopts.h"
 #endif
 #if (!LWIP_UDP && LWIP_DNS)
   #error "If you want to use DNS, you have to define LWIP_UDP=1 in your lwipopts.h"

--- a/third_party/lwip/repo/lwip/src/core/ipv4/autoip.c
+++ b/third_party/lwip/repo/lwip/src/core/ipv4/autoip.c
@@ -105,6 +105,7 @@ static void autoip_start_probing(struct netif *netif);
 void
 autoip_set_struct(struct netif *netif, struct autoip *autoip)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_ASSERT("netif != NULL", netif != NULL);
   LWIP_ASSERT("autoip != NULL", autoip != NULL);
   LWIP_ASSERT("netif already has a struct autoip set",
@@ -256,6 +257,7 @@ autoip_start(struct netif *netif)
   struct autoip* autoip = netif_autoip_data(netif);
   err_t result = ERR_OK;
 
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_ERROR("netif is not up, old style port?", netif_is_up(netif), return ERR_ARG;);
 
   /* Set IP-Address, Netmask and Gateway to 0 to make sure that
@@ -349,6 +351,7 @@ autoip_stop(struct netif *netif)
 {
   struct autoip* autoip = netif_autoip_data(netif);
 
+  LWIP_ASSERT_CORE_LOCKED();
   if (autoip != NULL) {
     autoip->state = AUTOIP_STATE_OFF;
     if (ip4_addr_islinklocal(netif_ip4_addr(netif))) {

--- a/third_party/lwip/repo/lwip/src/core/ipv4/dhcp.c
+++ b/third_party/lwip/repo/lwip/src/core/ipv4/dhcp.c
@@ -675,6 +675,7 @@ dhcp_handle_ack(struct netif *netif)
 void
 dhcp_set_struct(struct netif *netif, struct dhcp *dhcp)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_ASSERT("netif != NULL", netif != NULL);
   LWIP_ASSERT("dhcp != NULL", dhcp != NULL);
   LWIP_ASSERT("netif already has a struct dhcp set", netif_dhcp_data(netif) == NULL);
@@ -696,6 +697,7 @@ dhcp_set_struct(struct netif *netif, struct dhcp *dhcp)
  */
 void dhcp_cleanup(struct netif *netif)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_ASSERT("netif != NULL", netif != NULL);
 
   if (netif_dhcp_data(netif) != NULL) {
@@ -723,6 +725,7 @@ dhcp_start(struct netif *netif)
   struct dhcp *dhcp;
   err_t result;
 
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_ERROR("netif != NULL", (netif != NULL), return ERR_ARG;);
   LWIP_ERROR("netif is not up, old style port?", netif_is_up(netif), return ERR_ARG;);
   dhcp = netif_dhcp_data(netif);
@@ -804,6 +807,7 @@ dhcp_inform(struct netif *netif)
   struct dhcp dhcp;
   err_t result = ERR_OK;
 
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_ERROR("netif != NULL", (netif != NULL), return;);
 
   if (dhcp_inc_pcb_refcount() != ERR_OK) { /* ensure DHCP PCB is allocated */
@@ -1130,6 +1134,8 @@ dhcp_renew(struct netif *netif)
   err_t result;
   u16_t msecs;
   u8_t i;
+
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_DEBUGF(DHCP_DEBUG | LWIP_DBG_TRACE, ("dhcp_renew()\n"));
   dhcp_set_state(dhcp, DHCP_STATE_RENEWING);
 
@@ -1284,6 +1290,7 @@ dhcp_release(struct netif *netif)
   ip_addr_t server_ip_addr;
   u8_t is_dhcp_supplied_address;
 
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_DEBUGF(DHCP_DEBUG | LWIP_DBG_TRACE, ("dhcp_release()\n"));
   if (dhcp == NULL) {
     return ERR_ARG;

--- a/third_party/lwip/repo/lwip/src/core/ipv4/ip4.c
+++ b/third_party/lwip/repo/lwip/src/core/ipv4/ip4.c
@@ -381,6 +381,8 @@ ip4_input(struct pbuf *p, struct netif *inp)
   int check_ip_src = 1;
 #endif /* IP_ACCEPT_LINK_LAYER_ADDRESSING || LWIP_IGMP */
 
+  LWIP_ASSERT_CORE_LOCKED();
+
   IP_STATS_INC(ip.recv);
   MIB2_STATS_INC(mib2.ipinreceives);
 

--- a/third_party/lwip/repo/lwip/src/core/ipv6/ip6.c
+++ b/third_party/lwip/repo/lwip/src/core/ipv6/ip6.c
@@ -425,6 +425,8 @@ ip6_input(struct pbuf *p, struct netif *inp)
   int check_ip_src=1;
 #endif /* IP_ACCEPT_LINK_LAYER_ADDRESSING */
 
+  LWIP_ASSERT_CORE_LOCKED();
+
   IP6_STATS_INC(ip6.recv);
 
   /* identify the IP header */

--- a/third_party/lwip/repo/lwip/src/core/ipv6/ip6.c
+++ b/third_party/lwip/repo/lwip/src/core/ipv6/ip6.c
@@ -940,6 +940,11 @@ ip6_output_if_src(struct pbuf *p, const ip6_addr_t *src, const ip6_addr_t *dest,
       }
     }
   }
+#if LWIP_MULTICAST_TX_OPTIONS
+  if ((p->flags & PBUF_FLAG_MCASTLOOP) != 0) {
+    netif_loop_output(netif, p);
+  }
+#endif /* LWIP_MULTICAST_TX_OPTIONS */
 #endif /* ENABLE_LOOPBACK */
 #if LWIP_IPV6_FRAG
   /* don't fragment if interface has mtu set to 0 [loopif] */

--- a/third_party/lwip/repo/lwip/src/core/mem.c
+++ b/third_party/lwip/repo/lwip/src/core/mem.c
@@ -468,16 +468,16 @@ mem_free(void *rmem)
  * Shrink memory returned by mem_malloc().
  *
  * @param rmem pointer to memory allocated by mem_malloc the is to be shrinked
- * @param newsize required size after shrinking (needs to be smaller than or
+ * @param new_size required size after shrinking (needs to be smaller than or
  *                equal to the previous size)
  * @return for compatibility reasons: is always == rmem, at the moment
  *         or NULL if newsize is > old size, in which case rmem is NOT touched
  *         or freed!
  */
 void *
-mem_trim(void *rmem, mem_size_t newsize)
+mem_trim(void *rmem, mem_size_t new_size)
 {
-  mem_size_t size;
+  mem_size_t size, newsize;
   mem_size_t ptr, ptr2;
   struct mem *mem, *mem2;
   /* use the FREE_PROTECT here: it protects with sem OR SYS_ARCH_PROTECT */
@@ -485,15 +485,14 @@ mem_trim(void *rmem, mem_size_t newsize)
 
   /* Expand the size of the allocated memory region so that we can
      adjust for alignment. */
-  newsize = LWIP_MEM_ALIGN_SIZE(newsize);
+  newsize = (mem_size_t)LWIP_MEM_ALIGN_SIZE(new_size);
+  if ((newsize > MEM_SIZE_ALIGNED) || (newsize < new_size)) {
+    return NULL;
+  }
 
   if (newsize < MIN_SIZE_ALIGNED) {
     /* every data block must be at least MIN_SIZE_ALIGNED long */
     newsize = MIN_SIZE_ALIGNED;
-  }
-
-  if (newsize > MEM_SIZE_ALIGNED) {
-    return NULL;
   }
 
   LWIP_ASSERT("mem_trim: legal memory", (u8_t *)rmem >= (u8_t *)ram &&
@@ -514,7 +513,7 @@ mem_trim(void *rmem, mem_size_t newsize)
   /* ... and its offset pointer */
   ptr = (mem_size_t)((u8_t *)mem - ram);
 
-  size = mem->next - ptr - SIZEOF_STRUCT_MEM;
+  size = (mem_size_t)((mem_size_t)(mem->next - ptr) - SIZEOF_STRUCT_MEM);
   LWIP_ASSERT("mem_trim can only shrink memory", newsize <= size);
   if (newsize > size) {
     /* not supported */
@@ -535,7 +534,7 @@ mem_trim(void *rmem, mem_size_t newsize)
     /* remember the old next pointer */
     next = mem2->next;
     /* create new struct mem which is moved directly after the shrinked mem */
-    ptr2 = ptr + SIZEOF_STRUCT_MEM + newsize;
+    ptr2 = (mem_size_t)(ptr + SIZEOF_STRUCT_MEM + newsize);
     if (lfree == mem2) {
       lfree = (struct mem *)(void *)&ram[ptr2];
     }
@@ -563,7 +562,7 @@ mem_trim(void *rmem, mem_size_t newsize)
      * @todo we could leave out MIN_SIZE_ALIGNED. We would create an empty
      *       region that couldn't hold data, but when mem->next gets freed,
      *       the 2 regions would be combined, resulting in more free memory */
-    ptr2 = ptr + SIZEOF_STRUCT_MEM + newsize;
+    ptr2 = (mem_size_t)(ptr + SIZEOF_STRUCT_MEM + newsize);
     mem2 = (struct mem *)(void *)&ram[ptr2];
     if (mem2 < lfree) {
       lfree = mem2;
@@ -594,36 +593,36 @@ mem_trim(void *rmem, mem_size_t newsize)
 /**
  * Allocate a block of memory with a minimum of 'size' bytes.
  *
- * @param size is the minimum size of the requested block in bytes.
+ * @param size_in is the minimum size of the requested block in bytes.
  * @return pointer to allocated memory or NULL if no free memory was found.
  *
  * Note that the returned value will always be aligned (as defined by MEM_ALIGNMENT).
  */
 void *
-mem_malloc(mem_size_t size)
+mem_malloc(mem_size_t size_in)
 {
-  mem_size_t ptr, ptr2;
+  mem_size_t ptr, ptr2, size;
   struct mem *mem, *mem2;
 #if LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT
   u8_t local_mem_free_count = 0;
 #endif /* LWIP_ALLOW_MEM_FREE_FROM_OTHER_CONTEXT */
   LWIP_MEM_ALLOC_DECL_PROTECT();
 
-  if (size == 0) {
+  if (size_in == 0) {
     return NULL;
   }
 
   /* Expand the size of the allocated memory region so that we can
      adjust for alignment. */
-  size = LWIP_MEM_ALIGN_SIZE(size);
+  size = (mem_size_t)LWIP_MEM_ALIGN_SIZE(size_in);
+  if ((size > MEM_SIZE_ALIGNED) ||
+      (size < size_in)) {
+    return NULL;
+  }
 
   if (size < MIN_SIZE_ALIGNED) {
     /* every data block must be at least MIN_SIZE_ALIGNED long */
     size = MIN_SIZE_ALIGNED;
-  }
-
-  if (size > MEM_SIZE_ALIGNED) {
-    return NULL;
   }
 
   /* protect the heap from concurrent access */
@@ -670,7 +669,7 @@ mem_malloc(mem_size_t size)
            *       region that couldn't hold data, but when mem->next gets freed,
            *       the 2 regions would be combined, resulting in more free memory
            */
-          ptr2 = ptr + SIZEOF_STRUCT_MEM + size;
+          ptr2 = (mem_size_t)(ptr + SIZEOF_STRUCT_MEM + size);
           /* create mem2 struct */
           mem2 = (struct mem *)(void *)&ram[ptr2];
           mem2->used = 0;

--- a/third_party/lwip/repo/lwip/src/core/netif.c
+++ b/third_party/lwip/repo/lwip/src/core/netif.c
@@ -674,8 +674,6 @@ netif_set_up(struct netif *netif)
 static void
 netif_issue_reports(struct netif* netif, u8_t report_type)
 {
-  LWIP_ASSERT_CORE_LOCKED();
-
 #if LWIP_IPV4
   if ((report_type & NETIF_REPORT_TYPE_IPV4) &&
       !ip4_addr_isany_val(*netif_ip4_addr(netif))) {

--- a/third_party/lwip/repo/lwip/src/core/netif.c
+++ b/third_party/lwip/repo/lwip/src/core/netif.c
@@ -216,6 +216,8 @@ netif_apply_pcb(struct netif *netif, struct ip_pcb *pcb)
 err_t
 netif_input(struct pbuf *p, struct netif *inp)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
 #if LWIP_ETHERNET
   if (inp->flags & (NETIF_FLAG_ETHARP | NETIF_FLAG_ETHERNET)) {
     return ethernet_input(p, inp);
@@ -261,6 +263,8 @@ netif_add(struct netif *netif,
 #if LWIP_IPV6
   s8_t i;
 #endif
+
+  LWIP_ASSERT_CORE_LOCKED();
 
   LWIP_ASSERT("No init function given", init != NULL);
 
@@ -366,6 +370,8 @@ void
 netif_set_addr(struct netif *netif, const ip4_addr_t *ipaddr, const ip4_addr_t *netmask,
     const ip4_addr_t *gw)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (ip4_addr_isany(ipaddr)) {
     /* when removing an address, we have to remove it *before* changing netmask/gw
        to ensure that tcp RST segment can be sent correctly */
@@ -393,6 +399,8 @@ netif_remove(struct netif *netif)
 #if LWIP_IPV6
   int i;
 #endif
+
+  LWIP_ASSERT_CORE_LOCKED();
 
   if (netif == NULL) {
     return;
@@ -521,6 +529,9 @@ void
 netif_set_ipaddr(struct netif *netif, const ip4_addr_t *ipaddr)
 {
   ip_addr_t new_addr;
+
+  LWIP_ASSERT_CORE_LOCKED();
+
   *ip_2_ip4(&new_addr) = (ipaddr ? *ipaddr : *IP4_ADDR_ANY4);
   IP_SET_TYPE_VAL(new_addr, IPADDR_TYPE_V4);
 
@@ -570,6 +581,8 @@ netif_set_ipaddr(struct netif *netif, const ip4_addr_t *ipaddr)
 void
 netif_set_gw(struct netif *netif, const ip4_addr_t *gw)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   ip4_addr_set(ip_2_ip4(&netif->gw), gw);
   IP_SET_TYPE_VAL(netif->gw, IPADDR_TYPE_V4);
   LWIP_DEBUGF(NETIF_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_STATE, ("netif: GW address of interface %c%c set to %"U16_F".%"U16_F".%"U16_F".%"U16_F"\n",
@@ -593,6 +606,8 @@ netif_set_gw(struct netif *netif, const ip4_addr_t *gw)
 void
 netif_set_netmask(struct netif *netif, const ip4_addr_t *netmask)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   mib2_remove_route_ip4(0, netif);
   /* set new netmask to netif */
   ip4_addr_set(ip_2_ip4(&netif->netmask), netmask);
@@ -617,6 +632,8 @@ netif_set_netmask(struct netif *netif, const ip4_addr_t *netmask)
 void
 netif_set_default(struct netif *netif)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (netif == NULL) {
     /* remove default route */
     mib2_remove_route_ip4(1, netif);
@@ -637,6 +654,8 @@ netif_set_default(struct netif *netif)
 void
 netif_set_up(struct netif *netif)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (!(netif->flags & NETIF_FLAG_UP)) {
     netif->flags |= NETIF_FLAG_UP;
 
@@ -655,6 +674,8 @@ netif_set_up(struct netif *netif)
 static void
 netif_issue_reports(struct netif* netif, u8_t report_type)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
 #if LWIP_IPV4
   if ((report_type & NETIF_REPORT_TYPE_IPV4) &&
       !ip4_addr_isany_val(*netif_ip4_addr(netif))) {
@@ -695,6 +716,8 @@ netif_issue_reports(struct netif* netif, u8_t report_type)
 void
 netif_set_down(struct netif *netif)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (netif->flags & NETIF_FLAG_UP) {
     netif->flags &= ~NETIF_FLAG_UP;
     MIB2_COPY_SYSUPTIME_TO(&netif->ts);
@@ -721,6 +744,8 @@ netif_set_down(struct netif *netif)
 void
 netif_set_status_callback(struct netif *netif, netif_status_callback_fn status_callback)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (netif) {
     netif->status_callback = status_callback;
   }
@@ -748,6 +773,8 @@ netif_set_remove_callback(struct netif *netif, netif_status_callback_fn remove_c
 void
 netif_set_link_up(struct netif *netif)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (!(netif->flags & NETIF_FLAG_LINK_UP)) {
     netif->flags |= NETIF_FLAG_LINK_UP;
 
@@ -773,6 +800,8 @@ netif_set_link_up(struct netif *netif)
 void
 netif_set_link_down(struct netif *netif )
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (netif->flags & NETIF_FLAG_LINK_UP) {
     netif->flags &= ~NETIF_FLAG_LINK_UP;
     NETIF_LINK_CALLBACK(netif);
@@ -787,6 +816,8 @@ netif_set_link_down(struct netif *netif )
 void
 netif_set_link_callback(struct netif *netif, netif_status_callback_fn link_callback)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (netif) {
     netif->link_callback = link_callback;
   }
@@ -1010,6 +1041,8 @@ netif_alloc_client_data_id(void)
   u8_t result = netif_client_id;
   netif_client_id++;
 
+  LWIP_ASSERT_CORE_LOCKED();
+
   LWIP_ASSERT("Increase LWIP_NUM_NETIF_CLIENT_DATA in lwipopts.h", result < LWIP_NUM_NETIF_CLIENT_DATA);
   return result + LWIP_NETIF_CLIENT_DATA_INDEX_MAX;
 }
@@ -1030,6 +1063,9 @@ void
 netif_ip6_addr_set(struct netif *netif, s8_t addr_idx, const ip6_addr_t *addr6)
 {
   LWIP_ASSERT("addr6 != NULL", addr6 != NULL);
+
+  LWIP_ASSERT_CORE_LOCKED();
+
   netif_ip6_addr_set_parts(netif, addr_idx, addr6->addr[0], addr6->addr[1],
     addr6->addr[2], addr6->addr[3]);
 }
@@ -1048,6 +1084,7 @@ void
 netif_ip6_addr_set_parts(struct netif *netif, s8_t addr_idx, u32_t i0, u32_t i1, u32_t i2, u32_t i3)
 {
   const ip6_addr_t *old_addr;
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_ASSERT("netif != NULL", netif != NULL);
   LWIP_ASSERT("invalid index", addr_idx < LWIP_IPV6_NUM_ADDRESSES);
 
@@ -1102,6 +1139,7 @@ void
 netif_ip6_addr_set_state(struct netif* netif, s8_t addr_idx, u8_t state)
 {
   u8_t old_state;
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_ASSERT("netif != NULL", netif != NULL);
   LWIP_ASSERT("invalid index", addr_idx < LWIP_IPV6_NUM_ADDRESSES);
 
@@ -1164,6 +1202,9 @@ s8_t
 netif_get_ip6_addr_match(struct netif *netif, const ip6_addr_t *ip6addr)
 {
   s8_t i;
+
+  LWIP_ASSERT_CORE_LOCKED();
+
   for (i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
     if (!ip6_addr_isinvalid(netif_ip6_addr_state(netif, i)) &&
         ip6_addr_cmp(netif_ip6_addr(netif, i), ip6addr)) {
@@ -1189,6 +1230,8 @@ void
 netif_create_ip6_linklocal_address(struct netif *netif, u8_t from_mac_48bit)
 {
   u8_t i, addr_index;
+
+  LWIP_ASSERT_CORE_LOCKED();
 
   /* Link-local prefix. */
   ip_2_ip6(&netif->ip6_addr[0])->addr[0] = PP_HTONL(0xfe800000ul);
@@ -1332,6 +1375,8 @@ netif_add_ip6_address(struct netif *netif, const ip6_addr_t *ip6addr, s8_t *chos
 {
   s8_t i;
 
+  LWIP_ASSERT_CORE_LOCKED();
+
   i = netif_get_ip6_addr_match(netif, ip6addr);
   if (i >= 0) {
     /* Address already added */
@@ -1420,7 +1465,13 @@ char *
 netif_index_to_name(u8_t index, char *name)
 {
   struct netif *curif = netif_list;
+
+  LWIP_ASSERT_CORE_LOCKED();
+
   u8_t num;
+
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (index == 0) {
     return NULL; /* indexes start at 1 */
   }

--- a/third_party/lwip/repo/lwip/src/core/netif.c
+++ b/third_party/lwip/repo/lwip/src/core/netif.c
@@ -109,6 +109,7 @@
 struct netif *netif_list;
 struct netif *netif_default;
 
+#define netif_index_to_num(index)   ((index) - 1)
 static u8_t netif_num;
 
 #if LWIP_NUM_NETIF_CLIENT_DATA > 0
@@ -1445,7 +1446,7 @@ netif_name_to_index(const char *name)
 {
   struct netif *netif = netif_find(name);
   if (netif != NULL) {
-    return netif_num_to_index(netif);
+    return netif_get_index(netif);
   }
   /* No name found, return invalid index */
   return 0;
@@ -1486,4 +1487,26 @@ netif_index_to_name(u8_t index, char *name)
     curif = curif->next;
   }
   return NULL;
+}
+
+/**
+* @ingroup netif
+* Return the interface for the netif index
+*
+* @param index index of netif to find
+*/
+struct netif*
+netif_get_by_index(u8_t index)
+{
+  struct netif* netif;
+
+  if (index != NETIF_NO_INDEX) {
+    for (netif = netif_list; netif != NULL; netif = netif->next) {
+      if (index == netif_get_index(netif)) {
+        return netif; /* found! */
+      }
+    }
+  }
+
+  return NULL;   
 }

--- a/third_party/lwip/repo/lwip/src/core/netif.c
+++ b/third_party/lwip/repo/lwip/src/core/netif.c
@@ -65,6 +65,7 @@
 #include "lwip/stats.h"
 #include "lwip/sys.h"
 #include "lwip/ip.h"
+#include "lwip/if.h"
 #if ENABLE_LOOPBACK
 #if LWIP_NETIF_LOOPBACK_MULTITHREADING
 #include "lwip/tcpip.h"
@@ -1388,3 +1389,52 @@ netif_null_output_ip6(struct netif *netif, struct pbuf *p, const ip6_addr_t *ipa
   return ERR_IF;
 }
 #endif /* LWIP_IPV6 */
+
+/**
+* @ingroup netif_if
+* Return the interface index for the netif with name
+* or 0 (invalid interface) if not found/on error
+*
+* @param name the name of the netif
+*/
+u8_t
+netif_name_to_index(const char *name)
+{
+  struct netif *netif = netif_find(name);
+  if (netif != NULL) {
+    return netif_num_to_index(netif);
+  }
+  /* No name found, return invalid index */
+  return 0;
+}
+
+/**
+* @ingroup netif_if
+* Return the interface name for the netif matching index
+* or NULL if not found/on error
+*
+* @param index the interface index of the netif
+* @param name char buffer of at least IF_NAMESIZE bytes
+*/
+char *
+netif_index_to_name(u8_t index, char *name)
+{
+  struct netif *curif = netif_list;
+  u8_t num;
+  if (index == 0) {
+    return NULL; /* indexes start at 1 */
+  }
+  num = netif_index_to_num(index);
+
+  /* find netif from num */
+  while (curif != NULL) {
+    if (curif->num == num) {
+      name[0] = curif->name[0];
+      name[1] = curif->name[1];
+      lwip_itoa(&name[2], IF_NAMESIZE - 2, num);
+      return name;
+    }
+    curif = curif->next;
+  }
+  return NULL;
+}

--- a/third_party/lwip/repo/lwip/src/core/pbuf.c
+++ b/third_party/lwip/repo/lwip/src/core/pbuf.c
@@ -427,13 +427,15 @@ pbuf_alloc(pbuf_layer layer, u16_t length, pbuf_type type)
     break;
   case PBUF_RAM:
     {
-      mem_size_t alloc_len = LWIP_MEM_ALIGN_SIZE(SIZEOF_STRUCT_PBUF + offset) + LWIP_MEM_ALIGN_SIZE(length);
-      
+      u16_t payload_len = (u16_t)(LWIP_MEM_ALIGN_SIZE(offset) + LWIP_MEM_ALIGN_SIZE(length));
+      mem_size_t alloc_len = (mem_size_t)(LWIP_MEM_ALIGN_SIZE(SIZEOF_STRUCT_PBUF) + payload_len);
+
       /* bug #50040: Check for integer overflow when calculating alloc_len */
-      if (alloc_len < LWIP_MEM_ALIGN_SIZE(length)) {
+      if ((payload_len < LWIP_MEM_ALIGN_SIZE(length)) ||
+          (alloc_len < LWIP_MEM_ALIGN_SIZE(length))) {
         return NULL;
       }
-    
+
       /* If pbuf is to be allocated in RAM, allocate memory for it. */
       p = (struct pbuf*)mem_malloc(alloc_len);
     }
@@ -1165,7 +1167,7 @@ void pbuf_split_64k(struct pbuf *p, struct pbuf **rest)
 
     /* continue until the total length (summed up as u16_t) overflows */
     while ((r != NULL) && ((u16_t)(tot_len_front + r->len) > tot_len_front)) {
-      tot_len_front += r->len;
+      tot_len_front = (u16_t)(tot_len_front + r->len);
       i = r;
       r = r->next;
     }
@@ -1176,7 +1178,7 @@ void pbuf_split_64k(struct pbuf *p, struct pbuf **rest)
     if (r != NULL) {
       /* Update the tot_len field in the first part */
       for (i = p; i != NULL; i = i->next) {
-        i->tot_len -= r->tot_len;
+        i->tot_len = (u16_t)(i->tot_len - r->tot_len);
         LWIP_ASSERT("tot_len/len mismatch in last pbuf",
                     (i->next != NULL) || (i->tot_len == i->len));
       }

--- a/third_party/lwip/repo/lwip/src/core/raw.c
+++ b/third_party/lwip/repo/lwip/src/core/raw.c
@@ -321,13 +321,8 @@ raw_recv(struct raw_pcb *pcb, raw_recv_fn recv, void *recv_arg)
 err_t
 raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
 {
-  err_t err;
   struct netif *netif;
   const ip_addr_t *src_ip;
-  struct pbuf *q; /* q will be sent down the stack */
-  s16_t header_size;
-
-  LWIP_ASSERT_CORE_LOCKED();
 
   if ((pcb == NULL) || (ipaddr == NULL) || !IP_ADDR_PCB_VERSION_MATCH(pcb, ipaddr)) {
     return ERR_VAL;
@@ -335,9 +330,66 @@ raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
 
   LWIP_DEBUGF(RAW_DEBUG | LWIP_DBG_TRACE, ("raw_sendto\n"));
 
+  if (pcb->intf_filter == NULL) {
+    if(IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
+      /* Don't call ip_route() with IP_ANY_TYPE */
+      netif = ip_route(IP46_ADDR_ANY(IP_GET_TYPE(ipaddr)), ipaddr);
+    } else {
+      netif = ip_route(&pcb->local_ip, ipaddr);
+    }
+
+    if (netif == NULL) {
+      LWIP_DEBUGF(RAW_DEBUG | LWIP_DBG_LEVEL_WARNING, ("raw_sendto: No route to "));
+      ip_addr_debug_print(RAW_DEBUG | LWIP_DBG_LEVEL_WARNING, ipaddr);
+      return ERR_RTE;
+    }
+  } else {
+    netif = pcb->intf_filter;
+  }
+
+  if (ip_addr_isany(&pcb->local_ip)) {
+    /* use outgoing network interface IP address as source address */
+    src_ip = ip_netif_get_local_ip(netif, ipaddr);
+#if LWIP_IPV6
+    if (src_ip == NULL) {
+      return ERR_RTE;
+    }
+#endif /* LWIP_IPV6 */
+  } else {
+    /* use RAW PCB local IP address as source address */
+    src_ip = &pcb->local_ip;
+  }
+
+  return raw_sendto_if_src(pcb, p, ipaddr, netif, src_ip);
+}
+
+/**
+ * @ingroup raw_raw
+ * Send the raw IP packet to the given address, using a particular outgoing
+ * netif and source IP address. An IP header will be prepended to the packet.
+ *
+ * @param pcb RAW PCB used to send the data
+ * @param p chain of pbufs to be sent
+ * @param dst_ip destination IP address
+ * @param netif the netif used for sending
+ * @param src_ip source IP address
+ */
+err_t
+raw_sendto_if_src(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip,
+    struct netif *netif, const ip_addr_t *src_ip)
+{
+  err_t err;
+  struct pbuf *q; /* q will be sent down the stack */
+  s16_t header_size;
+
+  if ((pcb == NULL) || (dst_ip == NULL) || (netif == NULL) || (src_ip == NULL) ||
+      !IP_ADDR_PCB_VERSION_MATCH(pcb, src_ip) || !IP_ADDR_PCB_VERSION_MATCH(pcb, dst_ip)) {
+    return ERR_VAL;
+  }
+
   header_size = (
 #if LWIP_IPV4 && LWIP_IPV6
-    IP_IS_V6(ipaddr) ? IP6_HLEN : IP_HLEN);
+    IP_IS_V6(dst_ip) ? IP6_HLEN : IP_HLEN);
 #elif LWIP_IPV4
     IP_HLEN);
 #else
@@ -368,31 +420,11 @@ raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
     }
   }
 
-  if (pcb->intf_filter == NULL) {
-    if(IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
-      /* Don't call ip_route() with IP_ANY_TYPE */
-      netif = ip_route(IP46_ADDR_ANY(IP_GET_TYPE(ipaddr)), ipaddr);
-    } else {
-      netif = ip_route(&pcb->local_ip, ipaddr);
-    }
-
-    if (netif == NULL) {
-      LWIP_DEBUGF(RAW_DEBUG | LWIP_DBG_LEVEL_WARNING, ("raw_sendto: No route to "));
-      ip_addr_debug_print(RAW_DEBUG | LWIP_DBG_LEVEL_WARNING, ipaddr);
-      /* free any temporary header pbuf allocated by pbuf_header() */
-      if (q != p) {
-        pbuf_free(q);
-      }
-      return ERR_RTE;
-    }
-  } else {
-    netif = pcb->intf_filter;
-  }
 #if IP_SOF_BROADCAST
-  if (IP_IS_V4(ipaddr))
+  if (IP_IS_V4(dst_ip))
   {
     /* broadcast filter? */
-    if (!ip_get_option(pcb, SOF_BROADCAST) && ip_addr_isbroadcast(ipaddr, netif)) {
+    if (!ip_get_option(pcb, SOF_BROADCAST) && ip_addr_isbroadcast(dst_ip, netif)) {
       LWIP_DEBUGF(RAW_DEBUG | LWIP_DBG_LEVEL_WARNING, ("raw_sendto: SOF_BROADCAST not enabled on pcb %p\n", (void *)pcb));
       /* free any temporary header pbuf allocated by pbuf_header() */
       if (q != p) {
@@ -403,34 +435,18 @@ raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
   }
 #endif /* IP_SOF_BROADCAST */
 
-  if (ip_addr_isany(&pcb->local_ip)) {
-    /* use outgoing network interface IP address as source address */
-    src_ip = ip_netif_get_local_ip(netif, ipaddr);
-#if LWIP_IPV6
-    if (src_ip == NULL) {
-      if (q != p) {
-        pbuf_free(q);
-      }
-      return ERR_RTE;
-    }
-#endif /* LWIP_IPV6 */
-  } else {
-    /* use RAW PCB local IP address as source address */
-    src_ip = &pcb->local_ip;
-  }
-
 #if LWIP_IPV6
   /* If requested, based on the IPV6_CHECKSUM socket option per RFC3542,
      compute the checksum and update the checksum in the payload. */
-  if (IP_IS_V6(ipaddr) && pcb->chksum_reqd) {
-    u16_t chksum = ip6_chksum_pseudo(p, pcb->protocol, p->tot_len, ip_2_ip6(src_ip), ip_2_ip6(ipaddr));
+  if (IP_IS_V6(dst_ip) && pcb->chksum_reqd) {
+    u16_t chksum = ip6_chksum_pseudo(p, pcb->protocol, p->tot_len, ip_2_ip6(src_ip), ip_2_ip6(dst_ip));
     LWIP_ASSERT("Checksum must fit into first pbuf", p->len >= (pcb->chksum_offset + 2));
     SMEMCPY(((u8_t *)p->payload) + pcb->chksum_offset, &chksum, sizeof(u16_t));
   }
 #endif
 
   netif_apply_pcb(netif, (struct ip_pcb *)pcb);
-  err = ip_output_if(q, src_ip, ipaddr, pcb->ttl, pcb->tos, pcb->protocol, netif);
+  err = ip_output_if(q, src_ip, dst_ip, pcb->ttl, pcb->tos, pcb->protocol, netif);
   netif_apply_pcb(netif, NULL);
 
   /* did we chain a header earlier? */

--- a/third_party/lwip/repo/lwip/src/core/raw.c
+++ b/third_party/lwip/repo/lwip/src/core/raw.c
@@ -223,6 +223,7 @@ raw_input(struct pbuf *p, struct netif *inp)
 err_t
 raw_bind(struct raw_pcb *pcb, const ip_addr_t *ipaddr)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   if ((pcb == NULL) || (ipaddr == NULL)) {
     return ERR_VAL;
   }
@@ -247,6 +248,7 @@ raw_bind(struct raw_pcb *pcb, const ip_addr_t *ipaddr)
 err_t
 raw_connect(struct raw_pcb *pcb, const ip_addr_t *ipaddr)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   if ((pcb == NULL) || (ipaddr == NULL)) {
     return ERR_VAL;
   }
@@ -268,6 +270,7 @@ raw_connect(struct raw_pcb *pcb, const ip_addr_t *ipaddr)
 void
 raw_recv(struct raw_pcb *pcb, raw_recv_fn recv, void *recv_arg)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   /* remember recv() callback and user data */
   pcb->recv = recv;
   pcb->recv_arg = recv_arg;
@@ -294,6 +297,8 @@ raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
   const ip_addr_t *src_ip;
   struct pbuf *q; /* q will be sent down the stack */
   s16_t header_size;
+
+  LWIP_ASSERT_CORE_LOCKED();
 
   if ((pcb == NULL) || (ipaddr == NULL) || !IP_ADDR_PCB_VERSION_MATCH(pcb, ipaddr)) {
     return ERR_VAL;
@@ -434,6 +439,7 @@ void
 raw_remove(struct raw_pcb *pcb)
 {
   struct raw_pcb *pcb2;
+  LWIP_ASSERT_CORE_LOCKED();
   /* pcb to be removed is first in list? */
   if (raw_pcbs == pcb) {
     /* make list start at 2nd pcb */
@@ -469,6 +475,7 @@ raw_new(u8_t proto)
   struct raw_pcb *pcb;
 
   LWIP_DEBUGF(RAW_DEBUG | LWIP_DBG_TRACE, ("raw_new\n"));
+  LWIP_ASSERT_CORE_LOCKED();
 
   pcb = (struct raw_pcb *)memp_malloc(MEMP_RAW_PCB);
   /* could allocate RAW PCB? */
@@ -502,6 +509,7 @@ struct raw_pcb *
 raw_new_ip_type(u8_t type, u8_t proto)
 {
   struct raw_pcb *pcb;
+  LWIP_ASSERT_CORE_LOCKED();
   pcb = raw_new(proto);
 #if LWIP_IPV4 && LWIP_IPV6
   if (pcb != NULL) {

--- a/third_party/lwip/repo/lwip/src/core/raw.c
+++ b/third_party/lwip/repo/lwip/src/core/raw.c
@@ -373,12 +373,7 @@ raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
     if (netif == NULL)
 #endif /* LWIP_MULTICAST_TX_OPTIONS */
     {
-      if (IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
-        /* Don't call ip_route() with IP_ANY_TYPE */
-        netif = ip_route(IP46_ADDR_ANY(IP_GET_TYPE(ipaddr)), ipaddr);
-      } else {
-        netif = ip_route(&pcb->local_ip, ipaddr);
-      }
+      netif = ip_route(&pcb->local_ip, ipaddr);
     }
   }
 

--- a/third_party/lwip/repo/lwip/src/core/raw.c
+++ b/third_party/lwip/repo/lwip/src/core/raw.c
@@ -423,9 +423,9 @@ raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr)
   /* If requested, based on the IPV6_CHECKSUM socket option per RFC3542,
      compute the checksum and update the checksum in the payload. */
   if (IP_IS_V6(ipaddr) && pcb->chksum_reqd) {
-    u16_t chksum = ip6_chksum_pseudo(q, pcb->protocol, q->tot_len, ip_2_ip6(src_ip), ip_2_ip6(ipaddr));
-    LWIP_ASSERT("Checksum must fit into first pbuf", q->len >= (pcb->chksum_offset + 2));
-    *(u16_t *)(((u8_t *)p->payload) + (q == p ? header_size : 0) + pcb->chksum_offset) = chksum;
+    u16_t chksum = ip6_chksum_pseudo(p, pcb->protocol, p->tot_len, ip_2_ip6(src_ip), ip_2_ip6(ipaddr));
+    LWIP_ASSERT("Checksum must fit into first pbuf", p->len >= (pcb->chksum_offset + 2));
+    SMEMCPY(((u8_t *)p->payload) + pcb->chksum_offset, &chksum, sizeof(u16_t));
   }
 #endif
 

--- a/third_party/lwip/repo/lwip/src/core/raw.c
+++ b/third_party/lwip/repo/lwip/src/core/raw.c
@@ -282,7 +282,7 @@ raw_connect(struct raw_pcb *pcb, const ip_addr_t *ipaddr)
     return ERR_VAL;
   }
   ip_addr_set_ipaddr(&pcb->remote_ip, ipaddr);
-  pcb->flags |= RAW_FLAGS_CONNECTED;
+  raw_set_flags(pcb, RAW_FLAGS_CONNECTED);
   return ERR_OK;
 }
 
@@ -308,7 +308,7 @@ raw_disconnect(struct raw_pcb *pcb)
 #endif
   pcb->netif_idx = NETIF_NO_INDEX;
   /* mark PCB as unconnected */
-  pcb->flags &= ~RAW_FLAGS_CONNECTED;
+  raw_clear_flags(pcb, RAW_FLAGS_CONNECTED);
 }
 
 /**
@@ -440,7 +440,7 @@ raw_sendto_if_src(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip,
   } else {
     /* first pbuf q equals given pbuf */
     q = p;
-    if (pbuf_header(q, -header_size)) {
+    if (pbuf_header(q, (s16_t)-header_size)) {
       LWIP_ASSERT("Can't restore header we just removed!", 0);
       return ERR_MEM;
     }

--- a/third_party/lwip/repo/lwip/src/core/tcp.c
+++ b/third_party/lwip/repo/lwip/src/core/tcp.c
@@ -71,7 +71,7 @@
    "The Dynamic and/or Private Ports are those from 49152 through 65535" */
 #define TCP_LOCAL_PORT_RANGE_START        0xc000
 #define TCP_LOCAL_PORT_RANGE_END          0xffff
-#define TCP_ENSURE_LOCAL_PORT_RANGE(port) ((u16_t)(((port) & ~TCP_LOCAL_PORT_RANGE_START) + TCP_LOCAL_PORT_RANGE_START))
+#define TCP_ENSURE_LOCAL_PORT_RANGE(port) ((u16_t)(((port) & (u16_t)~TCP_LOCAL_PORT_RANGE_START) + TCP_LOCAL_PORT_RANGE_START))
 #endif
 
 #if LWIP_TCP_KEEPALIVE
@@ -241,7 +241,7 @@ tcp_backlog_accepted(struct tcp_pcb* pcb)
     if (pcb->listener != NULL) {
       LWIP_ASSERT("accepts_pending != 0", pcb->listener->accepts_pending != 0);
       pcb->listener->accepts_pending--;
-      pcb->flags &= ~TF_BACKLOGPEND;
+      tcp_clear_flags(pcb, TF_BACKLOGPEND);
     }
   }
 }
@@ -820,14 +820,14 @@ tcp_update_rcv_ann_wnd(struct tcp_pcb *pcb)
 void
 tcp_recved(struct tcp_pcb *pcb, u16_t len)
 {
-  int wnd_inflation;
+  uint32_t wnd_inflation;
 
   LWIP_ASSERT_CORE_LOCKED();
   /* pcb->state LISTEN not allowed here */
   LWIP_ASSERT("don't call tcp_recved for listen-pcbs",
     pcb->state != LISTEN);
 
-  pcb->rcv_wnd += len;
+  pcb->rcv_wnd = (tcpwnd_size_t)(pcb->rcv_wnd + len);
   if (pcb->rcv_wnd > TCP_WND_MAX(pcb)) {
     pcb->rcv_wnd = TCP_WND_MAX(pcb);
   } else if (pcb->rcv_wnd == 0) {
@@ -1087,7 +1087,8 @@ tcp_slowtmr_start:
            * connect to somebody (i.e., we are in SYN_SENT). */
           if (pcb->state != SYN_SENT) {
             u8_t backoff_idx = LWIP_MIN(pcb->nrtx, sizeof(tcp_backoff)-1);
-            pcb->rto = ((pcb->sa >> 3) + pcb->sv) << tcp_backoff[backoff_idx];
+            int calc_rto = ((pcb->sa >> 3) + pcb->sv) << tcp_backoff[backoff_idx];
+            pcb->rto = (s16_t)LWIP_MIN(calc_rto, 0x7FFF);
           }
 
           /* Reset the retransmission timer. */
@@ -1097,7 +1098,7 @@ tcp_slowtmr_start:
           eff_wnd = LWIP_MIN(pcb->cwnd, pcb->snd_wnd);
           pcb->ssthresh = eff_wnd >> 1;
           if (pcb->ssthresh < (tcpwnd_size_t)(pcb->mss << 1)) {
-            pcb->ssthresh = (pcb->mss << 1);
+            pcb->ssthresh = (tcpwnd_size_t)(pcb->mss << 1);
           }
           pcb->cwnd = pcb->mss;
           LWIP_DEBUGF(TCP_CWND_DEBUG, ("tcp_slowtmr: cwnd %"TCPWNDSIZE_F
@@ -1153,7 +1154,7 @@ tcp_slowtmr_start:
        be retransmitted). */
 #if TCP_QUEUE_OOSEQ
     if (pcb->ooseq != NULL &&
-        (u32_t)tcp_ticks - pcb->tmr >= pcb->rto * TCP_OOSEQ_TIMEOUT) {
+        (tcp_ticks - pcb->tmr >= (u32_t)pcb->rto * TCP_OOSEQ_TIMEOUT)) {
       tcp_segs_free(pcb->ooseq);
       pcb->ooseq = NULL;
       LWIP_DEBUGF(TCP_CWND_DEBUG, ("tcp_slowtmr: dropping OOSEQ queued data\n"));
@@ -1296,12 +1297,12 @@ tcp_fasttmr_start:
         LWIP_DEBUGF(TCP_DEBUG, ("tcp_fasttmr: delayed ACK\n"));
         tcp_ack_now(pcb);
         tcp_output(pcb);
-        pcb->flags &= ~(TF_ACK_DELAY | TF_ACK_NOW);
+        tcp_clear_flags(pcb, TF_ACK_DELAY | TF_ACK_NOW);
       }
       /* send pending FIN */
       if (pcb->flags & TF_CLOSEPEND) {
         LWIP_DEBUGF(TCP_DEBUG, ("tcp_fasttmr: pending FIN\n"));
-        pcb->flags &= ~(TF_CLOSEPEND);
+        tcp_clear_flags(pcb, TF_CLOSEPEND);
         tcp_close_shutdown_fin(pcb);
       }
 
@@ -1960,7 +1961,7 @@ tcp_eff_send_mss_impl(u16_t sendmss, const ip_addr_t *dest
 {
   u16_t mss_s;
   struct netif *outif;
-  s16_t mtu;
+  u16_t mtu;
 
   outif = ip_route(src, dest);
 #if LWIP_IPV6
@@ -1989,12 +1990,13 @@ tcp_eff_send_mss_impl(u16_t sendmss, const ip_addr_t *dest
 #endif /* LWIP_IPV4 */
 
   if (mtu != 0) {
+    u16_t offset;
 #if LWIP_IPV6
 #if LWIP_IPV4
     if (IP_IS_V6(dest))
 #endif /* LWIP_IPV4 */
     {
-      mss_s = mtu - IP6_HLEN - TCP_HLEN;
+      offset = IP6_HLEN + TCP_HLEN;
     }
 #if LWIP_IPV4
     else
@@ -2002,9 +2004,10 @@ tcp_eff_send_mss_impl(u16_t sendmss, const ip_addr_t *dest
 #endif /* LWIP_IPV6 */
 #if LWIP_IPV4
     {
-      mss_s = mtu - IP_HLEN - TCP_HLEN;
+      offset = IP_HLEN + TCP_HLEN;
     }
 #endif /* LWIP_IPV4 */
+    mss_s = (mtu > offset) ? (u16_t)(mtu - offset) : 0;
     /* RFC 1122, chap 4.2.2.6:
      * Eff.snd.MSS = min(SendMSS+20, MMS_S) - TCPhdrsize - IPoptionsize
      * We correct for TCP options in tcp_write(), and don't support IP options.

--- a/third_party/lwip/repo/lwip/src/core/tcp.c
+++ b/third_party/lwip/repo/lwip/src/core/tcp.c
@@ -213,6 +213,7 @@ void
 tcp_backlog_delayed(struct tcp_pcb* pcb)
 {
   LWIP_ASSERT("pcb != NULL", pcb != NULL);
+  LWIP_ASSERT_CORE_LOCKED();
   if ((pcb->flags & TF_BACKLOGPEND) == 0) {
     if (pcb->listener != NULL) {
       pcb->listener->accepts_pending++;
@@ -235,6 +236,7 @@ void
 tcp_backlog_accepted(struct tcp_pcb* pcb)
 {
   LWIP_ASSERT("pcb != NULL", pcb != NULL);
+  LWIP_ASSERT_CORE_LOCKED();
   if ((pcb->flags & TF_BACKLOGPEND) != 0) {
     if (pcb->listener != NULL) {
       LWIP_ASSERT("accepts_pending != 0", pcb->listener->accepts_pending != 0);
@@ -399,6 +401,7 @@ err_t
 tcp_close(struct tcp_pcb *pcb)
 {
   LWIP_DEBUGF(TCP_DEBUG, ("tcp_close: closing in "));
+  LWIP_ASSERT_CORE_LOCKED();
   tcp_debug_print_state(pcb->state);
 
   if (pcb->state != LISTEN) {
@@ -425,6 +428,7 @@ tcp_close(struct tcp_pcb *pcb)
 err_t
 tcp_shutdown(struct tcp_pcb *pcb, int shut_rx, int shut_tx)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   if (pcb->state == LISTEN) {
     return ERR_CONN;
   }
@@ -475,6 +479,7 @@ tcp_abandon(struct tcp_pcb *pcb, int reset)
 #endif /* LWIP_CALLBACK_API */
   void *errf_arg;
 
+  LWIP_ASSERT_CORE_LOCKED();
   /* pcb->state LISTEN not allowed here */
   LWIP_ASSERT("don't call tcp_abort/tcp_abandon for listen-pcbs",
     pcb->state != LISTEN);
@@ -564,6 +569,8 @@ tcp_bind(struct tcp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port)
   int i;
   int max_pcb_list = NUM_TCP_PCB_LISTS;
   struct tcp_pcb *cpcb;
+
+  LWIP_ASSERT_CORE_LOCKED();
 
 #if LWIP_IPV4
   /* Don't propagate NULL pointer (IPv4 ANY) to subsequent functions */
@@ -663,6 +670,7 @@ tcp_accept_null(void *arg, struct tcp_pcb *pcb, err_t err)
 struct tcp_pcb *
 tcp_listen_with_backlog(struct tcp_pcb *pcb, u8_t backlog)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   return tcp_listen_with_backlog_and_err(pcb, backlog, NULL);
 }
 
@@ -689,6 +697,7 @@ tcp_listen_with_backlog_and_err(struct tcp_pcb *pcb, u8_t backlog, err_t *err)
   err_t res;
 
   LWIP_UNUSED_ARG(backlog);
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_ERROR("tcp_listen: pcb already connected", pcb->state == CLOSED, res = ERR_CLSD; goto done);
 
   /* already listening? */
@@ -795,6 +804,7 @@ tcp_recved(struct tcp_pcb *pcb, u16_t len)
 {
   int wnd_inflation;
 
+  LWIP_ASSERT_CORE_LOCKED();
   /* pcb->state LISTEN not allowed here */
   LWIP_ASSERT("don't call tcp_recved for listen-pcbs",
     pcb->state != LISTEN);
@@ -880,6 +890,8 @@ tcp_connect(struct tcp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port,
   err_t ret;
   u32_t iss;
   u16_t old_local_port;
+
+  LWIP_ASSERT_CORE_LOCKED();
 
   if ((pcb == NULL) || (ipaddr == NULL)) {
     return ERR_VAL;
@@ -1409,6 +1421,7 @@ tcp_seg_free(struct tcp_seg *seg)
 void
 tcp_setprio(struct tcp_pcb *pcb, u8_t prio)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   pcb->prio = prio;
 }
 
@@ -1556,6 +1569,8 @@ tcp_alloc(u8_t prio)
 {
   struct tcp_pcb *pcb;
 
+  LWIP_ASSERT_CORE_LOCKED();
+
   pcb = (struct tcp_pcb *)memp_malloc(MEMP_TCP_PCB);
   if (pcb == NULL) {
     /* Try killing oldest connection in TIME-WAIT. */
@@ -1700,6 +1715,7 @@ tcp_new_ip_type(u8_t type)
 void
 tcp_arg(struct tcp_pcb *pcb, void *arg)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   /* This function is allowed to be called for both listen pcbs and
      connection pcbs. */
   if (pcb != NULL) {
@@ -1719,6 +1735,7 @@ tcp_arg(struct tcp_pcb *pcb, void *arg)
 void
 tcp_recv(struct tcp_pcb *pcb, tcp_recv_fn recv)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   if (pcb != NULL) {
     LWIP_ASSERT("invalid socket state for recv callback", pcb->state != LISTEN);
     pcb->recv = recv;
@@ -1736,6 +1753,7 @@ tcp_recv(struct tcp_pcb *pcb, tcp_recv_fn recv)
 void
 tcp_sent(struct tcp_pcb *pcb, tcp_sent_fn sent)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   if (pcb != NULL) {
     LWIP_ASSERT("invalid socket state for sent callback", pcb->state != LISTEN);
     pcb->sent = sent;
@@ -1756,6 +1774,7 @@ tcp_sent(struct tcp_pcb *pcb, tcp_sent_fn sent)
 void
 tcp_err(struct tcp_pcb *pcb, tcp_err_fn err)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   if (pcb != NULL) {
     LWIP_ASSERT("invalid socket state for err callback", pcb->state != LISTEN);
     pcb->errf = err;
@@ -1774,6 +1793,7 @@ tcp_err(struct tcp_pcb *pcb, tcp_err_fn err)
 void
 tcp_accept(struct tcp_pcb *pcb, tcp_accept_fn accept)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   if ((pcb != NULL) && (pcb->state == LISTEN)) {
     struct tcp_pcb_listen *lpcb = (struct tcp_pcb_listen*)pcb;
     lpcb->accept = accept;
@@ -1792,6 +1812,7 @@ tcp_accept(struct tcp_pcb *pcb, tcp_accept_fn accept)
 void
 tcp_poll(struct tcp_pcb *pcb, tcp_poll_fn poll, u8_t interval)
 {
+  LWIP_ASSERT_CORE_LOCKED();
   LWIP_ASSERT("invalid socket state for poll", pcb->state != LISTEN);
 #if LWIP_CALLBACK_API
   pcb->poll = poll;

--- a/third_party/lwip/repo/lwip/src/core/tcp.c
+++ b/third_party/lwip/repo/lwip/src/core/tcp.c
@@ -556,7 +556,7 @@ tcp_abort(struct tcp_pcb *pcb)
  *
  * @param pcb the tcp_pcb to bind (no check is done whether this pcb is
  *        already bound!)
- * @param ipaddr the local ip address to bind to (use IP4_ADDR_ANY to bind
+ * @param ipaddr the local ip address to bind to (use IPx_ADDR_ANY to bind
  *        to any local address
  * @param port the local port to bind to
  * @return ERR_USE if the port is already in use
@@ -636,6 +636,24 @@ tcp_bind(struct tcp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port)
   LWIP_DEBUGF(TCP_DEBUG, ("tcp_bind: bind to port %"U16_F"\n", port));
   return ERR_OK;
 }
+
+/**
+ * @ingroup tcp_raw
+ * Binds the connection to a netif and IP address.
+ *
+ * @param pcb the tcp_pcb to bind.
+ * @param netif the netif to bind to. Can be NULL.
+ */
+void
+tcp_bind_netif(struct tcp_pcb *pcb, const struct netif *netif)
+{
+  if (netif != NULL) {
+    pcb->netif_idx = netif_get_index(netif);
+  } else {
+    pcb->netif_idx = NETIF_NO_INDEX;
+  }
+}
+
 #if LWIP_CALLBACK_API
 /**
  * Default accept callback if no accept callback is specified by the user.

--- a/third_party/lwip/repo/lwip/src/core/tcp_in.c
+++ b/third_party/lwip/repo/lwip/src/core/tcp_in.c
@@ -113,6 +113,7 @@ tcp_input(struct pbuf *p, struct netif *inp)
   err_t err;
 
   LWIP_UNUSED_ARG(inp);
+  LWIP_ASSERT_CORE_LOCKED();
 
   PERF_START;
 

--- a/third_party/lwip/repo/lwip/src/core/tcp_in.c
+++ b/third_party/lwip/repo/lwip/src/core/tcp_in.c
@@ -288,6 +288,12 @@ tcp_input(struct pbuf *p, struct netif *inp)
       if (inp->using_management_channel && !ip_get_option(lpcb,SOF_MANAGEMENT))
         continue;
 #endif
+      /* check if PCB is bound to specific netif */
+      if ((pcb->netif_idx != NETIF_NO_INDEX) &&
+          (pcb->netif_idx != netif_get_index(ip_data.current_input_netif))) {
+        continue;
+      }
+      
       if (lpcb->local_port == tcphdr->dest) {
         if (IP_IS_ANY_TYPE_VAL(lpcb->local_ip)) {
           /* found an ANY TYPE (IPv4/IPv6) match */

--- a/third_party/lwip/repo/lwip/src/core/tcp_out.c
+++ b/third_party/lwip/repo/lwip/src/core/tcp_out.c
@@ -391,6 +391,8 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u16_t len, u8_t apiflags)
   u16_t mss_local = LWIP_MIN(pcb->mss, TCPWND_MIN16(pcb->snd_wnd_max/2));
   mss_local = mss_local ? mss_local : pcb->mss;
 
+  LWIP_ASSERT_CORE_LOCKED();
+
 #if LWIP_NETIF_TX_SINGLE_PBUF
   /* Always copy to try to create single pbufs for TX */
   apiflags |= TCP_WRITE_FLAG_COPY;
@@ -1000,6 +1002,7 @@ tcp_output(struct tcp_pcb *pcb)
   s16_t i = 0;
 #endif /* TCP_CWND_DEBUG */
 
+  LWIP_ASSERT_CORE_LOCKED();
   /* pcb->state LISTEN not allowed here */
   LWIP_ASSERT("don't call tcp_output for listen-pcbs",
     pcb->state != LISTEN);

--- a/third_party/lwip/repo/lwip/src/core/timeouts.c
+++ b/third_party/lwip/repo/lwip/src/core/timeouts.c
@@ -214,6 +214,8 @@ sys_timeout(u32_t msecs, sys_timeout_handler handler, void *arg)
   struct sys_timeo *timeout, *t;
   u32_t now, diff;
 
+  LWIP_ASSERT_CORE_LOCKED();
+
   timeout = (struct sys_timeo *)memp_malloc(MEMP_SYS_TIMEOUT);
   if (timeout == NULL) {
     LWIP_ASSERT("sys_timeout: timeout != NULL, pool MEMP_SYS_TIMEOUT is empty", timeout != NULL);
@@ -281,6 +283,8 @@ sys_untimeout(sys_timeout_handler handler, void *arg)
 {
   struct sys_timeo *prev_t, *t;
 
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (next_timeout == NULL) {
     return;
   }
@@ -319,6 +323,8 @@ static
 void
 sys_check_timeouts(void)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (next_timeout) {
     struct sys_timeo *tmptimeout;
     u32_t diff;
@@ -375,6 +381,8 @@ sys_check_timeouts(void)
 void
 sys_restart_timeouts(void)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   timeouts_last_time = sys_now();
 }
 
@@ -388,6 +396,9 @@ u32_t
 sys_timeouts_sleeptime(void)
 {
   u32_t diff;
+
+  LWIP_ASSERT_CORE_LOCKED();
+
   if (next_timeout == NULL) {
     return 0xffffffff;
   }

--- a/third_party/lwip/repo/lwip/src/core/udp.c
+++ b/third_party/lwip/repo/lwip/src/core/udp.c
@@ -522,7 +522,7 @@ udp_sendto_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip,
 {
 #endif /* LWIP_CHECKSUM_ON_COPY && CHECKSUM_GEN_UDP */
   struct netif *netif;
-  const ip_addr_t *dst_ip_route = dst_ip;
+  const ip_addr_t *src_ip_route;
 
   if ((pcb == NULL) || (dst_ip == NULL) || !IP_ADDR_PCB_VERSION_MATCH(pcb, dst_ip)) {
     return ERR_VAL;
@@ -530,35 +530,53 @@ udp_sendto_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip,
 
   LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_send\n"));
 
-#if LWIP_IPV6 || (LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS)
-  if (ip_addr_ismulticast(dst_ip_route)) {
+  if (IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
+    /* Don't call ip_route() with IP_ANY_TYPE */
+    src_ip_route = IP46_ADDR_ANY(IP_GET_TYPE(dst_ip));
+  } else {
+    src_ip_route = &pcb->local_ip;
+  }
+
+#if LWIP_MULTICAST_TX_OPTIONS
+  netif = NULL;
+  if (ip_addr_ismulticast(dst_ip)) {
+    /* For IPv6, the interface to use for packets with a multicast destination
+     * is specified using an interface index. The same approach may be used for
+     * IPv4 as well, in which case it overrides the IPv4 multicast override
+     * address below. Here we have to look up the netif by going through the
+     * list, but by doing so we skip a route lookup. If the interface index has
+     * gone stale, we fall through and do the regular route lookup after all. */
+    if (pcb->mcast_ifindex != NETIF_NO_INDEX) {
+      for (netif = netif_list; netif != NULL; netif = netif->next) {
+        if (pcb->mcast_ifindex == netif_num_to_index(netif)) {
+          break; /* found! */
+        }
+      }
+    }
+#if LWIP_IPV4
+    else
 #if LWIP_IPV6
-    if (IP_IS_V6(dst_ip)) {
-      /* For multicast, find a netif based on source address. */
-      dst_ip_route = &pcb->local_ip;
-    } else
+    if (IP_IS_V4(dst_ip))
 #endif /* LWIP_IPV6 */
     {
-#if LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS
       /* IPv4 does not use source-based routing by default, so we use an
          administratively selected interface for multicast by default.
          However, this can be overridden by setting an interface address
-         in pcb->multicast_ip that is used for routing. */
-      if (!ip_addr_isany_val(pcb->multicast_ip) &&
-          !ip4_addr_cmp(ip_2_ip4(&pcb->multicast_ip), IP4_ADDR_BROADCAST)) {
-        dst_ip_route = &pcb->multicast_ip;
+         in pcb->mcast_ip4 that is used for routing. If this routing lookup
+         fails, we try regular routing as though no override was set. */
+      if (!ip4_addr_isany_val(pcb->mcast_ip4) &&
+          !ip4_addr_cmp(&pcb->mcast_ip4, IP4_ADDR_BROADCAST)) {
+        netif = ip4_route_src(ip_2_ip4(src_ip_route), &pcb->mcast_ip4);
       }
-#endif /* LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS */
     }
+#endif /* LWIP_IPV4 */
   }
-#endif /* LWIP_IPV6 || (LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS) */
 
-  /* find the outgoing network interface for this packet */
-  if(IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
-    /* Don't call ip_route() with IP_ANY_TYPE */
-    netif = ip_route(IP46_ADDR_ANY(IP_GET_TYPE(dst_ip_route)), dst_ip_route);
-  } else {
-    netif = ip_route(&pcb->local_ip, dst_ip_route);
+  if (netif == NULL)
+#endif /* LWIP_MULTICAST_TX_OPTIONS */
+  {
+    /* find the outgoing network interface for this packet */
+    netif = ip_route(src_ip_route, dst_ip);
   }
 
   /* no outgoing network interface could be found? */
@@ -617,10 +635,11 @@ udp_sendto_if_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_i
     return ERR_VAL;
   }
 
-  /* PCB local address is IP_ANY_ADDR? */
+  /* PCB local address is IP_ANY_ADDR or multicast? */
 #if LWIP_IPV6
   if (IP_IS_V6(dst_ip)) {
-    if (ip6_addr_isany(ip_2_ip6(&pcb->local_ip))) {
+    if (ip6_addr_isany(ip_2_ip6(&pcb->local_ip)) ||
+        ip6_addr_ismulticast(ip_2_ip6(&pcb->local_ip))) {
       src_ip = ip6_select_source_address(netif, ip_2_ip6(dst_ip));
       if (src_ip == NULL) {
         /* No suitable source address was found. */
@@ -746,11 +765,11 @@ udp_sendto_if_src_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *d
   udphdr->chksum = 0x0000;
 
   /* Multicast Loop? */
-#if (LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS) || (LWIP_IPV6 && LWIP_IPV6_MLD)
+#if LWIP_MULTICAST_TX_OPTIONS
   if (((pcb->flags & UDP_FLAGS_MULTICAST_LOOP) != 0) && ip_addr_ismulticast(dst_ip)) {
     q->flags |= PBUF_FLAG_MCASTLOOP;
   }
-#endif /* (LWIP_IPV4 && LWIP_MULTICAST_TX_OPTIONS) || (LWIP_IPV6 && LWIP_IPV6_MLD) */
+#endif /* LWIP_MULTICAST_TX_OPTIONS */
 
   LWIP_DEBUGF(UDP_DEBUG, ("udp_send: sending datagram of length %"U16_F"\n", q->tot_len));
 

--- a/third_party/lwip/repo/lwip/src/core/udp.c
+++ b/third_party/lwip/repo/lwip/src/core/udp.c
@@ -192,6 +192,7 @@ udp_input(struct pbuf *p, struct netif *inp)
   u8_t for_us = 0;
 
   LWIP_UNUSED_ARG(inp);
+  LWIP_ASSERT_CORE_LOCKED();
 
   PERF_START;
 
@@ -705,6 +706,8 @@ udp_sendto_if_src_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *d
   u8_t ip_proto;
   u8_t ttl;
 
+  LWIP_ASSERT_CORE_LOCKED();
+
   if ((pcb == NULL) || (dst_ip == NULL) || !IP_ADDR_PCB_VERSION_MATCH(pcb, src_ip) ||
       !IP_ADDR_PCB_VERSION_MATCH(pcb, dst_ip)) {
     return ERR_VAL;
@@ -914,6 +917,8 @@ udp_bind(struct udp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port)
   struct udp_pcb *ipcb;
   u8_t rebind;
 
+  LWIP_ASSERT_CORE_LOCKED();
+
 #if LWIP_IPV4
   /* Don't propagate NULL pointer (IPv4 ANY) to subsequent functions */
   if (ipaddr == NULL) {
@@ -1012,6 +1017,8 @@ udp_connect(struct udp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port)
 {
   struct udp_pcb *ipcb;
 
+  LWIP_ASSERT_CORE_LOCKED();
+
   if ((pcb == NULL) || (ipaddr == NULL)) {
     return ERR_VAL;
   }
@@ -1054,6 +1061,8 @@ udp_connect(struct udp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port)
 void
 udp_disconnect(struct udp_pcb *pcb)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   /* reset remote address association */
 #if LWIP_IPV4 && LWIP_IPV6
   if (IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
@@ -1082,6 +1091,8 @@ udp_disconnect(struct udp_pcb *pcb)
 void
 udp_recv(struct udp_pcb *pcb, udp_recv_fn recv, void *recv_arg)
 {
+  LWIP_ASSERT_CORE_LOCKED();
+
   /* remember recv() callback and user data */
   pcb->recv = recv;
   pcb->recv_arg = recv_arg;
@@ -1100,6 +1111,8 @@ void
 udp_remove(struct udp_pcb *pcb)
 {
   struct udp_pcb *pcb2;
+
+  LWIP_ASSERT_CORE_LOCKED();
 
   mib2_udp_unbind(pcb);
   /* pcb to be removed is first in list? */
@@ -1133,6 +1146,9 @@ struct udp_pcb *
 udp_new(void)
 {
   struct udp_pcb *pcb;
+
+  LWIP_ASSERT_CORE_LOCKED();
+
   pcb = (struct udp_pcb *)memp_malloc(MEMP_UDP_PCB);
   /* could allocate UDP PCB? */
   if (pcb != NULL) {
@@ -1165,6 +1181,9 @@ struct udp_pcb *
 udp_new_ip_type(u8_t type)
 {
   struct udp_pcb *pcb;
+
+  LWIP_ASSERT_CORE_LOCKED();
+
   pcb = udp_new();
 #if LWIP_IPV4 && LWIP_IPV6
   if (pcb != NULL) {

--- a/third_party/lwip/repo/lwip/src/core/udp.c
+++ b/third_party/lwip/repo/lwip/src/core/udp.c
@@ -129,9 +129,14 @@ again:
 static u8_t
 udp_input_local_match(struct udp_pcb *pcb, struct netif *inp, u8_t broadcast)
 {
-  LWIP_UNUSED_ARG(inp);       /* in IPv6 only case */
   LWIP_UNUSED_ARG(broadcast); /* in IPv6 only case */
 
+  /* check if PCB is bound to specific netif */
+  if ((pcb->netif_idx != NETIF_NO_INDEX) &&
+      (pcb->netif_idx != netif_get_index(ip_data.current_input_netif))) {
+    return 0;
+  }
+    
   /* Dual-stack: PCBs listening to any IP type also listen to any IP address */
   if (IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
 #if LWIP_IPV4 && IP_SOF_BROADCAST_RECV
@@ -531,53 +536,54 @@ udp_sendto_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip,
 
   LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_send\n"));
 
-  if (IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
-    /* Don't call ip_route() with IP_ANY_TYPE */
-    src_ip_route = IP46_ADDR_ANY(IP_GET_TYPE(dst_ip));
+  if (pcb->netif_idx != NETIF_NO_INDEX) {
+    netif = netif_get_by_index(pcb->netif_idx);
   } else {
-    src_ip_route = &pcb->local_ip;
-  }
+    if (IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
+      /* Don't call ip_route() with IP_ANY_TYPE */
+      src_ip_route = IP46_ADDR_ANY(IP_GET_TYPE(dst_ip));
+    } else {
+      src_ip_route = &pcb->local_ip;
+    }
+    LWIP_UNUSED_ARG(src_ip_route); /* IPv4 only and no source based routing */
 
 #if LWIP_MULTICAST_TX_OPTIONS
-  netif = NULL;
-  if (ip_addr_ismulticast(dst_ip)) {
-    /* For IPv6, the interface to use for packets with a multicast destination
-     * is specified using an interface index. The same approach may be used for
-     * IPv4 as well, in which case it overrides the IPv4 multicast override
-     * address below. Here we have to look up the netif by going through the
-     * list, but by doing so we skip a route lookup. If the interface index has
-     * gone stale, we fall through and do the regular route lookup after all. */
-    if (pcb->mcast_ifindex != NETIF_NO_INDEX) {
-      for (netif = netif_list; netif != NULL; netif = netif->next) {
-        if (pcb->mcast_ifindex == netif_num_to_index(netif)) {
-          break; /* found! */
+    netif = NULL;
+    if (ip_addr_ismulticast(dst_ip)) {
+      /* For IPv6, the interface to use for packets with a multicast destination
+       * is specified using an interface index. The same approach may be used for
+       * IPv4 as well, in which case it overrides the IPv4 multicast override
+       * address below. Here we have to look up the netif by going through the
+       * list, but by doing so we skip a route lookup. If the interface index has
+       * gone stale, we fall through and do the regular route lookup after all. */
+      if (pcb->mcast_ifindex != NETIF_NO_INDEX) {
+        netif = netif_get_by_index(pcb->mcast_ifindex);
+      }
+#if LWIP_IPV4
+      else
+#if LWIP_IPV6
+      if (IP_IS_V4(dst_ip))
+#endif /* LWIP_IPV6 */
+      {
+        /* IPv4 does not use source-based routing by default, so we use an
+           administratively selected interface for multicast by default.
+           However, this can be overridden by setting an interface address
+           in pcb->mcast_ip4 that is used for routing. If this routing lookup
+           fails, we try regular routing as though no override was set. */
+        if (!ip4_addr_isany_val(pcb->mcast_ip4) &&
+            !ip4_addr_cmp(&pcb->mcast_ip4, IP4_ADDR_BROADCAST)) {
+          netif = ip4_route_src(ip_2_ip4(src_ip_route), &pcb->mcast_ip4);
         }
       }
-    }
-#if LWIP_IPV4
-    else
-#if LWIP_IPV6
-    if (IP_IS_V4(dst_ip))
-#endif /* LWIP_IPV6 */
-    {
-      /* IPv4 does not use source-based routing by default, so we use an
-         administratively selected interface for multicast by default.
-         However, this can be overridden by setting an interface address
-         in pcb->mcast_ip4 that is used for routing. If this routing lookup
-         fails, we try regular routing as though no override was set. */
-      if (!ip4_addr_isany_val(pcb->mcast_ip4) &&
-          !ip4_addr_cmp(&pcb->mcast_ip4, IP4_ADDR_BROADCAST)) {
-        netif = ip4_route_src(ip_2_ip4(src_ip_route), &pcb->mcast_ip4);
-      }
-    }
 #endif /* LWIP_IPV4 */
-  }
+    }
 
-  if (netif == NULL)
+    if (netif == NULL)
 #endif /* LWIP_MULTICAST_TX_OPTIONS */
-  {
-    /* find the outgoing network interface for this packet */
-    netif = ip_route(src_ip_route, dst_ip);
+    {
+      /* find the outgoing network interface for this packet */
+      netif = ip_route(src_ip_route, dst_ip);
+    }
   }
 
   /* no outgoing network interface could be found? */
@@ -996,6 +1002,25 @@ udp_bind(struct udp_pcb *pcb, const ip_addr_t *ipaddr, u16_t port)
 
 /**
  * @ingroup udp_raw
+ * Bind an UDP PCB to a specific netif.
+ *
+ * @param pcb UDP PCB to be bound.
+ * @param netif netif to bind udp pcb to. Can be NULL.
+ *
+ * @see udp_disconnect()
+ */
+void
+udp_bind_netif(struct udp_pcb *pcb, const struct netif *netif)
+{
+  if (netif != NULL) {
+    pcb->netif_idx = netif_get_index(netif);
+  } else {
+    pcb->netif_idx = NETIF_NO_INDEX;
+  }
+}
+
+/**
+ * @ingroup udp_raw
  * Connect an UDP PCB.
  *
  * This will associate the UDP PCB with the remote address.
@@ -1074,6 +1099,7 @@ udp_disconnect(struct udp_pcb *pcb)
   }
 #endif
   pcb->remote_port = 0;
+  pcb->netif_idx = NETIF_NO_INDEX;
   /* mark PCB as unconnected */
   pcb->flags &= ~UDP_FLAGS_CONNECTED;
 }

--- a/third_party/lwip/repo/lwip/src/core/udp.c
+++ b/third_party/lwip/repo/lwip/src/core/udp.c
@@ -70,7 +70,7 @@
    "The Dynamic and/or Private Ports are those from 49152 through 65535" */
 #define UDP_LOCAL_PORT_RANGE_START  0xc000
 #define UDP_LOCAL_PORT_RANGE_END    0xffff
-#define UDP_ENSURE_LOCAL_PORT_RANGE(port) ((u16_t)(((port) & ~UDP_LOCAL_PORT_RANGE_START) + UDP_LOCAL_PORT_RANGE_START))
+#define UDP_ENSURE_LOCAL_PORT_RANGE(port) ((u16_t)(((port) & (u16_t)~UDP_LOCAL_PORT_RANGE_START) + UDP_LOCAL_PORT_RANGE_START))
 #endif
 
 /* last local UDP port */
@@ -1101,7 +1101,7 @@ udp_disconnect(struct udp_pcb *pcb)
   pcb->remote_port = 0;
   pcb->netif_idx = NETIF_NO_INDEX;
   /* mark PCB as unconnected */
-  pcb->flags &= ~UDP_FLAGS_CONNECTED;
+  udp_clear_flags(pcb, UDP_FLAGS_CONNECTED);
 }
 
 /**

--- a/third_party/lwip/repo/lwip/src/core/udp.c
+++ b/third_party/lwip/repo/lwip/src/core/udp.c
@@ -528,7 +528,6 @@ udp_sendto_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip,
 {
 #endif /* LWIP_CHECKSUM_ON_COPY && CHECKSUM_GEN_UDP */
   struct netif *netif;
-  const ip_addr_t *src_ip_route;
 
   if ((pcb == NULL) || (dst_ip == NULL) || !IP_ADDR_PCB_VERSION_MATCH(pcb, dst_ip)) {
     return ERR_VAL;
@@ -539,14 +538,6 @@ udp_sendto_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip,
   if (pcb->netif_idx != NETIF_NO_INDEX) {
     netif = netif_get_by_index(pcb->netif_idx);
   } else {
-    if (IP_IS_ANY_TYPE_VAL(pcb->local_ip)) {
-      /* Don't call ip_route() with IP_ANY_TYPE */
-      src_ip_route = IP46_ADDR_ANY(IP_GET_TYPE(dst_ip));
-    } else {
-      src_ip_route = &pcb->local_ip;
-    }
-    LWIP_UNUSED_ARG(src_ip_route); /* IPv4 only and no source based routing */
-
 #if LWIP_MULTICAST_TX_OPTIONS
     netif = NULL;
     if (ip_addr_ismulticast(dst_ip)) {
@@ -572,7 +563,7 @@ udp_sendto_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip,
            fails, we try regular routing as though no override was set. */
         if (!ip4_addr_isany_val(pcb->mcast_ip4) &&
             !ip4_addr_cmp(&pcb->mcast_ip4, IP4_ADDR_BROADCAST)) {
-          netif = ip4_route_src(ip_2_ip4(src_ip_route), &pcb->mcast_ip4);
+          netif = ip4_route_src(ip_2_ip4(&pcb->local_ip), &pcb->mcast_ip4);
         }
       }
 #endif /* LWIP_IPV4 */
@@ -582,7 +573,7 @@ udp_sendto_chksum(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip,
 #endif /* LWIP_MULTICAST_TX_OPTIONS */
     {
       /* find the outgoing network interface for this packet */
-      netif = ip_route(src_ip_route, dst_ip);
+      netif = ip_route(&pcb->local_ip, dst_ip);
     }
   }
 

--- a/third_party/lwip/repo/lwip/src/include/lwip/if.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/if.h
@@ -1,0 +1,59 @@
+/**
+ * @file
+ * Interface Identification APIs from:
+ *              RFC 3493: Basic Socket Interface Extensions for IPv6
+ *                  Section 4: Interface Identification
+ */
+
+/*
+ * Copyright (c) 2017 Joel Cunningham <joel.cunningham@me.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modificat
+ion,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO E
+VENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREM
+ENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARIS
+ING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILI
+TY
+ * OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ * Author: Joel Cunningham <joel.cunningham@me.com>
+ *
+ */
+#ifndef LWIP_HDR_IF_H
+#define LWIP_HDR_IF_H
+
+#include "lwip/opt.h"
+
+#define IF_NAMESIZE 6 /* 2 chars, 3 nums, 1 \0 */
+
+char * lwip_if_indextoname(unsigned ifindex, char *ifname);
+unsigned int lwip_if_nametoindex(const char *ifname);
+
+#if LWIP_COMPAT_SOCKETS
+#define if_indextoname(ifindex, ifname)  lwip_if_indextoname(ifindex,ifname)
+#define if_nametoindex(ifname)           lwip_if_nametoindex(ifname)
+#endif /* LWIP_COMPAT_SOCKETS */
+
+#endif /* LWIP_HDR_IF_H */

--- a/third_party/lwip/repo/lwip/src/include/lwip/ip.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/ip.h
@@ -77,7 +77,9 @@ extern "C" {
   /* ip addresses in network byte order */ \
   ip_addr_t local_ip; \
   ip_addr_t remote_ip; \
-   /* Socket options */  \
+  /* Bound netif index */                  \
+  u8_t netif_idx;                          \
+  /* Socket options */                     \
   u8_t so_options;      \
    /* Type Of Service */ \
   u8_t tos;              \

--- a/third_party/lwip/repo/lwip/src/include/lwip/netif.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/netif.h
@@ -486,6 +486,7 @@ char * netif_index_to_name(u8_t index, char *name);
 /* Interface indexes always start at 1 per RFC 3493, section 4, num starts at 0 */
 #define netif_num_to_index(netif)   ((netif)->num + 1)
 #define netif_index_to_num(index)   ((index) - 1)
+#define NETIF_NO_INDEX              (0)
 
 #ifdef __cplusplus
 }

--- a/third_party/lwip/repo/lwip/src/include/lwip/netif.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/netif.h
@@ -479,6 +479,14 @@ err_t netif_remove_ip6_address_with_route(struct netif *netif, ip6_addr_t *ip6ad
 #define NETIF_SET_HWADDRHINT(netif, hint)
 #endif /* LWIP_NETIF_HWADDRHINT */
 
+/* @ingroup netif */
+u8_t netif_name_to_index(const char *name);
+char * netif_index_to_name(u8_t index, char *name);
+
+/* Interface indexes always start at 1 per RFC 3493, section 4, num starts at 0 */
+#define netif_num_to_index(netif)   ((netif)->num + 1)
+#define netif_index_to_num(index)   ((index) - 1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/third_party/lwip/repo/lwip/src/include/lwip/netif.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/netif.h
@@ -479,13 +479,12 @@ err_t netif_remove_ip6_address_with_route(struct netif *netif, ip6_addr_t *ip6ad
 #define NETIF_SET_HWADDRHINT(netif, hint)
 #endif /* LWIP_NETIF_HWADDRHINT */
 
-/* @ingroup netif */
 u8_t netif_name_to_index(const char *name);
-char * netif_index_to_name(u8_t index, char *name);
+char * netif_index_to_name(u8_t idx, char *name);
+struct netif* netif_get_by_index(u8_t index);
 
 /* Interface indexes always start at 1 per RFC 3493, section 4, num starts at 0 */
-#define netif_num_to_index(netif)   ((netif)->num + 1)
-#define netif_index_to_num(index)   ((index) - 1)
+#define netif_get_index(netif)      ((netif)->num + 1)
 #define NETIF_NO_INDEX              (0)
 
 #ifdef __cplusplus

--- a/third_party/lwip/repo/lwip/src/include/lwip/netifapi.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/netifapi.h
@@ -40,6 +40,7 @@
 #include "lwip/netif.h"
 #include "lwip/dhcp.h"
 #include "lwip/autoip.h"
+#include "lwip/if.h"
 #include "lwip/priv/tcpip_priv.h"
 
 #ifdef __cplusplus
@@ -73,6 +74,14 @@ struct netifapi_msg {
       netifapi_void_fn voidfunc;
       netifapi_errt_fn errtfunc;
     } common;
+    struct {
+#if LWIP_MPU_COMPATIBLE
+      char name[IF_NAMESIZE];
+#else /* LWIP_MPU_COMPATIBLE */
+      char *name;
+#endif /* LWIP_MPU_COMPATIBLE */
+      u8_t index;
+    } ifs;
   } msg;
 };
 
@@ -91,6 +100,11 @@ err_t netifapi_netif_set_addr(struct netif *netif, const ip4_addr_t *ipaddr,
 
 err_t netifapi_netif_common(struct netif *netif, netifapi_void_fn voidfunc,
                             netifapi_errt_fn errtfunc);
+
+/** @ingroup netifapi_netif */
+err_t netifapi_netif_name_to_index(const char *name, u8_t *index);
+/** @ingroup netifapi_netif */
+err_t netifapi_netif_index_to_name(u8_t index, char *name);
 
 /** @ingroup netifapi_netif */
 #define netifapi_netif_remove(n)        netifapi_netif_common(n, netif_remove, NULL)

--- a/third_party/lwip/repo/lwip/src/include/lwip/opt.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/opt.h
@@ -203,6 +203,27 @@
 #if !defined SYS_LIGHTWEIGHT_PROT || defined __DOXYGEN__
 #define SYS_LIGHTWEIGHT_PROT            1
 #endif
+
+/**
+ * LWIP_ASSERT_CORE_LOCKED: Macro to check whether lwIP's threading/locking
+ * requirements are satisfied during current function call.
+ * This macro usually calls a function that is implemented in the OS-dependent
+ * sys layer and performs the following checks:
+ * - Not in ISR
+ * - If LWIP_TCPIP_CORE_LOCKING=1: TCPIP core lock is held
+ * - If LWIP_TCPIP_CORE_LOCKING=0: function is called from TCPIP thread
+ */
+#if !defined LWIP_ASSERT_CORE_LOCKED || defined __DOXYGEN__
+#define LWIP_ASSERT_CORE_LOCKED()
+#endif
+
+/**
+ * Called as first thing in the lwIP TCPIP thread. Can be used in conjunction
+ * with LWIP_ASSERT_CORE_LOCKED to check core locking.
+ */
+#if !defined LWIP_MARK_TCPIP_THREAD || defined __DOXYGEN__
+#define LWIP_MARK_TCPIP_THREAD()
+#endif
 /**
  * @}
  */

--- a/third_party/lwip/repo/lwip/src/include/lwip/opt.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/opt.h
@@ -963,7 +963,29 @@
 
 /*
    ----------------------------------
-   ----- Multicast/IGMP options -----
+   -------- Multicast options -------
+   ----------------------------------
+*/
+/**
+ * @defgroup lwip_opts_multicast Multicast
+ * @ingroup lwip_opts_infrastructure
+ * @{
+ */
+/**
+ * LWIP_MULTICAST_TX_OPTIONS==1: Enable multicast TX support like the socket options
+ * IP_MULTICAST_TTL/IP_MULTICAST_IF/IP_MULTICAST_LOOP, as well as (currently only)
+ * core support for the corresponding IPv6 options.
+ */
+#if !defined LWIP_MULTICAST_TX_OPTIONS || defined __DOXYGEN__
+#define LWIP_MULTICAST_TX_OPTIONS       ((LWIP_IGMP || LWIP_IPV6_MLD) && LWIP_UDP)
+#endif
+/**
+ * @}
+ */
+
+/*
+   ----------------------------------
+   ---------- IGMP options ----------
    ----------------------------------
 */
 /**
@@ -980,14 +1002,6 @@
 #if !LWIP_IPV4
 #undef LWIP_IGMP
 #define LWIP_IGMP                       0
-#endif
-
-/**
- * LWIP_MULTICAST_TX_OPTIONS==1: Enable multicast TX support like the socket options
- * IP_MULTICAST_TTL/IP_MULTICAST_IF/IP_MULTICAST_LOOP
- */
-#if !defined LWIP_MULTICAST_TX_OPTIONS || defined __DOXYGEN__
-#define LWIP_MULTICAST_TX_OPTIONS       (LWIP_IGMP && LWIP_UDP)
 #endif
 /**
  * @}

--- a/third_party/lwip/repo/lwip/src/include/lwip/opt.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/opt.h
@@ -998,7 +998,7 @@
  * core support for the corresponding IPv6 options.
  */
 #if !defined LWIP_MULTICAST_TX_OPTIONS || defined __DOXYGEN__
-#define LWIP_MULTICAST_TX_OPTIONS       ((LWIP_IGMP || LWIP_IPV6_MLD) && LWIP_UDP)
+#define LWIP_MULTICAST_TX_OPTIONS       ((LWIP_IGMP || LWIP_IPV6_MLD) && (LWIP_UDP || LWIP_RAW))
 #endif
 /**
  * @}

--- a/third_party/lwip/repo/lwip/src/include/lwip/prot/tcp.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/prot/tcp.h
@@ -81,6 +81,7 @@ PACK_STRUCT_END
 #define TCP_FLAGS 0x3fU
 
 #define TCPH_HDRLEN(phdr) ((u16_t)(lwip_ntohs((phdr)->_hdrlen_rsvd_flags) >> 12))
+#define TCPH_HDRLEN_BYTES(phdr) ((u8_t)(TCPH_HDRLEN(phdr) << 2))
 #define TCPH_FLAGS(phdr)  ((u16_t)(lwip_ntohs((phdr)->_hdrlen_rsvd_flags) & TCP_FLAGS))
 
 #define TCPH_HDRLEN_SET(phdr, len) (phdr)->_hdrlen_rsvd_flags = lwip_htons(((len) << 12) | TCPH_FLAGS(phdr))

--- a/third_party/lwip/repo/lwip/src/include/lwip/raw.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/raw.h
@@ -101,6 +101,7 @@ err_t            raw_connect    (struct raw_pcb *pcb, const ip_addr_t *ipaddr);
 void             raw_disconnect (struct raw_pcb *pcb);
 
 err_t            raw_sendto     (struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr);
+err_t            raw_sendto_if_src(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip, struct netif *netif, const ip_addr_t *src_ip);
 err_t            raw_send       (struct raw_pcb *pcb, struct pbuf *p);
 
 void             raw_recv       (struct raw_pcb *pcb, raw_recv_fn recv, void *recv_arg);

--- a/third_party/lwip/repo/lwip/src/include/lwip/raw.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/raw.h
@@ -109,6 +109,10 @@ void             raw_recv       (struct raw_pcb *pcb, raw_recv_fn recv, void *re
 
 #define          raw_flags(pcb) ((pcb)->flags)
 
+#define          raw_set_flags(pcb, set_flags)     do { (pcb)->flags = (u8_t)((pcb)->flags |  (set_flags)); } while(0)
+#define          raw_clear_flags(pcb, clr_flags)   do { (pcb)->flags = (u8_t)((pcb)->flags & ~(clr_flags)); } while(0)
+#define          raw_is_flag_set(pcb, flag)        (((pcb)->flags & (flag)) != 0)
+
 /* The following functions are the lower layer interface to RAW. */
 u8_t             raw_input      (struct pbuf *p, struct netif *inp);
 #define raw_init() /* Compatibility define, no init needed. */

--- a/third_party/lwip/repo/lwip/src/include/lwip/raw.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/raw.h
@@ -97,6 +97,7 @@ struct raw_pcb * raw_new        (u8_t proto);
 struct raw_pcb * raw_new_ip_type(u8_t type, u8_t proto);
 void             raw_remove     (struct raw_pcb *pcb);
 err_t            raw_bind       (struct raw_pcb *pcb, const ip_addr_t *ipaddr);
+void             raw_bind_netif (struct raw_pcb *pcb, const struct netif *netif);
 err_t            raw_connect    (struct raw_pcb *pcb, const ip_addr_t *ipaddr);
 void             raw_disconnect (struct raw_pcb *pcb);
 

--- a/third_party/lwip/repo/lwip/src/include/lwip/raw.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/raw.h
@@ -52,6 +52,8 @@
 extern "C" {
 #endif
 
+#define RAW_FLAGS_CONNECTED      0x01U
+
 struct raw_pcb;
 
 /** Function prototype for raw pcb receive callback functions.
@@ -76,6 +78,7 @@ struct raw_pcb {
   struct netif *intf_filter;
 
   u8_t protocol;
+  u8_t flags;
 
   /** receive callback function */
   raw_recv_fn recv;
@@ -95,11 +98,14 @@ struct raw_pcb * raw_new_ip_type(u8_t type, u8_t proto);
 void             raw_remove     (struct raw_pcb *pcb);
 err_t            raw_bind       (struct raw_pcb *pcb, const ip_addr_t *ipaddr);
 err_t            raw_connect    (struct raw_pcb *pcb, const ip_addr_t *ipaddr);
+void             raw_disconnect (struct raw_pcb *pcb);
 
 err_t            raw_sendto     (struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr);
 err_t            raw_send       (struct raw_pcb *pcb, struct pbuf *p);
 
 void             raw_recv       (struct raw_pcb *pcb, raw_recv_fn recv, void *recv_arg);
+
+#define          raw_flags(pcb) ((pcb)->flags)
 
 /* The following functions are the lower layer interface to RAW. */
 u8_t             raw_input      (struct pbuf *p, struct netif *inp);

--- a/third_party/lwip/repo/lwip/src/include/lwip/raw.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/raw.h
@@ -53,6 +53,7 @@ extern "C" {
 #endif
 
 #define RAW_FLAGS_CONNECTED      0x01U
+#define RAW_FLAGS_MULTICAST_LOOP 0x04U
 
 struct raw_pcb;
 
@@ -79,6 +80,13 @@ struct raw_pcb {
 
   u8_t protocol;
   u8_t flags;
+
+#if LWIP_MULTICAST_TX_OPTIONS
+  /** outgoing network interface for multicast packets, by interface index (if nonzero) */
+  u8_t mcast_ifindex;
+  /** TTL for outgoing multicast packets */
+  u8_t mcast_ttl;
+#endif /* LWIP_MULTICAST_TX_OPTIONS */
 
   /** receive callback function */
   raw_recv_fn recv;
@@ -108,6 +116,7 @@ err_t            raw_send       (struct raw_pcb *pcb, struct pbuf *p);
 void             raw_recv       (struct raw_pcb *pcb, raw_recv_fn recv, void *recv_arg);
 
 #define          raw_flags(pcb) ((pcb)->flags)
+#define          raw_setflags(pcb,f)  ((pcb)->flags = (f))
 
 #define          raw_set_flags(pcb, set_flags)     do { (pcb)->flags = (u8_t)((pcb)->flags |  (set_flags)); } while(0)
 #define          raw_clear_flags(pcb, clr_flags)   do { (pcb)->flags = (u8_t)((pcb)->flags & ~(clr_flags)); } while(0)
@@ -121,6 +130,13 @@ void raw_netif_ip_addr_changed(const ip_addr_t* old_addr, const ip_addr_t* new_a
 
 /* for compatibility with older implementation */
 #define raw_new_ip6(proto) raw_new_ip_type(IPADDR_TYPE_V6, proto)
+
+#if LWIP_MULTICAST_TX_OPTIONS
+#define raw_set_multicast_netif_index(pcb, idx) ((pcb)->mcast_ifindex = (idx))
+#define raw_get_multicast_netif_index(pcb)      ((pcb)->mcast_ifindex)
+#define raw_set_multicast_ttl(pcb, value)       ((pcb)->mcast_ttl = (value))
+#define raw_get_multicast_ttl(pcb)              ((pcb)->mcast_ttl)
+#endif /* LWIP_MULTICAST_TX_OPTIONS */
 
 #ifdef __cplusplus
 }

--- a/third_party/lwip/repo/lwip/src/include/lwip/stats.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/stats.h
@@ -308,7 +308,7 @@ void stats_init(void);
 
 #define STATS_INC(x) ++lwip_stats.x
 #define STATS_DEC(x) --lwip_stats.x
-#define STATS_INC_USED(x, y) do { lwip_stats.x.used += y; \
+#define STATS_INC_USED(x, y, type) do { lwip_stats.x.used = (type)(lwip_stats.x.used + y); \
                                 if (lwip_stats.x.max < lwip_stats.x.used) { \
                                     lwip_stats.x.max = lwip_stats.x.used; \
                                 } \
@@ -318,7 +318,7 @@ void stats_init(void);
 #define stats_init()
 #define STATS_INC(x)
 #define STATS_DEC(x)
-#define STATS_INC_USED(x)
+#define STATS_INC_USED(x, y, type)
 #endif /* LWIP_STATS */
 
 #if TCP_STATS
@@ -387,9 +387,9 @@ void stats_init(void);
 
 #if MEM_STATS
 #define MEM_STATS_AVAIL(x, y) lwip_stats.mem.x = y
-#define MEM_STATS_INC(x) SYS_ARCH_INC(lwip_stats.mem.x, 1)
-#define MEM_STATS_INC_USED(x, y) SYS_ARCH_INC(lwip_stats.mem.x, y)
-#define MEM_STATS_DEC_USED(x, y) SYS_ARCH_DEC(lwip_stats.mem.x, y)
+#define MEM_STATS_INC(x) STATS_INC(mem.x)
+#define MEM_STATS_INC_USED(x, y) STATS_INC_USED(mem, y, mem_size_t)
+#define MEM_STATS_DEC_USED(x, y) lwip_stats.mem.x = (mem_size_t)((lwip_stats.mem.x) - (y))
 #define MEM_STATS_DISPLAY() stats_display_mem(&lwip_stats.mem, "HEAP")
 #else
 #define MEM_STATS_AVAIL(x, y)
@@ -412,7 +412,7 @@ void stats_init(void);
 #if SYS_STATS
 #define SYS_STATS_INC(x) STATS_INC(sys.x)
 #define SYS_STATS_DEC(x) STATS_DEC(sys.x)
-#define SYS_STATS_INC_USED(x) STATS_INC_USED(sys.x, 1)
+#define SYS_STATS_INC_USED(x) STATS_INC_USED(sys.x, 1, STAT_COUNTER)
 #define SYS_STATS_DISPLAY() stats_display_sys(&lwip_stats.sys)
 #else
 #define SYS_STATS_INC(x)

--- a/third_party/lwip/repo/lwip/src/include/lwip/tcp.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/tcp.h
@@ -361,6 +361,10 @@ void             tcp_accept  (struct tcp_pcb *pcb, tcp_accept_fn accept);
 #endif /* LWIP_CALLBACK_API */
 void             tcp_poll    (struct tcp_pcb *pcb, tcp_poll_fn poll, u8_t interval);
 
+#define          tcp_set_flags(pcb, set_flags)     do { (pcb)->flags = (tcpflags_t)((pcb)->flags |  (set_flags)); } while(0)
+#define          tcp_clear_flags(pcb, clr_flags)   do { (pcb)->flags = (tcpflags_t)((pcb)->flags & ~(clr_flags)); } while(0)
+#define          tcp_is_flag_set(pcb, flag)        (((pcb)->flags & (flag)) != 0)
+
 #if LWIP_TCP_TIMESTAMPS
 #define          tcp_mss(pcb)             (((pcb)->flags & TF_TIMESTAMP) ? ((pcb)->mss - 12)  : (pcb)->mss)
 #else /* LWIP_TCP_TIMESTAMPS */
@@ -369,11 +373,11 @@ void             tcp_poll    (struct tcp_pcb *pcb, tcp_poll_fn poll, u8_t interv
 #define          tcp_sndbuf(pcb)          (TCPWND16((pcb)->snd_buf))
 #define          tcp_sndqueuelen(pcb)     ((pcb)->snd_queuelen)
 /** @ingroup tcp_raw */
-#define          tcp_nagle_disable(pcb)   ((pcb)->flags |= TF_NODELAY)
+#define          tcp_nagle_disable(pcb)   tcp_set_flags(pcb, TF_NODELAY)
 /** @ingroup tcp_raw */
-#define          tcp_nagle_enable(pcb)    ((pcb)->flags = (tcpflags_t)((pcb)->flags & ~TF_NODELAY))
+#define          tcp_nagle_enable(pcb)    tcp_clear_flags(pcb, TF_NODELAY)
 /** @ingroup tcp_raw */
-#define          tcp_nagle_disabled(pcb)  (((pcb)->flags & TF_NODELAY) != 0)
+#define          tcp_nagle_disabled(pcb)  tcp_is_flag_set(pcb, TF_NODELAY)
 
 #if TCP_LISTEN_BACKLOG
 #define          tcp_backlog_set(pcb, new_backlog) do { \

--- a/third_party/lwip/repo/lwip/src/include/lwip/tcp.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/tcp.h
@@ -391,6 +391,7 @@ void             tcp_backlog_accepted(struct tcp_pcb* pcb);
 void             tcp_recved  (struct tcp_pcb *pcb, u16_t len);
 err_t            tcp_bind    (struct tcp_pcb *pcb, const ip_addr_t *ipaddr,
                               u16_t port);
+void             tcp_bind_netif(struct tcp_pcb *pcb, const struct netif *netif);
 err_t            tcp_connect (struct tcp_pcb *pcb, const ip_addr_t *ipaddr,
                               u16_t port, tcp_connected_fn connected);
 

--- a/third_party/lwip/repo/lwip/src/include/lwip/udp.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/udp.h
@@ -92,8 +92,12 @@ struct udp_pcb {
   u16_t local_port, remote_port;
 
 #if LWIP_MULTICAST_TX_OPTIONS
-  /** outgoing network interface for multicast packets */
-  ip_addr_t multicast_ip;
+#if LWIP_IPV4
+  /** outgoing network interface for multicast packets, by IPv4 address (if not 'any') */
+  ip4_addr_t mcast_ip4;
+#endif /* LWIP_IPV4 */
+  /** outgoing network interface for multicast packets, by interface index (if nonzero) */
+  u8_t mcast_ifindex;
   /** TTL for outgoing multicast packets */
   u8_t mcast_ttl;
 #endif /* LWIP_MULTICAST_TX_OPTIONS */
@@ -160,9 +164,13 @@ void             udp_init       (void);
 #define udp_new_ip6() udp_new_ip_type(IPADDR_TYPE_V6)
 
 #if LWIP_MULTICAST_TX_OPTIONS
-#define udp_set_multicast_netif_addr(pcb, ip4addr) ip_addr_copy_from_ip4((pcb)->multicast_ip, *(ip4addr))
-#define udp_get_multicast_netif_addr(pcb)          ip_2_ip4(&(pcb)->multicast_ip)
-#define udp_set_multicast_ttl(pcb, value)      do { (pcb)->mcast_ttl = value; } while(0)
+#if LWIP_IPV4
+#define udp_set_multicast_netif_addr(pcb, ip4addr) ip4_addr_copy((pcb)->mcast_ip4, *(ip4addr))
+#define udp_get_multicast_netif_addr(pcb)          (&(pcb)->mcast_ip4)
+#endif /* LWIP_IPV4 */
+#define udp_set_multicast_netif_index(pcb, idx)    ((pcb)->mcast_ifindex = (idx))
+#define udp_get_multicast_netif_index(pcb)         ((pcb)->mcast_ifindex)
+#define udp_set_multicast_ttl(pcb, value)          ((pcb)->mcast_ttl = (value))
 #define udp_get_multicast_ttl(pcb)                 ((pcb)->mcast_ttl)
 #endif /* LWIP_MULTICAST_TX_OPTIONS */
 

--- a/third_party/lwip/repo/lwip/src/include/lwip/udp.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/udp.h
@@ -156,6 +156,10 @@ err_t            udp_sendto_if_src_chksum(struct udp_pcb *pcb, struct pbuf *p,
 #define          udp_flags(pcb) ((pcb)->flags)
 #define          udp_setflags(pcb, f)  ((pcb)->flags = (f))
 
+#define          udp_set_flags(pcb, set_flags)     do { (pcb)->flags = (u8_t)((pcb)->flags |  (set_flags)); } while(0)
+#define          udp_clear_flags(pcb, clr_flags)   do { (pcb)->flags = (u8_t)((pcb)->flags & ~(clr_flags)); } while(0)
+#define          udp_is_flag_set(pcb, flag)        (((pcb)->flags & (flag)) != 0)
+
 /* The following functions are the lower layer interface to UDP. */
 void             udp_input      (struct pbuf *p, struct netif *inp);
 

--- a/third_party/lwip/repo/lwip/src/include/lwip/udp.h
+++ b/third_party/lwip/repo/lwip/src/include/lwip/udp.h
@@ -122,6 +122,7 @@ struct udp_pcb * udp_new_ip_type(u8_t type);
 void             udp_remove     (struct udp_pcb *pcb);
 err_t            udp_bind       (struct udp_pcb *pcb, const ip_addr_t *ipaddr,
                                  u16_t port);
+void             udp_bind_netif (struct udp_pcb *pcb, const struct netif* netif);
 err_t            udp_connect    (struct udp_pcb *pcb, const ip_addr_t *ipaddr,
                                  u16_t port);
 void             udp_disconnect (struct udp_pcb *pcb);

--- a/third_party/lwip/repo/lwip/src/include/posix/net/if.h
+++ b/third_party/lwip/repo/lwip/src/include/posix/net/if.h
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * This file is a posix wrapper for lwip/if.h.
+ */
+
+/*
+ * Redistribution and use in source and binary forms, with or without modification, 
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED 
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+ * OF SUCH DAMAGE.
+ *
+ * This file is part of the lwIP TCP/IP stack.
+ *
+ */
+
+#include "lwip/if.h"

--- a/third_party/lwip/repo/lwip/src/netif/ppp/vj.c
+++ b/third_party/lwip/repo/lwip/src/netif/ppp/vj.c
@@ -471,7 +471,7 @@ vj_uncompress_uncomp(struct pbuf *nb, struct vjcompress *comp)
   hlen = IPH_HL(ip) << 2;
   if (IPH_PROTO(ip) >= MAX_SLOTS
       || hlen + sizeof(struct tcp_hdr) > nb->len
-      || (hlen += TCPH_HDRLEN(((struct tcp_hdr *)&((char *)ip)[hlen])) << 2)
+      || (hlen += TCPH_HDRLEN_BYTES((struct tcp_hdr *)&((char *)ip)[hlen]))
           > nb->len
       || hlen > MAX_HDR) {
     PPPDEBUG(LOG_INFO, ("vj_uncompress_uncomp: bad cid=%d, hlen=%d buflen=%d\n",


### PR DESCRIPTION
Outside of link local multicast addresses and the stack-required all-nodes, all-routers, and solicited node multicast addresses, the state of generalized IPv6 multicast support in LwIP was a bit spotty.

This pull request cherry-picks and adapts the minimal set of upstream multicast-related patches necessary to get a set of multi-node site-local multicast functional tests working:

- 1b20e664b: Task #14314: Add interface name/index APIs
- ab8119360: udp: add core-level multicast support for IPv6
- b33b3bb8b: Start working on task #14780: Add debug helper asserts to ensure threading/locking requirements are met
- f334ac68b: Work on task #14780: Add debug helper asserts to ensure threading/locking requirements are met Add LWIP_ASSERT_CORE_LOCKED() in several places
- aea706222: raw: extend support for connected sockets
- 4d69d0eda: Fixed IPv6 raw checksumming after a hint from Philip Gladstone
- 162cc4d34: raw: split off raw_sendto_if_src() from raw_sendto()
- d4d8fd819: Some code cleanup related to netif index handling Made the macro "netif_index_to_num" private, if someone needs it externally, please complain.
- 13ffc86ae: Start working task #14494: Implement SO_BINDTODEVICE Implement binding TCP, UDP and RAW PCBs to a netif
- 41177cfd1: work on -Wconversion...
- debf34ff9: work on -Wconversion...
- 6ce9a01c3: raw: add core support for multicast TX options
- 6c236b047: ip_route() can be called with IP_ANY_TYPE in src parameter, so remove code associated to that
