### PR TITLE
Fix for Issue #124: TestDNSResolution: Seg fault in udp_sendto

### DIFF
--- a/third_party/lwip/repo/lwip/src/core/dns.c
+++ b/third_party/lwip/repo/lwip/src/core/dns.c
@@ -1378,6 +1378,7 @@ dns_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, 
                 entry->state = DNS_STATE_ASKING;
               } else {
                 dns_call_found(i, NULL);
+                dns_table[i].state = DNS_STATE_UNUSED;
               }
             }
             goto memerr;
@@ -1396,6 +1397,7 @@ dns_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, 
                 entry->state = DNS_STATE_ASKING;
               } else {
                 dns_call_found(i, NULL);
+                dns_table[i].state = DNS_STATE_UNUSED;
               }
             }
             goto memerr; /* ignore this packet */
@@ -1518,6 +1520,7 @@ dns_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, 
             entry->state = DNS_STATE_ASKING;
           } else {
             dns_call_found(i, NULL);
+            dns_table[i].state = DNS_STATE_UNUSED;
           }
         }
         /* invalidate entry if the minimal TTL is zero */


### PR DESCRIPTION
Corrected a logic bug in LwIP’s dns_recv() function.  When processing a DNS response not containing any A or AAAA records, the code erroneously left the dns_table_entry in the DNS_STATE_ASKING state after alerting the user that the resolution had failed. Subsequently, when the DNS resolver timer (dns_tmr()) fired, code in dns_check_entry() would attempt to retry the request.  By this time, however, the UDP PCB associated with the dns_table_entry had been released, leading to a bad pointer dereference

The fix is to set the state to DNS_STATE_UNUSED after it has been determined that no further retries are possible.