### PR TITLE
Fixing typos in code comments

### DIFF
--- a/src/lib/profiles/data-management/Current/SubscriptionClient.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.h
@@ -122,7 +122,7 @@ public:
         // The update of a trait path has succeeded or failed
         kEvent_OnUpdateComplete       = 9,
 
-        // No more paths need to be udpated
+        // No more paths need to be updated
         kEvent_OnNoMorePendingUpdates = 10,
 #endif // WEAVE_CONFIG_ENABLE_WDM_UPDATE
     };

--- a/src/lib/profiles/data-management/Current/TraitData.cpp
+++ b/src/lib/profiles/data-management/Current/TraitData.cpp
@@ -1385,7 +1385,7 @@ exit:
  * @retval      WEAVE_ERROR_INVALID_ARGUMENT if the handle or the SubscriptionClient
  *                  pointer are invalid.
  * @retval      WEAVE_ERROR_WDM_INCONSISTENT_CONDITIONALITY if the trait instance is already being
- *                  udpated with the opposite conditionality.
+ *                  updated with the opposite conditionality.
  * @retval      WEAVE_ERROR_WDM_LOCAL_DATA_INCONSISTENT if aIsConditional is true but the
  *                  trait instance does not have a valid version.
  * @retval      WEAVE_ERROR_WDM_PATH_STORE_FULL if there is no memory to store the path.

--- a/src/lib/profiles/data-management/Current/UpdateEncoder.cpp
+++ b/src/lib/profiles/data-management/Current/UpdateEncoder.cpp
@@ -262,7 +262,7 @@ exit:
 /**
  * Encodes a DataElement.
  * If the DataElement is a dictionary, it resumes encoding from mContext->mNextDictionaryElementPathHandle.
- * If the dictionary overflows the buffer, mContext->mNextDictionaryElementPathHandle is udpated accordingly.
+ * If the dictionary overflows the buffer, mContext->mNextDictionaryElementPathHandle is updated accordingly.
  * This method does all the lookups required and passes everything to
  * EncodeElementPath and EncodeElementData.
  *

--- a/src/lib/profiles/echo/Next/WeaveEchoClient.cpp
+++ b/src/lib/profiles/echo/Next/WeaveEchoClient.cpp
@@ -746,7 +746,7 @@ bool WeaveEchoClient::IsMultiResponseAddress(const IPAddress & addr)
 /**
  * @fn bool WeaveEchoClient::RequestInProgress() const
  *
- * Returns true if an EchoRequest has been sent and the WeaveEchoClient object is awaiting a reponse.
+ * Returns true if an EchoRequest has been sent and the WeaveEchoClient object is awaiting a response.
  */
 
 /**

--- a/src/lib/profiles/service-directory/ServiceDirectory.cpp
+++ b/src/lib/profiles/service-directory/ServiceDirectory.cpp
@@ -1038,7 +1038,7 @@ void WeaveServiceManager::onResponseReceived(uint32_t aProfileId, uint8_t aMsgTy
     if (aProfileId == kWeaveProfile_StatusReport_Deprecated || aProfileId == kWeaveProfile_Common)
     {
         /*
-         * OK. so we got a status report rather than a reponse. at this
+         * OK. so we got a status report rather than a response. at this
          * point our handling for this case is pretty primitive. we need
          * a more sophisticated way of doing errors like this.
          */

--- a/src/test-apps/MockEvents.cpp
+++ b/src/test-apps/MockEvents.cpp
@@ -724,7 +724,7 @@ void TelemetryEventGenerator::Generate(void)
     // TelemetryEventGenerator generates WiFi telemetry events:
     // StatsEvent, DeauthEvent, InvalidKeyEvent and DHCPFailureEvent in sequence.
     //
-    // The first 5 events are StatsEvents with bcnRecvd/pktUcastRX/sleepTimePercent udpated
+    // The first 5 events are StatsEvents with bcnRecvd/pktUcastRX/sleepTimePercent updated
     // The 6th event is DeauthEvent
     // The 7th event is InvalidKeyEvent
     // The 8th event is DHCPFailureEvent


### PR DESCRIPTION
A couple of these typos are being flagged when generating the reference pages for openweave.io.  Fixing all occurrences of them in /src to avoid in future reference updates.