### PR TITLE
Only restart WRMP timer if needed

### DIFF
--- a/src/lib/core/WeaveExchangeMgr.cpp
+++ b/src/lib/core/WeaveExchangeMgr.cpp
@@ -1682,11 +1682,6 @@ void WeaveExchangeManager::WRMPStartTimer()
     bool foundWake                    = false;
     ExchangeContext *ec               = NULL;
 
-    // Stop any active timers, we are about to set a new timer
-    // based on the most up to date contents of the retrans
-    // table
-    WRMPStopTimer();
-
     // When do we need to next wake up to send an ACK?
     ec = (ExchangeContext *)ContextPool;
 
@@ -1728,28 +1723,45 @@ void WeaveExchangeManager::WRMPStartTimer()
 
     if (foundWake) {
         // Set timer for next tick boundary - subtract the elapsed time from the current tick
-        int32_t timerArmValue = nextWakeTime * mWRMPTimerInterval - (System::Timer::GetCurrentEpoch() - mWRMPTimeStampBase);
-#if defined(WRMP_TICKLESS_DEBUG)
-        WeaveLogProgress(ExchangeManager, "Setting WRMP timer for %d ms (%u %" PRIu64 " %" PRIu64 ")",
-                timerArmValue,
-                nextWakeTime, System::Timer::GetCurrentEpoch(), mWRMPTimeStampBase);
-#endif
-        // If the tick boundary has expired in the past (delayed processing of event due to other system activity),
-        // expire the timer immediately
-        if (timerArmValue < 0) {
-            timerArmValue = 0;
-        }
-        res = MessageLayer->SystemLayer->StartTimer((uint32_t)timerArmValue, WRMPTimeout, this);
+        System::Timer::Epoch currentTime = System::Timer::GetCurrentEpoch();
+        int32_t timerArmValue = nextWakeTime * mWRMPTimerInterval - (currentTime - mWRMPTimeStampBase);
+        System::Timer::Epoch timerExpiryEpoch = currentTime + timerArmValue;
+        System::Timer::Epoch prevTimerExpiryEpoch = 0;
 
-        VerifyOrDieWithMsg(res == WEAVE_NO_ERROR, ExchangeManager, "Cannot start WRMPTimeout\n");
 #if defined(WRMP_TICKLESS_DEBUG)
+        WeaveLogProgress(ExchangeManager, "WRMPStartTimer wake in %d ms (%" PRIu64" %u %" PRIu64 " %" PRIu64 ")",
+                timerArmValue,
+                timerExpiryEpoch, nextWakeTime, currentTime, mWRMPTimeStampBase);
+#endif
+        if (timerExpiryEpoch != prevTimerExpiryEpoch)
+        {
+            // If the tick boundary has expired in the past (delayed processing of event due to other system activity),
+            // expire the timer immediately
+            if (timerArmValue < 0) {
+                timerArmValue = 0;
+            }
+
+#if defined(WRMP_TICKLESS_DEBUG)
+            WeaveLogProgress(ExchangeManager, "WRMPStartTimer set timer for %d %" PRIu64, timerArmValue, timerExpiryEpoch);
+#endif
+            WRMPStopTimer();
+            res = MessageLayer->SystemLayer->StartTimer((uint32_t)timerArmValue, WRMPTimeout, this);
+
+            VerifyOrDieWithMsg(res == WEAVE_NO_ERROR, ExchangeManager, "Cannot start WRMPTimeout\n");
+            prevTimerExpiryEpoch = timerExpiryEpoch;
+#if defined(WRMP_TICKLESS_DEBUG)
+        } else {
+            WeaveLogProgress(ExchangeManager, "WRMPStartTimer timer already set for %" PRIu64, timerExpiryEpoch);
+#endif
+        }
     } else {
+#if defined(WRMP_TICKLESS_DEBUG)
         WeaveLogProgress(ExchangeManager, "Not setting WRMP timeout at %" PRIu64, System::Timer::GetCurrentEpoch());
 #endif
+        WRMPStopTimer();
     }
 
     TicklessDebugDumpRetransTable("WRMPStartTimer Dumping RetransTable entries after setting wakeup times");
-
 }
 
 void WeaveExchangeManager::WRMPStopTimer()

--- a/src/lib/core/WeaveExchangeMgr.h
+++ b/src/lib/core/WeaveExchangeMgr.h
@@ -32,6 +32,7 @@
 
 #include <Weave/Support/NLDLLUtil.h>
 #include <Weave/Core/WeaveWRMPConfig.h>
+#include <SystemLayer/SystemTimer.h>
 
  #define EXCHANGE_CONTEXT_ID(x)     ((x)+1)
 
@@ -449,6 +450,7 @@ private:
     uint16_t NextExchangeId;
 #if WEAVE_CONFIG_ENABLE_RELIABLE_MESSAGING
     uint64_t mWRMPTimeStampBase;    //WRMP timer base value to add offsets to evaluate timeouts
+    System::Timer::Epoch mWRMPCurrentTimerExpiry; //Tracks when the WRM timer will next expire
     uint16_t mWRMPTimerInterval;    //WRMP Timer tick period
     /**
      *  @class RetransTableEntry


### PR DESCRIPTION
This change reduces flooding of the Weave tasks' message queue on
NLER-based platforms in some circumstances. In NLER if a timer has
expired and posted its timer event but that event has not yet been
processed by the destination task (Weave task), and that timer is
then cancelled, the event will remain in the destination task's event
queue until the destination task dequeues it (and subsequently ignores
it, as it has been cancelled). This can lead to flooding of the message
queue by timer messages if we experince a burst of incoming traffic that
rapidly toggles the WRMP timer on and off. This is especially bad in
cases where we are overdue for a WRMP timer expiry, when every timer
toggle is an immediate expiry.