### PR TITLE
Issue 142 : Add support for Rendezvous WiFi ESSID Suffix to Device Descriptor

### DIFF
--- a/src/device-manager/WeaveDeviceManager-JNI.cpp
+++ b/src/device-manager/WeaveDeviceManager-JNI.cpp
@@ -3214,7 +3214,7 @@ WEAVE_ERROR N2J_DeviceDescriptor(JNIEnv *env, const WeaveDeviceDescriptor& inDev
         SuccessOrExit(err);
     }
 
-    constructor = env->GetMethodID(sWeaveDeviceDescriptorCls, "<init>", "(IIIIII[B[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;I)V");
+    constructor = env->GetMethodID(sWeaveDeviceDescriptorCls, "<init>", "(IIIIII[B[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;II)V");
     VerifyOrExit(constructor != NULL, err = WDM_JNI_ERROR_METHOD_NOT_FOUND);
 
     env->ExceptionClear();
@@ -3224,7 +3224,7 @@ WEAVE_ERROR N2J_DeviceDescriptor(JNIEnv *env, const WeaveDeviceDescriptor& inDev
                                                primary802154MACAddress, primaryWiFiMACAddress,
                                                serialNumber, rendezvousWiFiESSID, pairingCode,
                                                (jlong)inDeviceDesc.DeviceId, (jlong)inDeviceDesc.FabricId, softwareVersion,
-                                               (jint)inDeviceDesc.DeviceFeatures);
+                                               (jint)inDeviceDesc.DeviceFeatures, (jint)inDeviceDesc.Flags);
     VerifyOrExit(!env->ExceptionCheck(), err = WDM_JNI_ERROR_EXCEPTION_THROWN);
 
 exit:

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/TestMain.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/TestMain.java
@@ -190,7 +190,7 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler
         System.out.println("GetNetworks Test");
         System.out.println("    Getting configured networks...");
         ExpectedNetworkCount = 2;
-        DeviceMgr.beginGetNetworks(GetNetworkFlags.IncludeCredentials);
+        DeviceMgr.beginGetNetworks(GetNetworkFlags.None);
         ExpectSuccess("GetNetworks");
         System.out.println("GetNetworks Test Succeeded");
 
@@ -205,16 +205,14 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler
         System.out.println("GetNetworks Test");
         System.out.println("    Getting configured networks...");
         ExpectedNetworkCount = 1;
-        DeviceMgr.beginGetNetworks(GetNetworkFlags.IncludeCredentials);
+        DeviceMgr.beginGetNetworks(GetNetworkFlags.None);
         ExpectSuccess("GetNetworks");
         System.out.println("GetNetworks Test Succeeded");
 
         TestResult = null;
         System.out.println("GetCameraAuthData Test");
         System.out.println("    Getting camera auth data...");
-        String ExpectedCameraMACAddress = "112233445566";
-        String ExpectedCameraSignedPayload = "Ceci n'est pas un hash.";
-        DeviceMgr.beginGetCameraAuthData("Ceci n'est pas un nonce.");
+        DeviceMgr.beginGetCameraAuthData("Ceci n'est pas un nonce.012345670123456789ABCDEF0123456789ABCDEF");
         ExpectSuccess("GetCameraAuthData");
         System.out.println("GetCameraAuthData Test Succeeded");
 

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/WeaveDeviceDescriptor.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/WeaveDeviceDescriptor.java
@@ -58,9 +58,13 @@ public class WeaveDeviceDescriptor
         */
     public String softwareVersion;
 
-    /** ESSID for pairing WiFi network (null = not present).
+    /** ESSID or ESSID suffix for device's rendezvous WiFi network (null = not present).
         */
     public String rendezvousWiFiESSID;
+    
+    /** True if the rendezvousWiFiESSID field contains a suffix string.
+        */
+    public boolean isRendezvousWiFiESSIDSuffix;
 
     /** Device pairing code (null = not present).
         */
@@ -82,7 +86,8 @@ public class WeaveDeviceDescriptor
                                  int manufacturingYear, int manufacturingMonth, int manufacturingDay,
                                  byte[] primary802154MACAddress, byte[] primaryWiFiMACAddress,
                                  String serialNumber, String rendezvousWiFiESSID, String pairingCode,
-                                 long deviceId, long fabricId, String softwareVersion, int deviceFeatures)
+                                 long deviceId, long fabricId, String softwareVersion, int deviceFeatures,
+                                 int flags)
     {
         this.vendorCode = vendorCode;
         this.productCode = productCode;
@@ -105,7 +110,7 @@ public class WeaveDeviceDescriptor
         this.fabricId = fabricId;
         this.softwareVersion = softwareVersion;
         this.deviceFeatures = DeviceFeatures.fromFlags(deviceFeatures);
-
+        this.isRendezvousWiFiESSIDSuffix = ((flags & FLAG_IS_RENDEZVOUS_WIFI_ESSID_SUFFIX) != 0);
     }
 
     public static native WeaveDeviceDescriptor decode(byte[] encodedDeviceDesc);
@@ -113,4 +118,6 @@ public class WeaveDeviceDescriptor
     static {
         System.loadLibrary("WeaveDeviceManager");
     }
+    
+    static final int FLAG_IS_RENDEZVOUS_WIFI_ESSID_SUFFIX = 0x01;
 }

--- a/src/lib/profiles/device-description/DeviceDescription.h
+++ b/src/lib/profiles/device-description/DeviceDescription.h
@@ -87,8 +87,9 @@ enum
     kTag_SerialNumber                           = 4,    /**< [ UTF-8 string, len 1-32 ] Device serial number. Context-specific Tag */
     kTag_Primary802154MACAddress                = 5,    /**< [ byte string, len = 8 ] MAC address for device's primary 802.15.4 interface. Context-specific Tag */
     kTag_PrimaryWiFiMACAddress                  = 6,    /**< [ byte string, len = 6 ] MAC address for device's primary WiFi interface. Context-specific Tag */
-    kTag_RendezvousWiFiESSID                    = 7,    /**< [ UTF-8 string, len 1-32 ] ESSID for device's WiFi rendezvous network. Context-specific Tag */
-    kTag_PairingCode                            = 8,    /**< [ UTF-8 string, len 1-16 ] The pairing code for the device. Context-specific Tag
+    kTag_RendezvousWiFiESSID                    = 7,    /**< [ UTF-8 string, len 1-32 ] ESSID for device's WiFi rendezvous network. Context-specific Tag.
+                                                                @note: This tag is mutually exclusive with the RendezvousWiFiESSIDSuffix tag. */
+    kTag_PairingCode                            = 8,    /**< [ UTF-8 string, len 6-16 ] The pairing code for the device. Context-specific Tag
                                                                 @note @b IMPORTANT: For security reasons, the PairingCode field should *never*
                                                                 be sent over the network. It is present in a WeaveDeviceDescriptor structure so
                                                                 that is can encoded in a data label (e.g. QR-code) that is physically associated
@@ -98,6 +99,8 @@ enum
     kTag_FabricId                               = 11,   /**< [ uint, 2^64 max ] ID of Weave fabric to which the device belongs. Context-specific Tag */
     kTag_PairingCompatibilityVersionMajor       = 12,   /**< [ uint, range 1-65535 ] Pairing software compatibility major version. Context-specific Tag */
     kTag_PairingCompatibilityVersionMinor       = 13,   /**< [ uint, range 1-65535 ] Pairing software compatibility minor version. Context-specific Tag */
+    kTag_RendezvousWiFiESSIDSuffix              = 14,   /**< [ UTF-8 string, len 1-32 ] ESSID suffix for device's WiFi rendezvous network. Context-specific Tag.
+                                                                @note: This tag is mutually exclusive with the RendezvousWiFiESSID tag. */
 
     // Feature Tags (Context-specific Tags in WeaveDeviceDescriptor that indicate presence of device features)
     // NOTE: The absence of a specific tag indicates that the device does not support the associated feature.
@@ -126,12 +129,21 @@ public:
     };
 
     /**
-     *  Flags indicating specific device capabilities.
+     *  Feature flags indicating specific device capabilities.
      */
     enum
     {
         kFeature_HomeAlarmLinkCapable           = 0x00000001,   /**< Indicates a Nest Protect that supports connection to a home alarm panel. */
         kFeature_LinePowered                    = 0x00000002    /**< Indicates a device that requires line power. */
+    };
+
+    /**
+     * Flags field definitions.
+     */
+    enum
+    {
+        kFlag_IsRendezvousWiFiESSIDSuffix       = 0x01,         /**< Indicates that the RendezvousWiFiESSID value is a suffix string that
+                                                                     appears at the end of the ESSID of the device's WiFi rendezvous network. */
     };
 
      // Device specific characteristics
@@ -150,10 +162,11 @@ public:
     uint8_t PrimaryWiFiMACAddress[6];                           /**< MAC address for primary WiFi interface (big-endian, all zeros = not present) */
     char SerialNumber[kMaxSerialNumberLength+1];                /**< Serial number of device (NUL terminated, 0 length = not present) */
     char SoftwareVersion[kMaxSoftwareVersionLength+1];          /**< Active software version (NUL terminated, 0 length = not present) */
-    char RendezvousWiFiESSID[kMaxRendezvousWiFiESSID+1];        /**< ESSID for pairing WiFi network (NUL terminated, 0 length = not present) */
+    char RendezvousWiFiESSID[kMaxRendezvousWiFiESSID+1];        /**< ESSID for device WiFi rendezvous network (NUL terminated, 0 length = not present) */
     char PairingCode[kMaxPairingCodeLength+1];                  /**< Device pairing code (NUL terminated, 0 length = not present) */
     uint16_t PairingCompatibilityVersionMajor;                  /**< Major device pairing software compatibility version. */
     uint16_t PairingCompatibilityVersionMinor;                  /**< Minor device pairing software compatibility version. */
+    uint8_t Flags;                                              /**< Bit field containing additional information about the device. */
 
     void Clear(void);
 

--- a/src/test-apps/TestWeaveDeviceMangerJNI
+++ b/src/test-apps/TestWeaveDeviceMangerJNI
@@ -19,20 +19,28 @@
 
 SCRIPT_DIR=`DIR=\`dirname "$0"\` && (cd $DIR && pwd )`
 
+OPENWEAVE_ROOT=`(cd $SCRIPT_DIR/../.. && pwd )`
+
+BUILD_TARGET_DIR=`${OPENWEAVE_ROOT}/third_party/nlbuild-autotools/repo/third_party/autoconf/config.guess`
+
 JAR_FILE=WeaveDeviceManager.jar
 if [ \! -f ${JAR_FILE} ]; then
-    if [ -f ${SCRIPT_DIR}/../device-manager/${JAR_FILE} ]; then
+    if [ -f ${OPENWEAVE_ROOT}/output/share/java/${JAR_FILE} ]; then
+        JAR_FILE=${OPENWEAVE_ROOT}/output/share/java/${JAR_FILE}
+    elif [ -f ${SCRIPT_DIR}/../device-manager/${JAR_FILE} ]; then
         JAR_FILE=${SCRIPT_DIR}/../device-manager/${JAR_FILE}
     else
         echo "Unable to find ${JAR_FILE}"
-	exit -1
+	    exit -1
     fi
 fi
 
 LIB_DIR=.
 LIB_FILE=libWeaveDeviceManager.so
 if [ \! -f ${LIB_DIR}/${LIB_FILE} ]; then
-    if [ -f ${SCRIPT_DIR}/../device-manager/${LIB_FILE} ]; then
+    if [ -f ${OPENWEAVE_ROOT}/output/${BUILD_TARGET_DIR}/lib/${LIB_FILE} ]; then
+        LIB_DIR=${OPENWEAVE_ROOT}/output/${BUILD_TARGET_DIR}/lib
+    elif [ -f ${SCRIPT_DIR}/../device-manager/${LIB_FILE} ]; then
         LIB_DIR=${SCRIPT_DIR}/../device-manager
     else
         echo "Unable to find ${LIB_FILE}"
@@ -42,5 +50,5 @@ fi
 
 export WEAVE_IPV4_LISTEN_ADDR=127.0.0.2
 
-java -verbose:jni -Xcheck:jni -Djava.library.path=${LIB_DIR} -jar ${JAR_FILE} nl.Weave.DeviceManager.TestMain
+java --add-modules java.xml.bind -verbose:jni -Xcheck:jni -Djava.library.path=${LIB_DIR} -jar ${JAR_FILE} nl.Weave.DeviceManager.TestMain
 

--- a/src/test-apps/test-weave-device-descriptor-encode.sh
+++ b/src/test-apps/test-weave-device-descriptor-encode.sh
@@ -25,11 +25,13 @@ program="${builddir}/weave-device-descriptor"
 tests=(
     '--vendor 0x235A --product 6 --revision 1 --serial-num 05CA01AC29130044 --mfg-date 2014/03/26 --802-15-4-mac 18:B4:30:00:00:1E:8E:E5 --wifi-mac 18:B4:30:27:83:47 --ssid PROTECT-8EE5 --pairing-code K4H9ET'
     '--vendor 0x235A --product 0x13 --revision 1 --serial-num 15AA01ZZ01160101 --mfg-date 2016/08/05 --device-id 18B4300400000101'
+    '--vendor 0x235A --product 6 --revision 1 --serial-num 05CA01AC29130044 --mfg-date 2014/03/26 --802-15-4-mac 18:B4:30:00:00:1E:8E:E5 --wifi-mac 18:B4:30:27:83:47 --ssid-suffix 8EE5 --pairing-code K4H9ET'
 )
 
 expectedResults=(
     '1V:235A$P:6$R:1$D:140326$S:05CA01AC29130044$L:18B43000001E8EE5$W:18B430278347$I:PROTECT-8EE5$C:K4H9ET$'
     '1V:235A$P:13$R:1$D:160805$S:15AA01ZZ01160101$E:18B4300400000101$'
+    '1V:235A$P:6$R:1$D:140326$S:05CA01AC29130044$L:18B43000001E8EE5$W:18B430278347$H:8EE5$C:K4H9ET$'
 )
 
 numTests=${#tests[@]}


### PR DESCRIPTION
-- Extended WeaveDeviceDescriptor class with a new Flags field containing a single flag, (IsRendezvousWiFiESSIDSuffix) signaling that the RendezvousWiFiESSID field contains a
suffix string, rather than the entire ESSID string.

-- Modified the encode/decode methods for WeaveDeviceDescriptor to support device descriptors containing the new RendezvousWiFiESSIDSuffix tag/text key.

-- Updated the WeaveDeviceDescriptor wrapper classes for Java and Python to support the ESSID suffix field.

-- Modified the weave-device-descriptor command line tool to support encoding and decoding
device descriptors containing an ESSID suffix.

-- Added a unit test to the test-weave-device-descriptor-encode.sh test script.

-- Extended NLWeaveDeviceDescriptor interface with support for IsRendezvousWiFiESSIDSuffix flag.
