### PR TITLE
Add LwIP-based Network and Service Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-#    Copyright 2018 Google LLC. All Rights Reserved.
+#    Copyright 2018-2019 Google LLC. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -67,10 +67,14 @@ matrix:
       env: BUILD_TARGET="osx-lwip-clang" CC="clang"
       os: osx
       compiler: clang
-    - name: "Linux with Defaults against GCC Network and Service (Happy) Tests"
+    - name: "Linux with Defaults against GCC Network and Service Tests"
       os: linux
       compiler: gcc
       env: BUILD_TARGET="linux-auto-gcc-check-happy"
+    - name: "Linux with LwIP against GCC Network and Service Tests"
+      os: linux
+      compiler: gcc
+      env: BUILD_TARGET="linux-lwip-gcc-check-happy"
     - name: "ESP32"
       env: BUILD_TARGET="esp32"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,18 +43,10 @@ matrix:
       env: BUILD_TARGET="linux-auto-gcc-lint" CC="gcc"
       os: linux
       compiler: gcc
-    - name: "Linux with Defaults against GCC Functional and Unit Tests"
-      env: BUILD_TARGET="linux-auto-gcc-check" CC="gcc"
-      os: linux
-      compiler: gcc
     - name: "Linux with Defaults against clang/LLVM"
       env: BUILD_TARGET="linux-auto-clang" CC="clang"
       os: linux
       compiler: clang
-    - name: "Linux with LwIP against GCC Functional and Unit Tests"
-      env: BUILD_TARGET="linux-lwip-gcc-check" CC="gcc"
-      os: linux
-      compiler: gcc
     - name: "Linux with LWIP against clang/LLVM"
       env: BUILD_TARGET="linux-lwip-clang" CC="clang"
       os: linux
@@ -67,6 +59,16 @@ matrix:
       env: BUILD_TARGET="osx-lwip-clang" CC="clang"
       os: osx
       compiler: clang
+    - name: "ESP32"
+      env: BUILD_TARGET="esp32"
+    - name: "Linux with Defaults against GCC Functional and Unit Tests"
+      env: BUILD_TARGET="linux-auto-gcc-check" CC="gcc"
+      os: linux
+      compiler: gcc
+    - name: "Linux with LwIP against GCC Functional and Unit Tests"
+      env: BUILD_TARGET="linux-lwip-gcc-check" CC="gcc"
+      os: linux
+      compiler: gcc
     - name: "Linux with Defaults against GCC Network and Service Tests"
       os: linux
       compiler: gcc
@@ -75,6 +77,4 @@ matrix:
       os: linux
       compiler: gcc
       env: BUILD_TARGET="linux-lwip-gcc-check-happy"
-    - name: "ESP32"
-      env: BUILD_TARGET="esp32"
 

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-#    Copyright 2018 Google LLC All Rights Reserved.
+#    Copyright 2018-2019 Google LLC All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ case "${BUILD_TARGET}" in
 
         ;;
 
-    linux-auto-gcc-check-happy)
+    linux-auto-gcc-check-happy|linux-lwip-gcc-check-happy)
         # By default, the BLE layer is enabled in OpenWeave Core and,
         # by default on Linux, the BLE layer is implemented by
         # BlueZ. Satisfy its dependencies.

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-#    Copyright 2018 Google LLC All Rights Reserved.
+#    Copyright 2018-2019 Google LLC All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -39,8 +39,11 @@ case "${BUILD_TARGET}" in
         ;;
 
     linux-auto-gcc-check-happy)
-        # run happy test
         sudo make -f Makefile-Standalone DEBUG=1 TIMESTAMP=1 COVERAGE=1 BuildJobs=24 check
+        ;;
+
+    linux-lwip-gcc-check-happy)
+        sudo make -f Makefile-Standalone DEBUG=1 TIMESTAMP=1 COVERAGE=1 USE_LWIP=1 BuildJobs=24 check
         ;;
 
     linux-lwip-clang)


### PR DESCRIPTION
This pull request adds LwIP-based network and service tests to the Travis continuous integration matrix.