### PR TITLE
Fix a crash when decoding NetworkInfo from JNI

### DIFF
--- a/src/device-manager/WeaveDeviceManager-JNI.cpp
+++ b/src/device-manager/WeaveDeviceManager-JNI.cpp
@@ -3127,9 +3127,9 @@ WEAVE_ERROR N2J_NetworkInfo(JNIEnv *env, const NetworkInfo& inNetworkInfo, jobje
                                                  threadNetName,
                                                  threadExtPANId,
                                                  threadKey,
+                                                 (jshort)inNetworkInfo.WirelessSignalStrength,
                                                  (jint)inNetworkInfo.ThreadPANId,
-                                                 (jbyte)inNetworkInfo.ThreadChannel,
-                                                 (jshort)inNetworkInfo.WirelessSignalStrength);
+                                                 (jbyte)inNetworkInfo.ThreadChannel);
     VerifyOrExit(!env->ExceptionCheck(), err = WDM_JNI_ERROR_EXCEPTION_THROWN);
 
 exit:


### PR DESCRIPTION
Regression since 61384990c4; when the N2J_NetworkInfo method was updated to include the additional Thread network parameters, the order of parameters was incorrect. The Thread PAN ID was being supplied in place of the wireless signal strength, which frequently exceeds the limit of a jshort.