### PR TITLE
Enable exclusive use of legacy AddNetwork in WeaveDeviceManager

### DIFF
--- a/src/device-manager/WeaveDeviceManager.cpp
+++ b/src/device-manager/WeaveDeviceManager.cpp
@@ -1483,6 +1483,7 @@ WEAVE_ERROR WeaveDeviceManager::AddNetwork(const NetworkInfo *netInfo, void* app
 {
     WEAVE_ERROR     err     = WEAVE_NO_ERROR;
     PacketBuffer*   msgBuf  = NULL;
+    uint16_t        msgType = kMsgType_AddNetworkV2;
     TLVWriter       writer;
 
     if (mOpState != kOpState_Idle)
@@ -1507,6 +1508,11 @@ WEAVE_ERROR WeaveDeviceManager::AddNetwork(const NetworkInfo *netInfo, void* app
     mOpState = kOpState_AddNetwork;
 
 #if WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
+
+#if WEAVE_CONFIG_ALWAYS_USE_LEGACY_ADD_NETWORK_MESSAGE
+    // Revert to the deprecated, legacy msg type
+    msgType = kMsgType_AddNetwork;
+#else
     // Create duplicate of a message buffer.
     // If device returns error indicating that the new message type is not supported
     // this retained message will be re-sent to the device as an old AddNetwork() message type.
@@ -1518,9 +1524,11 @@ WEAVE_ERROR WeaveDeviceManager::AddNetwork(const NetworkInfo *netInfo, void* app
 
     // Identify if this request creates new Thread network.
     mCurReqCreateThreadNetwork = (netInfo->NetworkType == kNetworkType_Thread) && (netInfo->ThreadExtendedPANId == NULL);
+#endif // WEAVE_CONFIG_ALWAYS_USE_LEGACY_ADD_NETWORK_MESSAGE
+
 #endif // WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
 
-    err = SendRequest(kWeaveProfile_NetworkProvisioning, kMsgType_AddNetworkV2, msgBuf,
+    err = SendRequest(kWeaveProfile_NetworkProvisioning, msgType, msgBuf,
             HandleNetworkProvisioningResponse);
     msgBuf = NULL;
 

--- a/src/lib/core/WeaveConfig.h
+++ b/src/lib/core/WeaveConfig.h
@@ -2042,6 +2042,23 @@
 #endif // WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE
 
 /**
+ *  @def WEAVE_CONFIG_ALWAYS_USE_LEGACY_ADD_NETWORK_MESSAGE
+ *
+ *  @brief
+ *    Enable (1) or disable (0) the exclusive use of the depricated
+ *    version of AddNetwork() message in the Network Provisioning
+ *    profile.
+ *    This option should be enabled when exclusively pairing with Nest
+ *    legacy devices that don't have latest SW.
+ *    This option requires that
+ *    WEAVE_CONFIG_SUPPORT_LEGACY_ADD_NETWORK_MESSAGE is enabled.
+ *
+ */
+#ifndef WEAVE_CONFIG_ALWAYS_USE_LEGACY_ADD_NETWORK_MESSAGE
+#define WEAVE_CONFIG_ALWAYS_USE_LEGACY_ADD_NETWORK_MESSAGE     0
+#endif // WEAVE_CONFIG_ALWAYS_USE_LEGACY_ADD_NETWORK_MESSAGE
+
+/**
  * @def WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
  *
  * @brief Enable the Service Provisioning profile message


### PR DESCRIPTION
Permits the transmission of old message directly.

Issue:
SAPPHIRE-18344

Change-Id: I0a36fc31102e678bdb2ab1309757240ec180c821