### PR TITLE
Redesign how TraitCatalog is keeping elements.

### DIFF
--- a/src/lib/profiles/data-management/Current/NotificationEngine.cpp
+++ b/src/lib/profiles/data-management/Current/NotificationEngine.cpp
@@ -1680,13 +1680,15 @@ WEAVE_ERROR NotificationEngine::BuildSubscriptionlessNotification(PacketBuffer *
         TraitDataHandle traitHandle = currPath->mTraitDataHandle;
 
         // Get the max version from the datasource
-        err = pubCatalog->Locate(traitHandle, &dataSource);
-        SuccessOrExit(err);
+        // Locate() can return an error if the sink has been removed from the catalog. In that case,
+        // skip this path
+        if (pubCatalog->Locate(traitHandle, &dataSource) == WEAVE_NO_ERROR)
+        {
+            schemaVersion = dataSource->GetSchemaEngine()->GetMaxVersion();
 
-        schemaVersion = dataSource->GetSchemaEngine()->GetMaxVersion();
-
-        err = notifyRequest.WriteDataElement(traitHandle, kRootPropertyPathHandle, schemaVersion, NULL, 0, NULL, 0);
-        SuccessOrExit(err);
+            err = notifyRequest.WriteDataElement(traitHandle, kRootPropertyPathHandle, schemaVersion, NULL, 0, NULL, 0);
+            SuccessOrExit(err);
+        }
     }
 
     err = notifyRequest.MoveToState(kNotifyRequestBuilder_Idle);

--- a/src/lib/profiles/data-management/Current/SubscriptionClient.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.h
@@ -314,6 +314,7 @@ public:
     WEAVE_ERROR SetUpdated(TraitUpdatableDataSink * aDataSink, PropertyPathHandle aPropertyHandle, bool aIsConditional);
     void DiscardUpdates();
     void SuspendUpdateRetries();
+    void OnCatalogChanged();
 
     bool IsUpdatePendingOrInProgress() { return (kPendingSetEmpty != mPendingSetState || IsUpdateInProgress()); }
 #endif // WEAVE_CONFIG_ENABLE_WDM_UPDATE
@@ -544,32 +545,15 @@ private:
     static void UpdateEventCallback(void * const aAppState, UpdateClient::EventType aEvent, const UpdateClient::InEventParam & aInParam, UpdateClient::OutEventParam & aOutParam);
     void AbortUpdates(WEAVE_ERROR);
 
+    void ConfigureUpdatableSinks(void);
 
-    // Index of the TraitUpdatableDataSink instances stored in mDataSinkCatalog
-    /**
-     * Updatable trait instance context
-     */
-    struct UpdatableTIContext
-    {
-        void Init(TraitUpdatableDataSink *aUpdatableDataSink, TraitDataHandle aTraitDataHandle)
-        {
-            mUpdatableDataSink = aUpdatableDataSink;
-            mTraitDataHandle = aTraitDataHandle;
-        }
-
-        TraitDataHandle mTraitDataHandle;
-        TraitUpdatableDataSink *mUpdatableDataSink;
-    };
-    static void InitUpdatableSinkTrait(void *aDataSink, TraitDataHandle aDataHandle, void *aContext);
+    static void MovePendingToInProgressUpdatableSinkTrait(void *aDataSink, TraitDataHandle aDataHandle, void *aContext);
+    static void RefreshUpdatableSinkTrait(void *aDataSink, TraitDataHandle aDataHandle, void *aContext);
+    static void PurgePendingUpdatableSinkTrait(void *aDataSink, TraitDataHandle aDataHandle, void *aContext);
+    static void ConfigureUpdatableSinkTrait(void *aDataSink, TraitDataHandle aDataHandle, void *aContext);
     static void CleanupUpdatableSinkTrait(void *aDataSink, TraitDataHandle aDataHandle, void *aContext);
-    UpdatableTIContext *GetUpdatableTIContextList(void) { return mClientTraitInfoPool; }
-    uint32_t GetNumUpdatableTraitInstances(void) { return mNumUpdatableTraitInstances; }
 
-    // Data members for WDM Update
-
-    UpdatableTIContext mClientTraitInfoPool[WDM_CLIENT_MAX_NUM_UPDATABLE_TRAITS];
-    uint16_t mNumUpdatableTraitInstances;
-
+    bool mResubscribeNeeded;
     UpdateRequestContext mUpdateRequestContext;
     uint16_t mMaxUpdateSize;
     bool mUpdateInFlight;

--- a/src/lib/profiles/data-management/Current/SubscriptionHandler.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionHandler.cpp
@@ -294,8 +294,13 @@ WEAVE_ERROR SubscriptionHandler::ParsePathVersionEventLists(SubscribeRequest::Pa
 
         SuccessOrExit(err);
 
-        err = SubscriptionEngine::GetInstance()->mPublisherCatalog->Locate(traitDataHandle, &dataSource);
-        SuccessOrExit(err);
+        if (SubscriptionEngine::GetInstance()->mPublisherCatalog->Locate(traitDataHandle, &dataSource) != WEAVE_NO_ERROR)
+        {
+            // Ideally, this code will not be reached as Locate() should find the entry in the catalog.
+            // Otherwise, the earlier AddressToHandle() call would have continued.
+            // However, keeping this check here for consistency and code safety
+            continue;
+        }
 
         if (dataSource->GetSchemaEngine()->GetVersionIntersection(requestedSchemaVersionRange, computedVersionIntersection))
         {

--- a/src/test-apps/TestTDM.cpp
+++ b/src/test-apps/TestTDM.cpp
@@ -747,9 +747,9 @@ private:
 
     SubscriptionEngine mSubscriptionEngine;
     WeaveExchangeManager mExchangeMgr;
-    SingleResourceSourceTraitCatalog::CatalogItem mSourceCatalogStore[4];
+    SingleResourceSourceTraitCatalog::CatalogItem mSourceCatalogStore[5];
     SingleResourceSourceTraitCatalog mSourceCatalog;
-    SingleResourceSinkTraitCatalog::CatalogItem mSinkCatalogStore[4];
+    SingleResourceSinkTraitCatalog::CatalogItem mSinkCatalogStore[5];
     SingleResourceSinkTraitCatalog mSinkCatalog;
     TestTdmSource mTestTdmSource;
     TestTdmSource mTestTdmSource1;
@@ -770,8 +770,8 @@ private:
 };
 
 TestTdm::TestTdm()
-    : mSourceCatalog(ResourceIdentifier(ResourceIdentifier::SELF_NODE_ID), mSourceCatalogStore, 4),
-      mSinkCatalog(ResourceIdentifier(ResourceIdentifier::SELF_NODE_ID), mSinkCatalogStore, 4),
+    : mSourceCatalog(ResourceIdentifier(ResourceIdentifier::SELF_NODE_ID), mSourceCatalogStore, 5),
+      mSinkCatalog(ResourceIdentifier(ResourceIdentifier::SELF_NODE_ID), mSinkCatalogStore, 5),
       mClientBinding(NULL)
 {
     mTestCase = 0;


### PR DESCRIPTION
Redesign the way elements are removed. Instead of erasing an element from the catalog,
only set trait pointer to NULL, so DataHandle order would remain always the same.