### PR TITLE
Recording watermark by pbuf when queue is full fix

### DIFF
--- a/third_party/lwip/repo/lwip/src/core/memp.c
+++ b/third_party/lwip/repo/lwip/src/core/memp.c
@@ -486,7 +486,7 @@ memp_malloc_fn(memp_t type, const char* file, const int line)
   if (!memp) {
     LWIP_DEBUGF(MEMP_DEBUG | LWIP_DBG_TRACE, ("mm: out-of-mem in %s\n", memp_pools[type]->desc));
     if (LWIP_PERF && MEMP_IS_PBUF_POOL(type)) {
-      sys_profile_interval_set_pbuf_highwatermark(memp_sizes[type] + 1, MEMP_PBUF_POOL_HIGHWATERMARK(type));
+      sys_profile_interval_set_pbuf_highwatermark((u32_t)(*num_used_pool_ptr), MEMP_PBUF_POOL_HIGHWATERMARK(type));
     }
   }
   else {


### PR DESCRIPTION
This is a fix for TOPAZ-6525. When the queue was full the sys_profile_interval_set_pbuf_highwatermark() recorded a number of bytes in the element instead of elements count. 