### PR TITLE
Standalone Tunnel establishment should disable border gateway configuration at the platform level.

### DIFF
--- a/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.cpp
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.cpp
@@ -1882,12 +1882,13 @@ void WeaveTunnelAgent::WeaveTunnelUpNotifyAndSetState(AgentState state,
     // Perform address and route additions when the Service tunnel connection
     // is established.
 
-    if (isRoutingRestricted)
+    if (isRoutingRestricted || (mRole == kClientRole_StandaloneDevice))
     {
         // Although tunnel is restricted, it is still open but can only be
-        // usable by the border gateway for itself to access a limited set of
+        // usable by the device for itself to access a limited set of
         // Service endpoints. The device is put in this mode, typically, when
-        // it is removed from the account.
+        // it is removed from the account or configured to run in a
+        // Standalone role.
 
         // Disable border routing at the platform level.
 

--- a/src/test-apps/TestWeaveTunnel.h
+++ b/src/test-apps/TestWeaveTunnel.h
@@ -80,7 +80,8 @@ enum
     kTestNum_TestTunnelResetReconnectBackoffImmediately         = 24,
     kTestNum_TestTunnelResetReconnectBackoffRandomized          = 25,
     kTestNum_TestTunnelNoStatusReportResetReconnectBackoff      = 26,
-    kTestNum_TestTunnelTCPIdle                                  = 27,
+    kTestNum_TestTunnelRestrictedRoutingOnStandaloneTunnelOpen  = 27,
+    kTestNum_TestTunnelTCPIdle                                  = 28,
 };
 
 #endif // WEAVE_CONFIG_ENABLE_TUNNELING


### PR DESCRIPTION
Fix for Issue #172 

This was being achieved by the routingRestricted flag sent in the
StatusReport in response to the TunnelOpen. Instead, the
WeaveTunnelAgent should consult its configured role(Standalone) to
disable platform-level border gateway function.