### PR TITLE
enable inet dns test for lwip

### DIFF
--- a/src/test-apps/happy/test-templates/WeaveInetDNS.py
+++ b/src/test-apps/happy/test-templates/WeaveInetDNS.py
@@ -59,11 +59,11 @@ class WeaveInetDNS(HappyNode, HappyNetwork, WeaveTest):
 
         self.quiet = opts["quiet"]
         self.node_id = opts["node_id"]
-        self.tap_if = options["tap_if"]
+        self.tap_if = opts["tap_if"]
         self.prefix = opts["prefix"]
-        self.ipv4_gateway =options["ipv4_gateway"]
-        self.dns = options["dns"]
-        self.use_lwip = options["use_lwip"]
+        self.ipv4_gateway =opts["ipv4_gateway"]
+        self.dns = opts["dns"]
+        self.use_lwip = opts["use_lwip"]
 
         self.node_process_tag = "WEAVE-INET-NODE"
 

--- a/src/test-apps/happy/tests/standalone/inet/test_inet_dns_01.py
+++ b/src/test-apps/happy/tests/standalone/inet/test_inet_dns_01.py
@@ -52,10 +52,6 @@ class test_inet_dns(unittest.TestCase):
         subprocess.call(["happy-state-delete"])
 
     def test_inet_dns(self):
-        if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":
-            print hred("WARNING: Test skipped due to LwIP-based network cofiguration!")
-            return
-
         options = happy.HappyNodeList.option()
         options["quiet"] = True
 


### PR DESCRIPTION
1. Removed code that disabled the Inet DNS test on LWIP
2. Fixed typos in WeaveInetDNS init part -- the existing code passed some attributes to an irrelevant dictionary