### PR TITLE
artifact support to get both lwip and linux-auto logs to gcs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,30 @@ matrix:
     - name: "Linux with Defaults against GCC Network and Service Tests"
       os: linux
       compiler: gcc
-      env: BUILD_TARGET="linux-auto-gcc-check-happy"
+      env: BUILD_TARGET="linux-auto-gcc-check-happy" TRAVIS_TAG="true"
     - name: "Linux with LwIP against GCC Network and Service Tests"
       os: linux
       compiler: gcc
-      env: BUILD_TARGET="linux-lwip-gcc-check-happy"
+      env: BUILD_TARGET="linux-lwip-gcc-check-happy" TRAVIS_TAG="true"
 
+#
+#   deploy description:
+#      Travis CI supports uploading to Google Cloud Storage (GCS).
+#      openweave gcs bucket location: happy-test-log/<build_number> under link: https://storage.cloud.google.com/openweave"
+#      tags: true: deployment is triggered if and only if $TRAVIS_TAG is set here.
+#      Travis-CI help link: https://docs.travis-ci.com/user/deployment/gcs/
+#
+
+deploy:
+  provider: gcs
+  access_key_id: GOOGNPZYTVTEPZM5VBRAVVUU
+  secret_access_key:
+    secure: B7s1vLBrf2B3qvZ4trXfonkFkkWdO/BxXWCoJ9k+Jy3DQgWO6ibCSMfSv9f2pflJJpRimEZaqF6e6f1G/ojole8k19GYsj4iwuTkjBswF3E28OLV7SVvpIfDdKuRVMA+NPRfXAQVJY8yEyjpyHV8CkpO5+lE7iSGqFHQrdUVjCKtYT4loz7ABucP22BHa2FOowZuM2Yed+GtHDsWwcz5KfKl4E+SiRK9pkCno//ivP475JxNPuPN2f0W3JIMLY4r/hrTquzdUwYrKR5PaZn+S5IQ6Tc1pYlolei4l51O3y/jlCebjK2UpGziOjiHTAn+YPn6cUW4XL8UtWhP7qNts6ItpSAzKpG2ehIJ5F38UyMfCr9xK1PUSzj46DXCNyPGU/zXBqBj8o/ea7st0dbNqWVVM/ebMpSlT0aW+PRvVLfqyXwKKU6gv3b/rQg5/oybPzRIUQyAp9C6DXfyJv0LVtsDo4cvQkXrCZqzXm4kkUnRmp7ha4Dzd2tshEtciS6BNeT9uAXMiJgjmiHSTz55eqtFeiQA7fiB6Fk2Cv5WjIofClU6NAq+jaOHf6Qylk34Oy8N7Tfxmgw4cVj4slfxVHATG7AZ9YurH3G4ZQB2sNNJB00IF9mInJ//3Lz6/2VZYxIZnldkrEIzt3JQAJf2sUP/6Nmi/rYW/yMEIG9zyQY=
+  bucket: openweave
+  skip_cleanup: true
+  acl: public-read
+  upload-dir: happy-test-log/$TRAVIS_BUILD_NUMBER
+  local-dir: "$TRAVIS_BUILD_DIR/happy-test-logs"
+  on:
+    all_branches: true
+    tags: true

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -28,6 +28,34 @@ die()
     exit 1
 }
 
+###############################################################
+# Function gcc_check_happy()
+# Build for linux-auto or linux-lwip, and run tests using happy
+# Arguments:
+#     ${BUILD_TARGET}
+# Returns:
+#     None
+###############################################################
+gcc_check_happy()
+{
+    cmd_start="sudo make -f Makefile-Standalone DEBUG=1 TIMESTAMP=1 COVERAGE=1 "
+    cmd_end="BuildJobs=24 check"
+
+    if [ "lwip" in "${BUILD_TARGET}" ];then
+        build_cmd="$cmd_start USE_LWIP=1 $cmd_end"
+        build_folder="x86_64-unknown-linux-gnu-lwip"
+    else
+        build_cmd="$cmd_start $cmd_end"
+        build_folder="x86_64-unknown-linux-gnu"
+    fi
+
+    mkdir -p $TRAVIS_BUILD_DIR/happy-test-logs/$1/from-tmp
+    eval $build_cmd
+    cp $TRAVIS_BUILD_DIR/build/$build_folder/src/test-apps/happy $TRAVIS_BUILD_DIR/happy-test-logs/$1 -rf
+    cp /tmp/happy* $TRAVIS_BUILD_DIR/happy-test-logs/$1/from-tmp
+    echo "please check happy-test-log/<UTC time> under link: https://storage.cloud.google.com/openweave"
+}
+
 case "${BUILD_TARGET}" in
 
     linux-auto-clang)
@@ -39,19 +67,11 @@ case "${BUILD_TARGET}" in
         ;;
 
     linux-auto-gcc-check-happy)
-        mkdir -p $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET}/from-tmp
-        sudo make -f Makefile-Standalone DEBUG=1 TIMESTAMP=1 COVERAGE=1 BuildJobs=24 check
-        cp $TRAVIS_BUILD_DIR/build/x86_64-unknown-linux-gnu/src/test-apps/happy $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET} -rf
-        cp /tmp/happy* $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET}/from-tmp
-        echo "please check happy-test-log/<build_number> under link: https://storage.cloud.google.com/openweave"
+        gcc_check_happy ${BUILD_TARGET}
         ;;
 
     linux-lwip-gcc-check-happy)
-        mkdir -p $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET}/from-tmp
-        sudo make -f Makefile-Standalone DEBUG=1 TIMESTAMP=1 COVERAGE=1 USE_LWIP=1 BuildJobs=24 check
-        cp $TRAVIS_BUILD_DIR/build/x86_64-unknown-linux-gnu-lwip/src/test-apps/happy $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET} -rf
-        cp /tmp/happy* $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET}/from-tmp
-        echo "please check happy-test-log/<build_number> under link: https://storage.cloud.google.com/openweave"
+        gcc_check_happy ${BUILD_TARGET}
         ;;
 
     linux-lwip-clang)

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -39,11 +39,19 @@ case "${BUILD_TARGET}" in
         ;;
 
     linux-auto-gcc-check-happy)
+        mkdir -p $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET}/from-tmp
         sudo make -f Makefile-Standalone DEBUG=1 TIMESTAMP=1 COVERAGE=1 BuildJobs=24 check
+        cp $TRAVIS_BUILD_DIR/build/x86_64-unknown-linux-gnu/src/test-apps/happy $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET} -rf
+        cp /tmp/happy* $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET}/from-tmp
+        echo "please check happy-test-log/<build_number> under link: https://storage.cloud.google.com/openweave"
         ;;
 
     linux-lwip-gcc-check-happy)
+        mkdir -p $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET}/from-tmp
         sudo make -f Makefile-Standalone DEBUG=1 TIMESTAMP=1 COVERAGE=1 USE_LWIP=1 BuildJobs=24 check
+        cp $TRAVIS_BUILD_DIR/build/x86_64-unknown-linux-gnu-lwip/src/test-apps/happy $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET} -rf
+        cp /tmp/happy* $TRAVIS_BUILD_DIR/happy-test-logs/${BUILD_TARGET}/from-tmp
+        echo "please check happy-test-log/<build_number> under link: https://storage.cloud.google.com/openweave"
         ;;
 
     linux-lwip-clang)


### PR DESCRIPTION
 I've got artifacts work with gcs using travis-ci interface, PR is:
https://github.com/openweave/openweave-core/pull/182

I have tested on my repo, here is the link of test logs upload example on gcs:
https://pantheon.corp.google.com/storage/browser/openweave/happy-test-log/164/?project=openweave-test-project&authuser=0&organizationId=433637338589

I've enabled it for all branches, so it should upload logs automatically to gcs from PR branch as well.

Hope this effort will help debugging the test flakiness on travis-ci.

Please let me know if you have any questions.

Note: Content in .travis.yml got shift to front a little bit, that is done by command "travis setup gcs" during travis-ci/gcs setup, more info is in this link:
https://docs.travis-ci.com/user/deployment/gcs/