### PR TITLE
Fix for WEAV-3231.

### DIFF
--- a/src/lib/core/WeaveMessageLayer.cpp
+++ b/src/lib/core/WeaveMessageLayer.cpp
@@ -508,6 +508,12 @@ WEAVE_ERROR WeaveMessageLayer::SendMessage(const IPAddress &destAddr, uint16_t d
     //Check if drop flag is set; If so, do not send message; return WEAVE_NO_ERROR;
     VerifyOrExit(!mDropMessage, err = WEAVE_NO_ERROR);
 
+    // Drop the message and return. Free the buffer if it does not need to be
+    // retained(e.g., for WRM retransmissions).
+    WEAVE_FAULT_INJECT(FaultInjection::kFault_DropOutgoingUDPMsg,
+            ExitNow(err = WEAVE_NO_ERROR);
+            );
+
 #if INET_CONFIG_ENABLE_IPV4
     if (destAddr.IsIPv4())
     {

--- a/src/lib/profiles/data-management/Current/TraitData.cpp
+++ b/src/lib/profiles/data-management/Current/TraitData.cpp
@@ -522,19 +522,20 @@ WEAVE_ERROR TraitSchemaEngine::StoreData(PropertyPathHandle aHandle, TLVReader &
                     curHandle = GetChildHandle(parentHandle, TagNumFromTag(tag));
                 }
 
-                if (IsDictionary(curHandle)) {
-                    // If we're descending onto a node that is a dictionary, we know for certain that it is a replace operation
-                    // since the target path handle for this function was higher in the tree than the node representing the
-                    // dictionary itself.
-                    aDelegate->OnDataSinkEvent(ISetDataDelegate::kDataSinkEvent_DictionaryReplaceBegin, curHandle);
-                } else if (IsDictionary(parentHandle)) {
-                    // Alternatively, if we're descending onto a node whose parent is a dictionary, we know that this node
-                    // represents an element in the dictionary and as such, is an appropriate point in the traversal to notify the
-                    // application of an upcoming dictionary item modification/insertion.
-                    aDelegate->OnDataSinkEvent(ISetDataDelegate::kDataSinkEvent_DictionaryItemModifyBegin,
-                                               curHandle);
+                if (!(apPathFilter != NULL && apPathFilter->FilterPath(curHandle))) {
+                    if (IsDictionary(curHandle)) {
+                        // If we're descending onto a node that is a dictionary, we know for certain that it is a replace operation
+                        // since the target path handle for this function was higher in the tree than the node representing the
+                        // dictionary itself.
+                        aDelegate->OnDataSinkEvent(ISetDataDelegate::kDataSinkEvent_DictionaryReplaceBegin, curHandle);
+                    } else if (IsDictionary(parentHandle)) {
+                        // Alternatively, if we're descending onto a node whose parent is a dictionary, we know that this node
+                        // represents an element in the dictionary and as such, is an appropriate point in the traversal to notify the
+                        // application of an upcoming dictionary item modification/insertion.
+                        aDelegate->OnDataSinkEvent(ISetDataDelegate::kDataSinkEvent_DictionaryItemModifyBegin,
+                                                   curHandle);
+                    }
                 }
-
 #if !TDM_DISABLE_STRICT_SCHEMA_COMPLIANCE
                 if (IsNullPropertyPathHandle(curHandle)) {
                     err = WEAVE_ERROR_TLV_TAG_NOT_FOUND;

--- a/src/lib/profiles/data-management/Current/UpdateClient.cpp
+++ b/src/lib/profiles/data-management/Current/UpdateClient.cpp
@@ -152,6 +152,14 @@ WEAVE_ERROR UpdateClient::SendUpdate(bool aIsPartialUpdate, PacketBuffer *aBuf, 
                 nl::Inet::FaultInjection::kFault_Send,
                 0, 1));
 
+    // Use DropOutgoingMsg fault to fail the current outgoing message.
+    // If WRM is being used, the transmission would be retried after a
+    // retransmission timeout delay.
+    WEAVE_FAULT_INJECT(FaultInjection::kFault_WDM_UpdateRequestDropMessage,
+            nl::Inet::FaultInjection::GetManager().FailAtFault(
+                nl::Weave::FaultInjection::kFault_DropOutgoingUDPMsg,
+                0, 1));
+
     // Use WRM's SendError fault to fail asynchronously
     WEAVE_FAULT_INJECT(FaultInjection::kFault_WDM_UpdateRequestSendErrorAsync,
             nl::Weave::FaultInjection::GetManager().FailAtFault(

--- a/src/lib/support/WeaveFaultInjection.cpp
+++ b/src/lib/support/WeaveFaultInjection.cpp
@@ -40,6 +40,7 @@ static const nl::FaultInjection::Name sManagerName = "Weave";
 static const nl::FaultInjection::Name sFaultNames[] = {
     "AllocExchangeContext",
     "DropIncomingUDPMsg",
+    "DropOutgoingUDPMsg",
     "AllocBinding",
     "SendAlarm",
     "HandleAlarm",
@@ -69,6 +70,7 @@ static const nl::FaultInjection::Name sFaultNames[] = {
     "WDMUpdateRequestSendErrorInline",
     "WDMUpdateRequestSendErrorAsync",
     "WDMUpdateRequestBadProfile",
+    "WDMUpdateRequestDropMessage",
     "WDMUpdateResponseBusy",
     "WDMPathStoreFull",
     "WDMTreatNotifyAsCancel",

--- a/src/lib/support/WeaveFaultInjection.h
+++ b/src/lib/support/WeaveFaultInjection.h
@@ -53,6 +53,7 @@ typedef enum
 {
     kFault_AllocExchangeContext,                /**< Fail the allocation of an ExchangeContext */
     kFault_DropIncomingUDPMsg,                  /**< Drop an incoming UDP message without any processing */
+    kFault_DropOutgoingUDPMsg,                  /**< Drop an outgoing UDP message at the Weave Message layer */
     kFault_AllocBinding,                        /**< Fail the allocation of a Binding */
     kFault_SendAlarm,                           /**< Fail to send an alarm message */
     kFault_HandleAlarm,                         /**< Fail to handle an alarm message */
@@ -87,6 +88,7 @@ typedef enum
     kFault_WDM_UpdateRequestSendErrorInline,    /**< Inject an inline Inet Send error for the UpdateRequest */
     kFault_WDM_UpdateRequestSendErrorAsync,     /**< Inject a WRM SendError for the UpdateRequest */
     kFault_WDM_UpdateRequestBadProfile,         /**< Inject an invalid Profile ID in the UpdateRequest */
+    kFault_WDM_UpdateRequestDropMessage,        /**< Drop an outgoing WDM UpdateRequest message using the DropOutgoingUDPMsg fault */
     kFault_WDM_UpdateResponseBusy,              /**< Inject a status code busy in the StatusList */
     kFault_WDM_PathStoreFull,                   /**< Inject a WDM_PATH_STORE_FULL error */
     kFault_WDM_TreatNotifyAsCancel,             /**< Process a Notify request as a CancelSubscription request */


### PR DESCRIPTION
Make sure that while processing the DataList in a Notify starting from
the root, filter checks are correctly performed while descending into
dictionaries and DictionaryReplace/Modify pre-processing functions
are not called for dictionary paths that also exist in a pending WDM
Update.