### PR TITLE
On LwIP: count all interfaces that support broadcast as supporting mu…

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -173,7 +173,7 @@ bool InterfaceIteratorBasis::SupportsMulticast(void)
     {
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5
-        return (curIntf->flags & (NETIF_FLAG_IGMP | NETIF_FLAG_MLD6)) != 0;
+        return (curIntf->flags & (NETIF_FLAG_IGMP | NETIF_FLAG_MLD6 | NETIF_FLAG_BROADCAST)) != 0;
 #else
         return (curIntf->flags & NETIF_FLAG_POINTTOPOINT) == 0;
 #endif // LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5


### PR DESCRIPTION
…lticast

Rationale: The callers of this interface use it to determine whether
an interface is capable of multicast, with the common case being
link-local all-nodes.  Per spec, the MLD support is not required if the
node only supports all-nodes addess; consequently, checking for BROADCAST
support seems appropriate.