### PR TITLE
Adding ability to create firmware signing leaf from public key

### DIFF
--- a/src/tools/weave/Cmd_GenCodeSigningCert.cpp
+++ b/src/tools/weave/Cmd_GenCodeSigningCert.cpp
@@ -47,6 +47,7 @@ static OptionDef gCmdOptionDefs[] =
 {
     { "id",         kArgumentRequired, 'i' },
     { "key",        kArgumentRequired, 'k' },
+    { "pubkey",     kArgumentRequired, 'p' },
     { "ca-cert",    kArgumentRequired, 'C' },
     { "ca-key",     kArgumentRequired, 'K' },
     { "out",        kArgumentRequired, 'o' },
@@ -66,6 +67,11 @@ static const char *const gCmdOptionHelp =
     "\n"
     "       File containing the public and private keys for the new certificate.\n"
     "       (File must be in PEM format).\n"
+    "\n"
+    "   -p, --pubkey <file>\n"
+    "\n"
+    "       File containing the public key for the new certificate.\n"
+    "       (File must be in PEM or DER format).\n"
     "\n"
     "   -C, --ca-cert <file>\n"
     "\n"
@@ -129,6 +135,7 @@ static const char *gCACertFileName = NULL;
 static const char *gCAKeyFileName = NULL;
 static const char *gNewCertFileName = NULL;
 static const char *gNewCertKeyFileName = NULL;
+static const char *gNewCertPubKeyFileName = NULL;
 static int32_t gValidDays = 0;
 static const EVP_MD *gSigHashAlgo = NULL;
 static struct tm gValidFrom;
@@ -168,10 +175,17 @@ bool Cmd_GenCodeSigningCert(int argc, char *argv[])
         ExitNow(res = false);
     }
 
-    if (gNewCertKeyFileName == NULL)
+    if (gNewCertKeyFileName == NULL && gNewCertPubKeyFileName == NULL)
     {
         fprintf(stderr, "Please use the --key option to specify the public/private key file for the\n"
-                        "new certificate.\n");
+                        "new certificate or use the --pubkey option to specify the public key file\n");
+        ExitNow(res = false);
+    }
+
+    if (gNewCertKeyFileName != NULL && gNewCertPubKeyFileName != NULL)
+    {
+        fprintf(stderr, "Please use the --key option to specify the public/private key file for the\n"
+                        "new certificate or use the --pubkey option to specify the public key file\n");
         ExitNow(res = false);
     }
 
@@ -234,8 +248,17 @@ bool Cmd_GenCodeSigningCert(int argc, char *argv[])
     else
         newCertFile = stdout;
 
-    if (!ReadPrivateKey(gNewCertKeyFileName, "Enter password for private key:", newCertKey))
-        ExitNow(res = false);
+
+    if (gNewCertKeyFileName != NULL && gNewCertPubKeyFileName == NULL)
+    {
+        if (!ReadPrivateKey(gNewCertKeyFileName, "Enter password for private key:", newCertKey))
+           ExitNow(res = false);
+    }
+    if (gNewCertKeyFileName == NULL && gNewCertPubKeyFileName != NULL)
+    {
+	if (!ReadPublicKey(gNewCertPubKeyFileName, newCertKey))
+            ExitNow(res = false);
+    }
 
     if (!ReadCertPEM(gCACertFileName, caCert))
         ExitNow(res = false);
@@ -299,6 +322,9 @@ bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *n
     case 'k':
         gNewCertKeyFileName = arg;
         break;
+    case 'p':
+	gNewCertPubKeyFileName = arg;
+	break;
     case 'V':
         if (!ParseDateTime(arg, gValidFrom))
         {

--- a/src/tools/weave/Cmd_GenCodeSigningCert.cpp
+++ b/src/tools/weave/Cmd_GenCodeSigningCert.cpp
@@ -73,6 +73,8 @@ static const char *const gCmdOptionHelp =
     "       File containing the public key for the new certificate.\n"
     "       (File must be in PEM or DER format).\n"
     "\n"
+    "       Please only specify one of --key or --pubkey.\n"
+    "\n"
     "   -C, --ca-cert <file>\n"
     "\n"
     "       File containing CA certificate to be used to sign the new certificate.\n"
@@ -184,8 +186,7 @@ bool Cmd_GenCodeSigningCert(int argc, char *argv[])
 
     if (gNewCertKeyFileName != NULL && gNewCertPubKeyFileName != NULL)
     {
-        fprintf(stderr, "Please use the --key option to specify the public/private key file for the\n"
-                        "new certificate or use the --pubkey option to specify the public key file\n");
+        fprintf(stderr, "Please specify only one of --key or --pubkey\n");
         ExitNow(res = false);
     }
 

--- a/src/tools/weave/KeyUtils.cpp
+++ b/src/tools/weave/KeyUtils.cpp
@@ -269,7 +269,7 @@ bool DecodePublicKey(const uint8_t *keyData, uint32_t keyDataLen, KeyFormat keyF
         if (d2i_PUBKEY_bio(keyBIO, &key) == NULL)
         {
             fprintf(stderr, "Unable to read %s\n", keySource);
-	    ReportOpenSSLErrorAndExit("d2i_PUBKEY_bio", res = false);
+            ReportOpenSSLErrorAndExit("d2i_PUBKEY_bio", res = false);
 	}
     }
     else
@@ -282,7 +282,7 @@ exit:
     if (tmpKeyBuf != NULL)
         free(tmpKeyBuf);
     if (keyBIO != NULL)
-	BIO_free_all(keyBIO);
+        BIO_free_all(keyBIO);
     return res;
 }
 

--- a/src/tools/weave/KeyUtils.cpp
+++ b/src/tools/weave/KeyUtils.cpp
@@ -342,7 +342,7 @@ KeyFormat DetectKeyFormat(const uint8_t *key, uint32_t keyLen)
     if (ContainsPEMMarker(pkcs8PEMMarker, key, keyLen))
         return kKeyFormat_PEM_PKCS8;
 
-    if(ContainsPEMMarker(ecPUBPEMMarker, key, keyLen))
+    if (ContainsPEMMarker(ecPUBPEMMarker, key, keyLen))
         return kKeyFormat_PEM;
 
     return kKeyFormat_DER;

--- a/src/tools/weave/KeyUtils.cpp
+++ b/src/tools/weave/KeyUtils.cpp
@@ -59,6 +59,24 @@ exit:
     return res;
 }
 
+bool ReadPublicKey(const char *fileName, EVP_PKEY *& key)
+{
+    bool res = true;
+    uint8_t *keyData = NULL;
+    uint32_t keyDataLen;
+
+    key = NULL;
+    res = ReadFileIntoMem(fileName, keyData, keyDataLen);
+    if (!res)
+        ExitNow();
+    res = DecodePublicKey(keyData, keyDataLen, kKeyFormat_Unknown, fileName, key);
+
+exit:
+  if (keyData != NULL)
+      free(keyData);
+  return res;
+}
+
 bool ReadWeavePrivateKey(const char *fileName, uint8_t *& key, uint32_t &keyLen)
 {
     bool res = true;
@@ -220,6 +238,53 @@ exit:
     return res;
 }
 
+bool DecodePublicKey(const uint8_t *keyData, uint32_t keyDataLen, KeyFormat keyFormat, const char *keySource, EVP_PKEY *& key)
+{
+    bool res = true;
+    uint8_t *tmpKeyBuf = NULL;
+    BIO *keyBIO = NULL;
+    key = NULL;
+
+    if (keyFormat == kKeyFormat_Unknown)
+        keyFormat = DetectKeyFormat(keyData, keyDataLen);
+
+    keyBIO = BIO_new_mem_buf((void *)keyData, keyDataLen);
+    if (keyBIO == NULL)
+    {
+        fprintf(stderr, "Memory allocation error\n");
+        ExitNow(res = false);
+    }
+
+    if (keyFormat == kKeyFormat_PEM)
+    {
+        if (PEM_read_bio_PUBKEY(keyBIO, &key, NULL, NULL) == NULL)
+        {
+            fprintf(stderr, "Unable to read %s\n", keySource);
+            ReportOpenSSLErrorAndExit("PEM_read_bio_PUBKEY", res = false);
+        }
+
+    }
+    else if (keyFormat == kKeyFormat_DER)
+    {
+        if (d2i_PUBKEY_bio(keyBIO, &key) == NULL)
+        {
+            fprintf(stderr, "Unable to read %s\n", keySource);
+	    ReportOpenSSLErrorAndExit("d2i_PUBKEY_bio", res = false);
+	}
+    }
+    else
+    {
+        fprintf(stderr, "Key type not supported");
+        ExitNow(res = false);
+    }
+
+exit:
+    if (tmpKeyBuf != NULL)
+        free(tmpKeyBuf);
+    if (keyBIO != NULL)
+	BIO_free_all(keyBIO);
+    return res;
+}
 
 bool DetectKeyFormat(FILE *keyFile, KeyFormat& keyFormat)
 {
@@ -254,6 +319,8 @@ KeyFormat DetectKeyFormat(const uint8_t *key, uint32_t keyLen)
 
     static const char *pkcs8PEMMarker = "-----BEGIN PRIVATE KEY-----";
 
+    static const char *ecPUBPEMMarker = "-----BEGIN PUBLIC KEY-----";
+
     if (keyLen > sizeof(ecWeaveRawPrefix) && memcmp(key, ecWeaveRawPrefix, sizeof(ecWeaveRawPrefix)) == 0)
         return kKeyFormat_Weave_Raw;
 
@@ -274,6 +341,9 @@ KeyFormat DetectKeyFormat(const uint8_t *key, uint32_t keyLen)
 
     if (ContainsPEMMarker(pkcs8PEMMarker, key, keyLen))
         return kKeyFormat_PEM_PKCS8;
+
+    if(ContainsPEMMarker(ecPUBPEMMarker, key, keyLen))
+        return kKeyFormat_PEM;
 
     return kKeyFormat_DER;
 }

--- a/src/tools/weave/weave-tool.h
+++ b/src/tools/weave/weave-tool.h
@@ -121,8 +121,10 @@ extern bool X509DERToPEM(uint8_t *cert, uint32_t& certLen, uint32_t bufLen);
 extern CertFormat DetectCertFormat(uint8_t *cert, uint32_t certLen);
 
 extern bool ReadPrivateKey(const char *fileName, const char *prompt, EVP_PKEY *& key);
+extern bool ReadPublicKey(const char *fileName, EVP_PKEY *& key);
 extern bool ReadWeavePrivateKey(const char *fileName, uint8_t *& key, uint32_t &keyLen);
 extern bool DecodePrivateKey(const uint8_t *keyData, uint32_t keyDataLen, KeyFormat keyFormat, const char *keySource, const char *prompt, EVP_PKEY *& key);
+extern bool DecodePublicKey(const uint8_t *keyData, uint32_t keyDataLen, KeyFormat keyFormat, const char *keySource, EVP_PKEY *& key);
 extern bool DetectKeyFormat(FILE *keyFile, KeyFormat& keyFormat);
 extern KeyFormat DetectKeyFormat(const uint8_t *key, uint32_t keyLen);
 extern bool GenerateKeyPair(const char *curveName, EVP_PKEY *& key);


### PR DESCRIPTION
In order to store firmware leaf key material in an HSM, I need to generate the private keys in a secure environment and sign only the public key. Adding the functionality to do so in weave tool.