### PR TITLE
Give event ids from subscription request to the app

### DIFF
--- a/src/lib/profiles/data-management/Current/SubscriptionHandler.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionHandler.cpp
@@ -690,6 +690,8 @@ void SubscriptionHandler::InitWithIncomingRequest(Binding * const aBinding, cons
         inParam.mSubscribeRequestParsed.mNumTraitInstances    = mNumTraitInstances;
         inParam.mSubscribeRequestParsed.mSubscribeToAllEvents = mSubscribeToAllEvents;
 
+        memcpy(inParam.mSubscribeRequestParsed.mNextVendedEvents, mSelfVendedEvents, sizeof(inParam.mSubscribeRequestParsed.mNextVendedEvents));
+
         err = request.GetSubscribeTimeoutMin(&inParam.mSubscribeRequestParsed.mTimeoutSecMin);
         if (WEAVE_END_OF_TLV == err)
         {

--- a/src/lib/profiles/data-management/Current/SubscriptionHandler.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionHandler.h
@@ -100,6 +100,8 @@ public:
             bool mIsSubscriptionIdValid;
             uint64_t mSubscriptionId;
 
+            event_id_t mNextVendedEvents[kImportanceType_Last - kImportanceType_First + 1];
+
             SubscriptionHandler * mHandler;
         } mSubscribeRequestParsed;
 

--- a/src/lib/support/PersistedCounter.cpp
+++ b/src/lib/support/PersistedCounter.cpp
@@ -78,6 +78,21 @@ PersistedCounter::Advance(void)
     return IncrementCount();
 }
 
+WEAVE_ERROR
+PersistedCounter::AdvanceEpochRelative(uint32_t aValue)
+{
+    WEAVE_ERROR ret;
+
+    mStartingCounterValue = (aValue / mEpoch) * mEpoch;  // Start of enclosing epoch
+    mCounterValue = mStartingCounterValue + mEpoch - 1;  // Move to end of enclosing epoch
+    ret = IncrementCount(); // Force to next epoch
+#if WEAVE_CONFIG_PERSISTED_COUNTER_DEBUG_LOGGING
+    WeaveLogError(EventLogging, "Advanced counter to 0x%x (relative to 0x%x)", mCounterValue, aValue);
+#endif
+
+    return ret;
+}
+
 bool
 PersistedCounter::GetNextValue(uint32_t &aValue)
 {

--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -72,6 +72,15 @@ public:
      */
     WEAVE_ERROR Advance(void);
 
+    /*
+     *  @brief
+     *    Advance the counter to start of the epoch following the provided
+     *    value.
+     *
+     *  @return Any error returned by a write to persistent storage.
+     */
+    WEAVE_ERROR AdvanceEpochRelative(uint32_t aValue);
+
 private:
     /**
      *  @brief


### PR DESCRIPTION
Weave provides to the application the event ids send down as part of the
subscription request.

A new method is added to PersistentCounter that allows the counter to be
advanced past a given value (event id).
