### PR TITLE
Enhance the API of the ServiceDirectory to produce a HostPortList

### DIFF
--- a/src/lib/profiles/service-directory/ServiceDirectory.h
+++ b/src/lib/profiles/service-directory/ServiceDirectory.h
@@ -273,6 +273,7 @@ public:
                         const uint32_t aConnectTimeoutMsecs = 0,
                         const InterfaceId aConnectIntf = INET_NULL_INTERFACEID);
 
+    WEAVE_ERROR lookup(uint64_t aServiceEp, HostPortList *outHostPortList);
     WEAVE_ERROR lookup(uint64_t aServiceEp, uint8_t *aControlByte, uint8_t **aDirectoryEntry);
 
     WEAVE_ERROR replaceOrAddCacheEntry(uint16_t port,


### PR DESCRIPTION
The previous `lookup` method was not terribly useful -- it exposed the
internal structures in the ServiceDirectory, and it was not entirely
clear how to use it properly.  This commit refactors the code such
that:

* we provide a variant of the `lookup` method that populates a
  HostPortList.

* we use the code internally to implement the code paths inside
  `lookupAndConnect`