### PR TITLE
Make LoggingManagent::CreateLoggingManagement() API clearer and more …

### DIFF
--- a/src/lib/profiles/data-management/Current/LoggingManagement.h
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.h
@@ -159,10 +159,10 @@ class LogBDXUpload;
 
 struct LogStorageResources
 {
-    __CONSTEXPR LogStorageResources(void * inBuffer, size_t inBufferSize, nl::Weave::Platform::PersistedStorage::Key * inCounterKey,
-                                  uint32_t inCounterEpoch, nl::Weave::PersistedCounter * inCounterStorage, ImportanceType inImportance) :
-        mBuffer(inBuffer),
-        mBufferSize(inBufferSize), mCounterKey(inCounterKey), mCounterEpoch(inCounterEpoch), mCounterStorage(inCounterStorage), mImportance(inImportance) { };
+    // __CONSTEXPR LogStorageResources(void * inBuffer, size_t inBufferSize, nl::Weave::Platform::PersistedStorage::Key * inCounterKey,
+    //                               uint32_t inCounterEpoch, nl::Weave::PersistedCounter * inCounterStorage, ImportanceType inImportance) :
+    //     mBuffer(inBuffer),
+    //     mBufferSize(inBufferSize), mCounterKey(inCounterKey), mCounterEpoch(inCounterEpoch), mCounterStorage(inCounterStorage), mImportance(inImportance) { };
     void * mBuffer;     ///< Buffer to be used as a storage at the particular importance level and shared with more important events.
                         ///< Must not be NULL.  Must be large enough to accomodate the largest event emitted by the system.
     size_t mBufferSize; ///< The size, in bytes, of the `mBuffer`.

--- a/src/lib/profiles/data-management/Current/LoggingManagement.h
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.h
@@ -159,10 +159,6 @@ class LogBDXUpload;
 
 struct LogStorageResources
 {
-    // __CONSTEXPR LogStorageResources(void * inBuffer, size_t inBufferSize, nl::Weave::Platform::PersistedStorage::Key * inCounterKey,
-    //                               uint32_t inCounterEpoch, nl::Weave::PersistedCounter * inCounterStorage, ImportanceType inImportance) :
-    //     mBuffer(inBuffer),
-    //     mBufferSize(inBufferSize), mCounterKey(inCounterKey), mCounterEpoch(inCounterEpoch), mCounterStorage(inCounterStorage), mImportance(inImportance) { };
     void * mBuffer;     ///< Buffer to be used as a storage at the particular importance level and shared with more important events.
                         ///< Must not be NULL.  Must be large enough to accomodate the largest event emitted by the system.
     size_t mBufferSize; ///< The size, in bytes, of the `mBuffer`.

--- a/src/lib/profiles/data-management/Current/LoggingManagement.h
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.h
@@ -69,7 +69,7 @@ struct CircularEventBuffer
     CircularEventBuffer * mNext; ///< A pointer #CircularEventBuffer storing events more important events
 
     ImportanceType mImportance; ///< The buffer is the final bucket for events of this importance.  Events of lesser importance are
-                                //dropped when they get bumped out of this buffer
+                                ///< dropped when they get bumped out of this buffer
 
     event_id_t mFirstEventID; ///< First event ID stored in the logging subsystem for this importance
     event_id_t mLastEventID;  ///< Last event ID vended for this importance
@@ -132,7 +132,7 @@ struct EventEnvelopeContext
     int64_t mDeltaUtc;
 #endif
     ImportanceType mImportance;
-    ExternalEvents *mExternalEvents;
+    ExternalEvents * mExternalEvents;
 };
 
 enum LoggingManagementStates
@@ -148,6 +148,37 @@ class LogBDXUpload;
 
 /**
  * @brief
+ *   A helper class used in initializing logging management.
+ *
+ * The class is used to encapsulate the resources allocated by the caller and denotes
+ * resources to be used in logging events of a particular importance.  Note that
+ * while resources referring to the counters are used exclusively by the
+ * particular importance level, the buffers are shared between `this` importance
+ * level and events that are "more" important.
+ */
+
+struct LogStorageResources
+{
+    __CONSTEXPR LogStorageResources(void * inBuffer, size_t inBufferSize, nl::Weave::Platform::PersistedStorage::Key * inCounterKey,
+                                  uint32_t inCounterEpoch, nl::Weave::PersistedCounter * inCounterStorage, ImportanceType inImportance) :
+        mBuffer(inBuffer),
+        mBufferSize(inBufferSize), mCounterKey(inCounterKey), mCounterEpoch(inCounterEpoch), mCounterStorage(inCounterStorage), mImportance(inImportance) { };
+    void * mBuffer;     ///< Buffer to be used as a storage at the particular importance level and shared with more important events.
+                        ///< Must not be NULL.  Must be large enough to accomodate the largest event emitted by the system.
+    size_t mBufferSize; ///< The size, in bytes, of the `mBuffer`.
+    nl::Weave::Platform::PersistedStorage::Key *
+        mCounterKey;        ///< Name of the key naming persistent counter for events of this importance.  When NULL, the persistent
+                            ///< counters will not be used for this importance level.
+    uint32_t mCounterEpoch; ///< The interval used in incrementing persistent counters.  When 0, the persistent counters will not be
+                            ///< used for this importance level.
+    nl::Weave::PersistedCounter *
+        mCounterStorage; ///< Application-provided storage for persistent counter for this importance level. When NULL, persistent
+                         ///< counters will not be used for this importance level.
+    ImportanceType mImportance; ///< Log importance level associated with the resources provided in this structure.
+};
+
+/**
+ * @brief
  *   A class for managing the in memory event logs.
  */
 
@@ -156,20 +187,13 @@ class LoggingManagement
     friend class LogBDXUpload;
 
 public:
-    LoggingManagement(nl::Weave::WeaveExchangeManager * inMgr, size_t inNumBuffers, size_t * inBufferLengths, void ** inBuffers,
-                      nl::Weave::Platform::PersistedStorage::Key * inCounterKeys, const uint32_t * inCounterEpochs,
-                      nl::Weave::PersistedCounter ** inCounterStorage);
-    LoggingManagement(nl::Weave::WeaveExchangeManager * inMgr, size_t inNumBuffers, size_t * inBufferLengths, void ** inBuffers,
-                      nl::Weave::MonotonicallyIncreasingCounter ** nWeaveCounter);
+    LoggingManagement(nl::Weave::WeaveExchangeManager * inMgr, size_t inNumBuffers, const LogStorageResources * const inLogStorageResources);
     LoggingManagement(void);
 
     static LoggingManagement & GetInstance(void);
 
-    static void CreateLoggingManagement(nl::Weave::WeaveExchangeManager * inMgr, size_t inNumBuffers, size_t * inBufferLengths,
-                                        void ** inBuffers, nl::Weave::Platform::PersistedStorage::Key * inCounterKeys,
-                                        const uint32_t * inCounterEpochs, nl::Weave::PersistedCounter ** inCounterStorage);
-    static void CreateLoggingManagement(nl::Weave::WeaveExchangeManager * inMgr, size_t inNumBuffers, size_t * inBufferLengths,
-                                        void ** inBuffers, nl::Weave::MonotonicallyIncreasingCounter ** nWeaveCounter);
+    static void CreateLoggingManagement(nl::Weave::WeaveExchangeManager * inMgr, size_t inNumBuffers, const LogStorageResources * const inLogStorageResources);
+
     static void DestroyLoggingManagement(void);
 
     WEAVE_ERROR SetExchangeManager(nl::Weave::WeaveExchangeManager * inMgr);
@@ -209,8 +233,8 @@ public:
 #if WEAVE_CONFIG_EVENT_LOGGING_EXTERNAL_EVENT_SUPPORT
     WEAVE_ERROR RegisterEventCallbackForImportance(ImportanceType inImportance, FetchExternalEventsFunct inFetchCallback,
                                                    NotifyExternalEventsDeliveredFunct inNotifyCallback,
-                                                   NotifyExternalEventsEvictedFunct inEvictedCallback,
-                                                   size_t inNumEvents, event_id_t * outLastEventID);
+                                                   NotifyExternalEventsEvictedFunct inEvictedCallback, size_t inNumEvents,
+                                                   event_id_t * outLastEventID);
     WEAVE_ERROR RegisterEventCallbackForImportance(ImportanceType inImportance, FetchExternalEventsFunct inFetchCallback,
                                                    NotifyExternalEventsDeliveredFunct inNotifyCallback, size_t inNumEvents,
                                                    event_id_t * outLastEventID);
@@ -221,7 +245,6 @@ public:
     WEAVE_ERROR BlitEvent(EventLoadOutContext * aContext, const EventSchema & inSchema, EventWriterFunct inEventWriter,
                           void * inAppData, const EventOptions * inOptions);
     void SkipEvent(EventLoadOutContext * aContext);
-
 
 #if WEAVE_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
     bool CheckShouldRunWDM(void);
@@ -260,8 +283,10 @@ private:
 
 #if WEAVE_CONFIG_EVENT_LOGGING_EXTERNAL_EVENT_SUPPORT
     static WEAVE_ERROR FindExternalEvents(const nl::Weave::TLV::TLVReader & aReader, size_t aDepth, void * aContext);
-    WEAVE_ERROR GetExternalEventsFromEventId(ImportanceType inImportance, event_id_t inEventId, ExternalEvents * outExternalEvents, nl::Weave::TLV::TLVReader & inReader);
-    static WEAVE_ERROR BlitExternalEvent(nl::Weave::TLV::TLVWriter &inWriter, ImportanceType inImportance, ExternalEvents &inEvents);
+    WEAVE_ERROR GetExternalEventsFromEventId(ImportanceType inImportance, event_id_t inEventId, ExternalEvents * outExternalEvents,
+                                             nl::Weave::TLV::TLVReader & inReader);
+    static WEAVE_ERROR BlitExternalEvent(nl::Weave::TLV::TLVWriter & inWriter, ImportanceType inImportance,
+                                         ExternalEvents & inEvents);
 #endif // WEAVE_CONFIG_EVENT_LOGGING_EXTERNAL_EVENT_SUPPORT
     CircularEventBuffer * mEventBuffer;
     WeaveExchangeManager * mExchangeMgr;

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -389,6 +389,10 @@ inline void WeaveDie(void)
 #define __OVERRIDE override
 #endif
 
+#ifndef __CONSTEXPR
+#define __CONSTEXPR constexpr
+#endif
+
 #else
 
 #ifndef __FINAL
@@ -397,6 +401,10 @@ inline void WeaveDie(void)
 
 #ifndef __OVERRIDE
 #define __OVERRIDE
+#endif
+
+#ifndef __CONSTEXPR
+#define __CONSTEXPR constexpr
 #endif
 
 #endif // defined(__cplusplus) && (__cplusplus >= 201103L)

--- a/src/test-apps/GenerateEventLog.cpp
+++ b/src/test-apps/GenerateEventLog.cpp
@@ -60,29 +60,28 @@
 using namespace nl::Weave::TLV;
 using namespace nl::Weave::Profiles::DataManagement;
 
-static bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg);
+static bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
 
 namespace nl {
 namespace Weave {
 namespace Profiles {
 namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNamespaceDesignation_Current) {
 namespace Platform {
-    // for unit tests, the dummy critical section is sufficient.
-    void CriticalSectionEnter()
-    {
-        return;
-    }
+// for unit tests, the dummy critical section is sufficient.
+void CriticalSectionEnter()
+{
+    return;
+}
 
-    void CriticalSectionExit()
-    {
-        return;
-    }
-} // Platform
-} // WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNamespaceDesignation_Current)
-} // Profiles
-} // Weave
-} // nl
-
+void CriticalSectionExit()
+{
+    return;
+}
+} // namespace Platform
+} // namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNamespaceDesignation_Current)
+} // namespace Profiles
+} // namespace Weave
+} // namespace nl
 
 nl::Weave::Profiles::DataManagement::SubscriptionEngine * nl::Weave::Profiles::DataManagement::SubscriptionEngine::GetInstance()
 {
@@ -91,12 +90,11 @@ nl::Weave::Profiles::DataManagement::SubscriptionEngine * nl::Weave::Profiles::D
     return &gWdmSubscriptionEngine;
 }
 
-
 #define TOOL_NAME "GenerateEventLog"
 
 #define LOG_BUFFER_SIZE 512
 
-static const uint64_t kTestNodeId     = 0x18B4300001408362ULL;
+static const uint64_t kTestNodeId = 0x18B4300001408362ULL;
 
 const uint64_t kSubscriptionId = 0xB6C4B7BE2C4B859AULL;
 
@@ -109,14 +107,12 @@ enum WDMTags
     kCsTag_EventList           = 23
 };
 
-
-
 /************************************************************************/
 struct LogContext
 {
     LogContext();
-    WeaveExchangeManager *mExchangeMgr;
-    const char *mOutputFilename;
+    WeaveExchangeManager * mExchangeMgr;
+    const char * mOutputFilename;
     size_t mTestNum;
     nl::Weave::Profiles::DataManagement::ImportanceType mLogLevel;
     bool mRaw;
@@ -128,20 +124,13 @@ struct LogContext
 LogContext gLogContext;
 
 LogContext::LogContext() :
-    mExchangeMgr(NULL),
-    mOutputFilename(NULL),
-    mTestNum(0),
-    mLogLevel(nl::Weave::Profiles::DataManagement::Production),
-    mRaw(false),
-    mVerbose(false),
-    mBDX(false),
-    mWDMOutput(false)
-{
-}
+    mExchangeMgr(NULL), mOutputFilename(NULL), mTestNum(0), mLogLevel(nl::Weave::Profiles::DataManagement::Production), mRaw(false),
+    mVerbose(false), mBDX(false), mWDMOutput(false)
+{ }
 
-static int TestSetup(void *inContext)
+static int TestSetup(void * inContext)
 {
-    LogContext *ctx = static_cast<LogContext *>(inContext);
+    LogContext * ctx = static_cast<LogContext *>(inContext);
     static WeaveFabricState sFabricState;
     static WeaveExchangeManager sExchangeMgr;
 
@@ -167,16 +156,16 @@ static int TestSetup(void *inContext)
             return FAILURE;
 
         sFabricState.LocalNodeId = kTestNodeId;
-        sExchangeMgr.FabricState = & sFabricState;
-        sExchangeMgr.State = WeaveExchangeManager::kState_Initialized;
-        ctx->mExchangeMgr = &sExchangeMgr;
+        sExchangeMgr.FabricState = &sFabricState;
+        sExchangeMgr.State       = WeaveExchangeManager::kState_Initialized;
+        ctx->mExchangeMgr        = &sExchangeMgr;
     }
     return SUCCESS;
 }
 
-static int TestTeardown(void *inContext)
+static int TestTeardown(void * inContext)
 {
-    LogContext *ctx = static_cast<LogContext *>(inContext);
+    LogContext * ctx = static_cast<LogContext *>(inContext);
     if (ctx->mBDX)
     {
         ShutdownWeaveStack();
@@ -192,20 +181,23 @@ uint64_t gProdEventBuffer[LOG_BUFFER_SIZE];
 uint64_t gCritEventBuffer[LOG_BUFFER_SIZE];
 FILE * gFileOutput = NULL;
 
-void InitializeEventLogging(LogContext *context)
+void InitializeEventLogging(LogContext * context)
 {
-    LogStorageResources logStorageResources[] = {
-      {static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical},
-      {static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production},
-      {static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info},
-      {static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug} };
+    LogStorageResources logStorageResources[] = { { static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical },
+                                                  { static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production },
+                                                  { static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info },
+                                                  { static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug } };
 
     nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(
         context->mExchangeMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]), logStorageResources);
     nl::Weave::Profiles::DataManagement::LoggingConfiguration::GetInstance().mGlobalImportance = context->mLogLevel;
 }
 
-void SimpleDumpWriter(const char *aFormat, ...)
+void SimpleDumpWriter(const char * aFormat, ...)
 {
     va_list args;
 
@@ -218,15 +210,15 @@ void SimpleDumpWriter(const char *aFormat, ...)
     va_end(args);
 }
 
-void DumpEventLog(LogContext *inContext)
+void DumpEventLog(LogContext * inContext)
 {
-    uint8_t backingStore[LOG_BUFFER_SIZE*8];
+    uint8_t backingStore[LOG_BUFFER_SIZE * 8];
     size_t elementCount;
     event_id_t eventId = 0;
     TLVWriter writer;
     TLVReader reader;
     WEAVE_ERROR err = WEAVE_NO_ERROR;
-    FILE *out = stdout;
+    FILE * out      = stdout;
     TLVType dummyType;
     TLVType dummyType1;
 
@@ -239,7 +231,7 @@ void DumpEventLog(LogContext *inContext)
         out = gFileOutput;
     }
 
-    writer.Init(backingStore, LOG_BUFFER_SIZE*8);
+    writer.Init(backingStore, LOG_BUFFER_SIZE * 8);
 
     if (inContext->mWDMOutput)
     {
@@ -253,28 +245,31 @@ void DumpEventLog(LogContext *inContext)
         SuccessOrExit(err);
     }
 
-    err = nl::Weave::Profiles::DataManagement::LoggingManagement::GetInstance().FetchEventsSince(writer, nl::Weave::Profiles::DataManagement::Production, eventId);
+    err = nl::Weave::Profiles::DataManagement::LoggingManagement::GetInstance().FetchEventsSince(
+        writer, nl::Weave::Profiles::DataManagement::Production, eventId);
     if ((err == WEAVE_END_OF_TLV) || (err == WEAVE_ERROR_TLV_UNDERRUN))
     {
         err = WEAVE_NO_ERROR;
     }
     SuccessOrExit(err);
     eventId = 0;
-    err = nl::Weave::Profiles::DataManagement::LoggingManagement::GetInstance().FetchEventsSince(writer, nl::Weave::Profiles::DataManagement::Info, eventId);
+    err     = nl::Weave::Profiles::DataManagement::LoggingManagement::GetInstance().FetchEventsSince(
+        writer, nl::Weave::Profiles::DataManagement::Info, eventId);
     if ((err == WEAVE_END_OF_TLV) || (err == WEAVE_ERROR_TLV_UNDERRUN))
     {
         err = WEAVE_NO_ERROR;
     }
     SuccessOrExit(err);
     eventId = 0;
-    err = nl::Weave::Profiles::DataManagement::LoggingManagement::GetInstance().FetchEventsSince(writer, nl::Weave::Profiles::DataManagement::Debug, eventId);
+    err     = nl::Weave::Profiles::DataManagement::LoggingManagement::GetInstance().FetchEventsSince(
+        writer, nl::Weave::Profiles::DataManagement::Debug, eventId);
     if ((err == WEAVE_END_OF_TLV) || (err == WEAVE_ERROR_TLV_UNDERRUN))
     {
         err = WEAVE_NO_ERROR;
     }
     SuccessOrExit(err);
     eventId = 0;
-    err = writer.Finalize();
+    err     = writer.Finalize();
     SuccessOrExit(err);
 
     if (inContext->mWDMOutput)
@@ -306,8 +301,7 @@ exit:
     return;
 }
 
-
-void SimpleDebugLog(void *inContext)
+void SimpleDebugLog(void * inContext)
 {
     DebugEventGenerator generator;
     for (size_t i = 0; i < generator.GetNumStates(); i++)
@@ -318,7 +312,7 @@ void SimpleDebugLog(void *inContext)
     return;
 }
 
-void SimpleHeartbeatLog(void *inContext)
+void SimpleHeartbeatLog(void * inContext)
 {
     LivenessEventGenerator generator;
     for (size_t i = 0; i < generator.GetNumStates(); i++)
@@ -329,25 +323,11 @@ void SimpleHeartbeatLog(void *inContext)
     return;
 }
 
-void SimpleSecurityLog(void *inContext)
+void SimpleSecurityLog(void * inContext)
 {
 
-    useconds_t delays[] = { 10000,
-                            10000,
-                            10000,
-                            5000,
-                            5000,
-                            10000,
-                            100000,
-                            10000,
-                            10000,
-                            10000,
-                            10000,
-                            5000,
-                            1000,
-                            1000,
-                            1000,
-                            1000
+    useconds_t delays[] = {
+        10000, 10000, 10000, 5000, 5000, 10000, 100000, 10000, 10000, 10000, 10000, 5000, 1000, 1000, 1000, 1000
     };
     SecurityEventGenerator generator;
 
@@ -360,65 +340,39 @@ void SimpleSecurityLog(void *inContext)
 }
 
 typedef void (*LogGenerator)(void *);
-const LogGenerator gTests [] =
-{
-    SimpleDebugLog,
-    SimpleHeartbeatLog,
-    SimpleSecurityLog
-};
+const LogGenerator gTests[] = { SimpleDebugLog, SimpleHeartbeatLog, SimpleSecurityLog };
 
-const size_t gNumTests = sizeof(gTests)/sizeof(void(*)(void *));
+const size_t gNumTests = sizeof(gTests) / sizeof(void (*)(void *));
 
-static OptionDef gToolOptionDefs[] =
-{
-    { "loglevel",   kArgumentRequired,  'l' },
-    { "output",     kArgumentRequired,  'o' },
-    { "raw",        kNoArgument,        'r' },
-    { "test",       kArgumentRequired,  't' },
-    { "verbose",    kNoArgument,        'V' },
-    { "wdm",        kNoArgument,        'w' },
-    { NULL }
-};
+static OptionDef gToolOptionDefs[] = { { "loglevel", kArgumentRequired, 'l' },
+                                       { "output", kArgumentRequired, 'o' },
+                                       { "raw", kNoArgument, 'r' },
+                                       { "test", kArgumentRequired, 't' },
+                                       { "verbose", kNoArgument, 'V' },
+                                       { "wdm", kNoArgument, 'w' },
+                                       { NULL } };
 
-static const char *gToolOptionHelp =
-    "  -l, --loglevel <logLevel>\n"
-    "       Configured default log level, 1 - PRODUCTION, 2 - INFO, 3 - DEBUG\n"
-    "  -o, --output <filename>\n"
-    "       Save the output in the file\n"
-    "  -r, --raw\n"
-    "       Emit raw bytes\n"
-    "  -t, --test <num>\n"
-    "       The test log to use, valid range: 1 to %d\n"
-    "  -V, --verbose\n"
-    "       Verbose output\n"
-    "  -w, --wdm\n"
-    "       Enclose the output in the WDM Notification envelope\n"
-    ;
+static const char * gToolOptionHelp = "  -l, --loglevel <logLevel>\n"
+                                      "       Configured default log level, 1 - PRODUCTION, 2 - INFO, 3 - DEBUG\n"
+                                      "  -o, --output <filename>\n"
+                                      "       Save the output in the file\n"
+                                      "  -r, --raw\n"
+                                      "       Emit raw bytes\n"
+                                      "  -t, --test <num>\n"
+                                      "       The test log to use, valid range: 1 to %d\n"
+                                      "  -V, --verbose\n"
+                                      "       Verbose output\n"
+                                      "  -w, --wdm\n"
+                                      "       Enclose the output in the WDM Notification envelope\n";
 
-static OptionSet gToolOptions =
-{
-    HandleOption,
-    gToolOptionDefs,
-    "GENERAL OPTIONS",
-    gToolOptionHelp
-};
+static OptionSet gToolOptions = { HandleOption, gToolOptionDefs, "GENERAL OPTIONS", gToolOptionHelp };
 
-static HelpOptions gHelpOptions(
-    TOOL_NAME,
-    "Usage: " TOOL_NAME " [<options...>]\n",
-    WEAVE_VERSION_STRING "\n" WEAVE_TOOL_COPYRIGHT,
-    "Generate a sample event log showing various features of the event encoding.\n"
-);
+static HelpOptions gHelpOptions(TOOL_NAME, "Usage: " TOOL_NAME " [<options...>]\n", WEAVE_VERSION_STRING "\n" WEAVE_TOOL_COPYRIGHT,
+                                "Generate a sample event log showing various features of the event encoding.\n");
 
-static OptionSet *gToolOptionSets[] =
-{
-    &gToolOptions,
-    &gFaultInjectionOptions,
-    &gHelpOptions,
-    NULL
-};
+static OptionSet * gToolOptionSets[] = { &gToolOptions, &gFaultInjectionOptions, &gHelpOptions, NULL };
 
-bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg)
+bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
 {
     uint32_t level, testNum;
 
@@ -466,11 +420,11 @@ bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *n
     return true;
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char * argv[])
 {
     int status = 0;
 
-    status = asprintf((char **)&gToolOptions.OptionHelp, gToolOptionHelp, gNumTests);
+    status = asprintf((char **) &gToolOptions.OptionHelp, gToolOptionHelp, gNumTests);
     VerifyOrExit(status >= 0, /* no-op */);
 
     if (!ParseArgsFromEnvVar(TOOL_NAME, TOOL_OPTIONS_ENV_VAR_NAME, gToolOptionSets, NULL, true) ||
@@ -489,6 +443,6 @@ int main(int argc, char *argv[])
 
     TestTeardown(&gLogContext);
 
- exit:
+exit:
     return ((status >= 0) ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/src/test-apps/GenerateEventLog.cpp
+++ b/src/test-apps/GenerateEventLog.cpp
@@ -195,10 +195,10 @@ FILE * gFileOutput = NULL;
 void InitializeEventLogging(LogContext *context)
 {
     LogStorageResources logStorageResources[] = {
-        LogStorageResources(static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical),
-        LogStorageResources(static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production),
-        LogStorageResources(static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info),
-        LogStorageResources(static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug) };
+      {static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical},
+      {static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production},
+      {static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info},
+      {static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug} };
 
     nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(
         context->mExchangeMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]), logStorageResources);

--- a/src/test-apps/GenerateEventLog.cpp
+++ b/src/test-apps/GenerateEventLog.cpp
@@ -186,21 +186,22 @@ static int TestTeardown(void *inContext)
     return SUCCESS;
 }
 
-
+uint64_t gDebugEventBuffer[LOG_BUFFER_SIZE];
 uint64_t gInfoEventBuffer[LOG_BUFFER_SIZE];
 uint64_t gProdEventBuffer[LOG_BUFFER_SIZE];
+uint64_t gCritEventBuffer[LOG_BUFFER_SIZE];
 FILE * gFileOutput = NULL;
 
 void InitializeEventLogging(LogContext *context)
 {
-    size_t arraySizes[] = { sizeof(gInfoEventBuffer), sizeof(gProdEventBuffer) };
+    LogStorageResources logStorageResources[] = {
+        LogStorageResources(static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical),
+        LogStorageResources(static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production),
+        LogStorageResources(static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info),
+        LogStorageResources(static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug) };
 
-    void *arrays[] = {
-        static_cast<void *>(&gInfoEventBuffer[0]),
-        static_cast<void *>(&gProdEventBuffer[0]) };
-
-    nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(context->mExchangeMgr, 2, &arraySizes[0], &arrays[0], NULL, NULL, NULL);
-
+    nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(
+        context->mExchangeMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]), logStorageResources);
     nl::Weave::Profiles::DataManagement::LoggingConfiguration::GetInstance().mGlobalImportance = context->mLogLevel;
 }
 

--- a/src/test-apps/MockLoggingManager.cpp
+++ b/src/test-apps/MockLoggingManager.cpp
@@ -54,20 +54,21 @@
 using namespace nl::Weave::TLV;
 using namespace nl::Weave::Profiles::DataManagement;
 
-class MockEventGeneratorImpl: public MockEventGenerator
+class MockEventGeneratorImpl : public MockEventGenerator
 {
 public:
     MockEventGeneratorImpl(void);
-    WEAVE_ERROR Init(nl::Weave::WeaveExchangeManager *aExchangeMgr, EventGenerator *aEventGenerator, int aDelayBetweenEvents, bool aWraparound);
+    WEAVE_ERROR Init(nl::Weave::WeaveExchangeManager * aExchangeMgr, EventGenerator * aEventGenerator, int aDelayBetweenEvents,
+                     bool aWraparound);
     void SetEventGeneratorStop();
     bool IsEventGeneratorStopped();
 
 private:
-    static void HandleNextEvent(nl::Weave::System::Layer* aSystemLayer, void *aAppState, ::nl::Weave::System::Error aErr);
-    nl::Weave::WeaveExchangeManager *mExchangeMgr;
+    static void HandleNextEvent(nl::Weave::System::Layer * aSystemLayer, void * aAppState, ::nl::Weave::System::Error aErr);
+    nl::Weave::WeaveExchangeManager * mExchangeMgr;
     int mTimeBetweenEvents; ///< delay, in miliseconds, between events.
-    bool mEventWraparound; ///< does the event generator run indefinitely, or does it stop after iterating through its states
-    EventGenerator *mEventGenerator; ///< the event generator to use
+    bool mEventWraparound;  ///< does the event generator run indefinitely, or does it stop after iterating through its states
+    EventGenerator * mEventGenerator; ///< the event generator to use
     int32_t mEventsLeft;
 };
 
@@ -76,29 +77,29 @@ namespace Weave {
 namespace Profiles {
 namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNamespaceDesignation_Current) {
 namespace Platform {
-    // for unit tests, the dummy critical section is sufficient.
-    void CriticalSectionEnter()
-    {
-        return;
-    }
+// for unit tests, the dummy critical section is sufficient.
+void CriticalSectionEnter()
+{
+    return;
+}
 
-    void CriticalSectionExit()
-    {
-        return;
-    }
-} // Platform
-} // WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNamespaceDesignation_Current)
-} // Profiles
-} // Weave
-} // nl
+void CriticalSectionExit()
+{
+    return;
+}
+} // namespace Platform
+} // namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNamespaceDesignation_Current)
+} // namespace Profiles
+} // namespace Weave
+} // namespace nl
 
 uint64_t gDebugEventBuffer[192];
 uint64_t gInfoEventBuffer[64];
 uint64_t gProdEventBuffer[256];
 uint64_t gCritEventBuffer[256];
 
-bool gMockEventStop = false;
-bool gEventIsStopped = false;
+bool gMockEventStop                     = false;
+bool gEventIsStopped                    = false;
 bool gEnableMockTimestampInitialCounter = false;
 
 EventGenerator * GetTestDebugGenerator(void)
@@ -135,15 +136,19 @@ void EnableMockEventTimestampInitialCounter(void)
     gEnableMockTimestampInitialCounter = true;
 }
 
-void InitializeEventLogging(WeaveExchangeManager *inMgr)
+void InitializeEventLogging(WeaveExchangeManager * inMgr)
 {
-    LogStorageResources logStorageResources[] = {
-      {static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical},
-      {static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production},
-      {static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info},
-      {static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug} };
+    LogStorageResources logStorageResources[] = { { static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical },
+                                                  { static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production },
+                                                  { static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info },
+                                                  { static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug } };
 
-    nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(inMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]), logStorageResources);
+    nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(
+        inMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]), logStorageResources);
 }
 
 MockEventGenerator * MockEventGenerator::GetInstance(void)
@@ -153,21 +158,17 @@ MockEventGenerator * MockEventGenerator::GetInstance(void)
 }
 
 MockEventGeneratorImpl::MockEventGeneratorImpl(void) :
-    mExchangeMgr(NULL),
-    mTimeBetweenEvents(0),
-    mEventWraparound(false),
-    mEventGenerator(NULL),
-    mEventsLeft(0)
-{
-}
+    mExchangeMgr(NULL), mTimeBetweenEvents(0), mEventWraparound(false), mEventGenerator(NULL), mEventsLeft(0)
+{ }
 
-WEAVE_ERROR MockEventGeneratorImpl::Init(nl::Weave::WeaveExchangeManager *aExchangeMgr, EventGenerator *aEventGenerator, int aDelayBetweenEvents, bool aWraparound)
+WEAVE_ERROR MockEventGeneratorImpl::Init(nl::Weave::WeaveExchangeManager * aExchangeMgr, EventGenerator * aEventGenerator,
+                                         int aDelayBetweenEvents, bool aWraparound)
 {
-    WEAVE_ERROR err = WEAVE_NO_ERROR;
-    mExchangeMgr = aExchangeMgr;
-    mEventGenerator = aEventGenerator;
+    WEAVE_ERROR err    = WEAVE_NO_ERROR;
+    mExchangeMgr       = aExchangeMgr;
+    mEventGenerator    = aEventGenerator;
     mTimeBetweenEvents = aDelayBetweenEvents;
-    mEventWraparound = aWraparound;
+    mEventWraparound   = aWraparound;
 
     if (mEventWraparound)
         mEventsLeft = INT32_MAX;
@@ -180,7 +181,8 @@ WEAVE_ERROR MockEventGeneratorImpl::Init(nl::Weave::WeaveExchangeManager *aExcha
     return err;
 }
 
-void MockEventGeneratorImpl::HandleNextEvent(nl::Weave::System::Layer* aSystemLayer, void *aAppState, ::nl::Weave::System::Error aErr)
+void MockEventGeneratorImpl::HandleNextEvent(nl::Weave::System::Layer * aSystemLayer, void * aAppState,
+                                             ::nl::Weave::System::Error aErr)
 {
     MockEventGeneratorImpl * generator = static_cast<MockEventGeneratorImpl *>(aAppState);
     if (gMockEventStop)
@@ -214,7 +216,7 @@ bool MockEventGeneratorImpl::IsEventGeneratorStopped()
 {
     if (gEventIsStopped)
     {
-        gMockEventStop = false;
+        gMockEventStop  = false;
         gEventIsStopped = false;
         return true;
     }

--- a/src/test-apps/MockLoggingManager.cpp
+++ b/src/test-apps/MockLoggingManager.cpp
@@ -138,10 +138,10 @@ void EnableMockEventTimestampInitialCounter(void)
 void InitializeEventLogging(WeaveExchangeManager *inMgr)
 {
     LogStorageResources logStorageResources[] = {
-        LogStorageResources(static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical),
-        LogStorageResources(static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production),
-        LogStorageResources(static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info),
-        LogStorageResources(static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug) };
+      {static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical},
+      {static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production},
+      {static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info},
+      {static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug} };
 
     nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(inMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]), logStorageResources);
 }

--- a/src/test-apps/TestEventLogging.cpp
+++ b/src/test-apps/TestEventLogging.cpp
@@ -458,12 +458,14 @@ PersistedCounter * sCounterStorage[kImportanceType_Last] = {
 
 void InitializeEventLogging(TestLoggingContext * context)
 {
-    LogStorageResources logStorageResources[] = {
-        {static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical},
-        {static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production},
-        {static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info},
-        {static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug}};
-
+    LogStorageResources logStorageResources[] = { { static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical },
+                                                  { static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production },
+                                                  { static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info },
+                                                  { static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0,
+                                                    NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug } };
 
     nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(
         context->mExchangeMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]), logStorageResources);
@@ -484,10 +486,15 @@ void InitializeEventLoggingWithPersistedCounters(TestLoggingContext * context, u
                                                  nl::Weave::Profiles::DataManagement::ImportanceType globalImportance)
 {
     LogStorageResources logStorageResources[] = {
-        {static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), &sCritEventIdCounterStorageKey, sEventIdCounterEpoch, &sCritEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical},
-        {static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), &sProductionEventIdCounterStorageKey, sEventIdCounterEpoch, &sProductionEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Production},
-        {static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), &sInfoEventIdCounterStorageKey, sEventIdCounterEpoch, &sInfoEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Info},
-        {static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), &sDebugEventIdCounterStorageKey, sEventIdCounterEpoch, &sDebugEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Debug} };
+        { static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), &sCritEventIdCounterStorageKey, sEventIdCounterEpoch,
+          &sCritEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical },
+        { static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), &sProductionEventIdCounterStorageKey,
+          sEventIdCounterEpoch, &sProductionEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Production },
+        { static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), &sInfoEventIdCounterStorageKey, sEventIdCounterEpoch,
+          &sInfoEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Info },
+        { static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), &sDebugEventIdCounterStorageKey,
+          sEventIdCounterEpoch, &sDebugEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Debug }
+    };
 
     nl::Weave::Platform::PersistedStorage::Write(sCritEventIdCounterStorageKey, startingValue);
     nl::Weave::Platform::PersistedStorage::Write(sProductionEventIdCounterStorageKey, startingValue);
@@ -3134,7 +3141,7 @@ static void CheckSkipExternalEvents(nlTestSuite * inSuite, void * inContext)
     for (i = 0; i < 10; i++)
     {
         eid_before = nl::Weave::Profiles::DataManagement::LogFreeform(nl::Weave::Profiles::DataManagement::Production,
-                                                                  "Freeform entry %d", i);
+                                                                      "Freeform entry %d", i);
     }
 
     // register callback
@@ -3144,7 +3151,7 @@ static void CheckSkipExternalEvents(nlTestSuite * inSuite, void * inContext)
     for (i = 0; i < 10; i++)
     {
         eid_after = nl::Weave::Profiles::DataManagement::LogFreeform(nl::Weave::Profiles::DataManagement::Production,
-                                                                  "Freeform entry %d", i + 10);
+                                                                     "Freeform entry %d", i + 10);
     }
 
     // Validate event skipping by reading back what was written.
@@ -3181,7 +3188,7 @@ static void CheckSkipExternalEvents(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, eid == eid_after + 1);
 
         testReader.Init(gLargeMemoryBackingStore, testWriter.GetLengthWritten());
-        err = WEAVE_NO_ERROR;
+        err   = WEAVE_NO_ERROR;
         count = 0;
         while (err == WEAVE_NO_ERROR)
         {
@@ -3400,14 +3407,13 @@ static bool sExternalEventEvictionCalled;
 
 static void ResetExternalEventDeliveryState(void)
 {
-    sLastExpectedExternalEventID = 0;
+    sLastExpectedExternalEventID     = 0;
     sExternalEventNotificationCalled = false;
     sExternalEventNotificationPassed = false;
-    sExternalEventEvictionCalled = false;
+    sExternalEventEvictionCalled     = false;
 }
 
-static void MockExternalEventsDelivered(ExternalEvents * inEv, event_id_t inLastDeliveredEventID,
-                           uint64_t inRecipientNodeID)
+static void MockExternalEventsDelivered(ExternalEvents * inEv, event_id_t inLastDeliveredEventID, uint64_t inRecipientNodeID)
 {
     sExternalEventNotificationCalled = true;
     sExternalEventNotificationPassed = (inEv->mLastEventID == sLastExpectedExternalEventID);
@@ -3439,16 +3445,18 @@ static void CheckExternalEventNotifyDelivered(nlTestSuite * inSuite, void * inCo
     InitializeEventLogging(context);
 
     // Prime the event buffers with some internal events
-    now = System::Layer::GetClock_MonotonicMS();
+    now   = System::Layer::GetClock_MonotonicMS();
     eid_p = FastLogFreeform(nl::Weave::Profiles::DataManagement::Production, now, "Freeform entry %d", cnt);
     eid_d = FastLogFreeform(nl::Weave::Profiles::DataManagement::Debug, now, "Freeform entry %d", cnt);
 
     // Register external events with production and debug importance
-    err = logger.RegisterEventCallbackForImportance(nl::Weave::Profiles::DataManagement::Production, MockExternalEventsFetch, MockExternalEventsDelivered, 10, &external_eid_production);
+    err = logger.RegisterEventCallbackForImportance(nl::Weave::Profiles::DataManagement::Production, MockExternalEventsFetch,
+                                                    MockExternalEventsDelivered, 10, &external_eid_production);
     NL_TEST_ASSERT(inSuite, err == WEAVE_NO_ERROR);
     NL_TEST_ASSERT(inSuite, external_eid_production == (eid_p + 10));
 
-    err = logger.RegisterEventCallbackForImportance(nl::Weave::Profiles::DataManagement::Debug, MockExternalEventsFetch, MockExternalEventsDelivered, 10, &external_eid_debug);
+    err = logger.RegisterEventCallbackForImportance(nl::Weave::Profiles::DataManagement::Debug, MockExternalEventsFetch,
+                                                    MockExternalEventsDelivered, 10, &external_eid_debug);
     NL_TEST_ASSERT(inSuite, err == WEAVE_NO_ERROR);
     NL_TEST_ASSERT(inSuite, external_eid_debug == (eid_d + 10));
 
@@ -3462,7 +3470,7 @@ static void CheckExternalEventNotifyDelivered(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, sExternalEventNotificationCalled == false);
 
     // Verify we do get called for the first and last event in the external event range
-    logger.NotifyEventsDelivered(nl::Weave::Profiles::DataManagement::Production, eid_p+1, 0ULL);
+    logger.NotifyEventsDelivered(nl::Weave::Profiles::DataManagement::Production, eid_p + 1, 0ULL);
 
     NL_TEST_ASSERT(inSuite, sExternalEventNotificationCalled);
     NL_TEST_ASSERT(inSuite, sExternalEventNotificationPassed);
@@ -3475,7 +3483,8 @@ static void CheckExternalEventNotifyDelivered(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, sExternalEventNotificationCalled);
     NL_TEST_ASSERT(inSuite, sExternalEventNotificationPassed);
 
-    // Verify that we get called when the event handler is registered and that we do not get called when event handler is unregistered.  First, reset the checks notification state, and check we get a notification
+    // Verify that we get called when the event handler is registered and that we do not get called when event handler is
+    // unregistered.  First, reset the checks notification state, and check we get a notification
     ResetExternalEventDeliveryState();
     sLastExpectedExternalEventID = external_eid_debug;
 
@@ -3492,7 +3501,6 @@ static void CheckExternalEventNotifyDelivered(nlTestSuite * inSuite, void * inCo
     logger.NotifyEventsDelivered(nl::Weave::Profiles::DataManagement::Debug, external_eid_debug, 0ULL);
 
     NL_TEST_ASSERT(inSuite, sExternalEventNotificationCalled == false);
-
 }
 
 static void CheckExternalEventNotifyEvicted(nlTestSuite * inSuite, void * inContext)
@@ -3517,7 +3525,9 @@ static void CheckExternalEventNotifyEvicted(nlTestSuite * inSuite, void * inCont
     counter++;
 
     // Register external events with production importance
-    err = logger.RegisterEventCallbackForImportance(nl::Weave::Profiles::DataManagement::Production, MockExternalEventsFetch, MockExternalEventsDelivered, MockExternalEventsEvicted, 10, &external_eid_production);
+    err = logger.RegisterEventCallbackForImportance(nl::Weave::Profiles::DataManagement::Production, MockExternalEventsFetch,
+                                                    MockExternalEventsDelivered, MockExternalEventsEvicted, 10,
+                                                    &external_eid_production);
     NL_TEST_ASSERT(inSuite, err == WEAVE_NO_ERROR);
     NL_TEST_ASSERT(inSuite, external_eid_production == (eid + 10));
 

--- a/src/test-apps/TestEventLogging.cpp
+++ b/src/test-apps/TestEventLogging.cpp
@@ -458,14 +458,15 @@ PersistedCounter * sCounterStorage[kImportanceType_Last] = {
 
 void InitializeEventLogging(TestLoggingContext * context)
 {
-    size_t arraySizes[] = { sizeof(gDebugEventBuffer), sizeof(gInfoEventBuffer), sizeof(gProdEventBuffer),
-                            sizeof(gCritEventBuffer) };
+    LogStorageResources logStorageResources[] = {
+        LogStorageResources(static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical),
+        LogStorageResources(static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production),
+        LogStorageResources(static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info),
+        LogStorageResources(static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug) };
 
-    void * arrays[] = { static_cast<void *>(&gDebugEventBuffer[0]), static_cast<void *>(&gInfoEventBuffer[0]),
-                        static_cast<void *>(&gProdEventBuffer[0]), static_cast<void *>(&gCritEventBuffer[0]) };
 
     nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(
-        context->mExchangeMgr, sizeof(arrays) / sizeof(arrays[0]), &arraySizes[0], &arrays[0], NULL, NULL, NULL);
+        context->mExchangeMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]), logStorageResources);
     nl::Weave::Profiles::DataManagement::LoggingManagement & instance =
         nl::Weave::Profiles::DataManagement::LoggingManagement::GetInstance();
     nl::Weave::Profiles::DataManagement::LoggingConfiguration::GetInstance().mGlobalImportance =
@@ -482,11 +483,11 @@ void DestroyEventLogging(TestLoggingContext * context)
 void InitializeEventLoggingWithPersistedCounters(TestLoggingContext * context, uint32_t startingValue,
                                                  nl::Weave::Profiles::DataManagement::ImportanceType globalImportance)
 {
-    size_t arraySizes[] = { sizeof(gDebugEventBuffer), sizeof(gInfoEventBuffer), sizeof(gProdEventBuffer),
-                            sizeof(gCritEventBuffer[0]) };
-
-    void * arrays[] = { static_cast<void *>(&gDebugEventBuffer[0]), static_cast<void *>(&gInfoEventBuffer[0]),
-                        static_cast<void *>(&gProdEventBuffer[0]), static_cast<void *>(&gCritEventBuffer[0]) };
+    LogStorageResources logStorageResources[] = {
+        LogStorageResources(static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), &sCritEventIdCounterStorageKey, sEventIdCounterEpoch, &sCritEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical),
+        LogStorageResources(static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), &sProductionEventIdCounterStorageKey, sEventIdCounterEpoch, &sProductionEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Production),
+        LogStorageResources(static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), &sInfoEventIdCounterStorageKey, sEventIdCounterEpoch, &sInfoEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Info),
+        LogStorageResources(static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), &sDebugEventIdCounterStorageKey, sEventIdCounterEpoch, &sDebugEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Debug) };
 
     nl::Weave::Platform::PersistedStorage::Write(sCritEventIdCounterStorageKey, startingValue);
     nl::Weave::Platform::PersistedStorage::Write(sProductionEventIdCounterStorageKey, startingValue);
@@ -494,8 +495,7 @@ void InitializeEventLoggingWithPersistedCounters(TestLoggingContext * context, u
     nl::Weave::Platform::PersistedStorage::Write(sDebugEventIdCounterStorageKey, startingValue);
 
     nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(
-        context->mExchangeMgr, sizeof(arrays) / sizeof(arrays[0]), &arraySizes[0], &arrays[0], sCounterKeys, sCounterEpochs,
-        sCounterStorage);
+        context->mExchangeMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]), logStorageResources);
 
     nl::Weave::Profiles::DataManagement::LoggingConfiguration::GetInstance().mGlobalImportance = globalImportance;
 }

--- a/src/test-apps/TestEventLogging.cpp
+++ b/src/test-apps/TestEventLogging.cpp
@@ -459,10 +459,10 @@ PersistedCounter * sCounterStorage[kImportanceType_Last] = {
 void InitializeEventLogging(TestLoggingContext * context)
 {
     LogStorageResources logStorageResources[] = {
-        LogStorageResources(static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical),
-        LogStorageResources(static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production),
-        LogStorageResources(static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info),
-        LogStorageResources(static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug) };
+        {static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical},
+        {static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Production},
+        {static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Info},
+        {static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), NULL, 0, NULL, nl::Weave::Profiles::DataManagement::ImportanceType::Debug}};
 
 
     nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(
@@ -484,10 +484,10 @@ void InitializeEventLoggingWithPersistedCounters(TestLoggingContext * context, u
                                                  nl::Weave::Profiles::DataManagement::ImportanceType globalImportance)
 {
     LogStorageResources logStorageResources[] = {
-        LogStorageResources(static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), &sCritEventIdCounterStorageKey, sEventIdCounterEpoch, &sCritEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical),
-        LogStorageResources(static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), &sProductionEventIdCounterStorageKey, sEventIdCounterEpoch, &sProductionEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Production),
-        LogStorageResources(static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), &sInfoEventIdCounterStorageKey, sEventIdCounterEpoch, &sInfoEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Info),
-        LogStorageResources(static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), &sDebugEventIdCounterStorageKey, sEventIdCounterEpoch, &sDebugEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Debug) };
+        {static_cast<void *>(&gCritEventBuffer[0]), sizeof(gCritEventBuffer), &sCritEventIdCounterStorageKey, sEventIdCounterEpoch, &sCritEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::ProductionCritical},
+        {static_cast<void *>(&gProdEventBuffer[0]), sizeof(gProdEventBuffer), &sProductionEventIdCounterStorageKey, sEventIdCounterEpoch, &sProductionEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Production},
+        {static_cast<void *>(&gInfoEventBuffer[0]), sizeof(gInfoEventBuffer), &sInfoEventIdCounterStorageKey, sEventIdCounterEpoch, &sInfoEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Info},
+        {static_cast<void *>(&gDebugEventBuffer[0]), sizeof(gDebugEventBuffer), &sDebugEventIdCounterStorageKey, sEventIdCounterEpoch, &sDebugEventIdCounter, nl::Weave::Profiles::DataManagement::ImportanceType::Debug} };
 
     nl::Weave::Platform::PersistedStorage::Write(sCritEventIdCounterStorageKey, startingValue);
     nl::Weave::Platform::PersistedStorage::Write(sProductionEventIdCounterStorageKey, startingValue);


### PR DESCRIPTION
…robust

Previously, the API (and associated set of constructors) took a series
of arrays to initialize the LoggingManagement object.  All arrays were
supposed to be provided in the order from Debug to CriticalProduction
importance.  The code required 5 different arrays.  The ordering
required was the opposite of the numerical ordering of the importance
enum.  This led to confusion.  The new API replaces the prior arrays
with a single array of objects, each object specifies all required
storage and associated objects per importance level.  The API
documentation unabiguously states that the objects are passed in the
numerical order of importance, and the API removes the flexibility to
omit buffers per importance levels.  Finally, the API is friendly
towards flash based structures, which should allow constrained
platforms to create the initialization arguments in flash.