### PR TITLE
fix internal fault injection test fail CIEC-3526

### DIFF
--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_faults.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_faults.py
@@ -57,6 +57,7 @@ class test_weave_wdm_next_mutual_subscribe_faults(weave_wdm_next_test_base):
                               "Weave_WDMUpdateRequestSendErrorAsync",
                               "Weave_WDMUpdateRequestBadProfile",
                               "Weave_WDMUpdateResponseBusy",
+                              "Weave_WDMUpdateRequestDropMessage",
                               "Weave_WDMPathStoreFull"]
         not_required_server_faults = wdm_udpate_faults
 


### PR DESCRIPTION
Previous pull request added a new fault label for testing a particular scenario around WDM Update in the presence of faults.  This label needs to be added to the "not_required_server_faults" set in the scripts to ensure proper function. The fault injection tests are currently not a part of GitHub pull request validation, as at the moment they are too time consuming.