### PR TITLE
Properly conditionalize the use of -maes option

### DIFF
--- a/Makefile-Standalone
+++ b/Makefile-Standalone
@@ -40,7 +40,7 @@ BLUEZ                          ?= 0
 USE_FUZZING                    ?= 0
 
 HOSTOS                          = $(shell uname -s |tr [:upper:] [:lower:])
-ARCH                            = $(shell uname -i |tr [:upper:] [:lower:])
+ARCH                            = $(shell uname -m |tr [:upper:] [:lower:])
 
 ECHO                           := @echo
 MAKE                           := make
@@ -66,7 +66,9 @@ TargetTuple                     = $(shell ${AbsTopSourceDir}/third_party/nlbuild
 
 ProjectConfigDir               ?= $(AbsTopSourceDir)/build/config/standalone
 
+ifeq ($(ARCH),x86_64)
 configure_OPTIONS               = CPPFLAGS="-maes"
+endif
 
 # NOTE: Mac OS SDKs generated on OS X Sierra (or higher) seem to have trouble
 #       running on El Capitan (or earlier) due to issues with clock_gettime: 


### PR DESCRIPTION
The compilation flag -maes is applicable only to x86_64 processors that support AES-NI instructions. Use the flag only in that context.

Switch to using uname -m to determine the machine architecture. This call is POSIX-postable, whereas uname -i and uname -p are non-portable and produce unexpected results on Linux ARM, Mac OS x86_64, etc.