### PR TITLE
Fixes to the new logging configuration

### DIFF
--- a/src/ble/BleError.cpp
+++ b/src/ble/BleError.cpp
@@ -21,6 +21,8 @@
  *      This file contains functions for working with BLE Layer errors.
  */
 
+#include <stddef.h>
+
 #include <BleLayer/BleConfig.h>
 
 #if CONFIG_NETWORK_LAYER_BLE

--- a/src/inet/InetError.cpp
+++ b/src/inet/InetError.cpp
@@ -21,6 +21,8 @@
  *      This file contains functions for working with Inet Layer errors.
  */
 
+#include <stddef.h>
+
 #include <InetLayer/Inet.h>
 #include <InetLayer/InetError.h>
 

--- a/src/system/SystemConfig.h
+++ b/src/system/SystemConfig.h
@@ -40,7 +40,34 @@
 /* Platform include headers */
 #include <BuildConfig.h>
 
-/* Include a project-specific configuration file, if defined.
+/* Include a Weave project-specific configuration file, if defined.
+ *
+ * An application or module that incorporates Weave can define a project
+ * configuration file to override standard Weave configuration with
+ * application-specific values.  The WeaveProjectConfig.h file is typically
+ * located outside the OpenWeave source tree, alongside the source code for the
+ * application.  The config file is included here to enable certain system-wide
+ * configuration options, primarily related to logging and error reporting.
+ */
+#ifdef WEAVE_PROJECT_CONFIG_INCLUDE
+#include WEAVE_PROJECT_CONFIG_INCLUDE
+#endif
+
+/* Include a Weave platform-specific configuration file, if defined.
+ *
+ * A platform configuration file contains overrides to standard Weave
+ * configuration that are specific to the platform or OS on which Weave is
+ * running.  It is typically provided as apart of an adaptation layer that
+ * adapts OpenWeave to the target environment.  This adaptation layer may be
+ * included in the OpenWeave source tree itself or implemented externally.  The
+ * config file is included here to enable certain system-wide configuration
+ * options, primarily related to logging and error reporting.
+ */
+#ifdef WEAVE_PLATFORM_CONFIG_INCLUDE
+#include WEAVE_PLATFORM_CONFIG_INCLUDE
+#endif
+
+/* Include a SystemLayer project-specific configuration file, if defined.
  *
  * An application or module that incorporates Weave can define a project configuration
  * file to override standard System Layer configuration with application-specific values.
@@ -51,7 +78,7 @@
 #include SYSTEM_PROJECT_CONFIG_INCLUDE
 #endif // SYSTEM_PROJECT_CONFIG_INCLUDE
 
-/* Include a platform-specific configuration file, if defined.
+/* Include a SystemLayer platform-specific configuration file, if defined.
  *
  * A platform configuration file contains overrides to standard System Layer configuration
  * that are specific to the platform or OS on which Weave is running.  It is typically

--- a/src/system/SystemError.cpp
+++ b/src/system/SystemError.cpp
@@ -24,6 +24,8 @@
  *      error strings.
  */
 
+#include <stddef.h>
+
 // Include module header
 #include <SystemLayer/SystemError.h>
 


### PR DESCRIPTION
The new logging formatting code decentralized error formatting:
different Weave sub-libraries -- WeaveSystem, Inet, Warm -- now
provide their own error formatting.  Within Weave, however, it is
desirable to have a single config flag that switches between short and
verbose error codes.  To that end, we retain the control over the
logging format via WEAVE_CONFIG_SHORT_ERR_STRING, and to ensure the
propagation of that define into appropriate modules, we include the
config headers that could impact the value of that define in the
SystemConfig.h.

Include <stddef.h> in the new error formatter files, to ensure that
NULL is defined.