### PR TITLE
Fix typo in Tunnel Logging

### DIFF
--- a/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.cpp
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.cpp
@@ -1041,7 +1041,7 @@ void WeaveTunnelConnectionMgr::HandleOnlineCheckResult(bool isOnline)
         {
             // Reset the tunnel backoff and reconnect after a short randomized wait.
 
-            WeaveLogDetail(WeaveTunnel, "Tunnel Reconnecting on OnlineCheck success for %s tunnel : %s",
+            WeaveLogDetail(WeaveTunnel, "Tunnel Reconnecting on OnlineCheck success for %s tunnel",
                            mTunType == kType_TunnelPrimary ? "primary" : "backup");
             err = ResetReconnectBackoff(!reconnectImmediately);
             if (err != WEAVE_NO_ERROR)


### PR DESCRIPTION
Remove extraneous '%s' in logging format specifier in WeaveTunnelConnectionMgr.cpp.