### PR TITLE
Device Layer: Support for User Selected Mode

### DIFF
--- a/src/adaptations/device-layer/DeviceDescriptionServer.cpp
+++ b/src/adaptations/device-layer/DeviceDescriptionServer.cpp
@@ -19,6 +19,8 @@
 #include <Weave/DeviceLayer/internal/WeaveDeviceLayerInternal.h>
 #include <Weave/DeviceLayer/internal/DeviceDescriptionServer.h>
 
+#include <Weave/Support/TimeUtils.h>
+
 using namespace ::nl;
 using namespace ::nl::Weave;
 using namespace ::nl::Weave::Profiles::DeviceDescription;
@@ -41,8 +43,55 @@ WEAVE_ERROR DeviceDescriptionServer::Init()
     // Set the pointer to the HandleIdentifyRequest function.
     OnIdentifyRequestReceived = HandleIdentifyRequest;
 
+    // Initialize various members.
+    mUserSelectedModeEndTime = 0;
+    mUserSelectedModeTimeoutSec = WEAVE_DEVICE_CONFIG_USER_SELECTED_MODE_TIMEOUT_SEC;
+
 exit:
     return err;
+}
+
+bool DeviceDescriptionServer::IsUserSelectedModeActive(void)
+{
+    if (mUserSelectedModeEndTime != 0)
+    {
+        uint32_t nowShifted = static_cast<uint32_t>(System::Platform::Layer::GetClock_MonotonicMS() >> kUserSelectedModeTimeShift);
+        return nowShifted <= mUserSelectedModeEndTime;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+void DeviceDescriptionServer::SetUserSelectedMode(bool val)
+{
+    if (val)
+    {
+        WeaveLogProgress(DeviceLayer, "User selected mode %s (timeout %" PRId16 " seconds)",
+                IsUserSelectedModeActive() ? "extended" : "activated",
+                mUserSelectedModeTimeoutSec);
+
+        uint32_t timeoutMS = mUserSelectedModeTimeoutSec * kMillisecondPerSecond;
+        uint64_t endTimeMS = System::Platform::Layer::GetClock_MonotonicMS() + timeoutMS;
+        mUserSelectedModeEndTime = static_cast<uint32_t>(endTimeMS >> kUserSelectedModeTimeShift);
+    }
+    else
+    {
+        WeaveLogProgress(DeviceLayer, "User selected mode deactivated");
+
+        mUserSelectedModeEndTime = 0;
+    }
+}
+
+uint16_t DeviceDescriptionServer::GetUserSelectedModeTimeout(void)
+{
+    return mUserSelectedModeTimeoutSec;
+}
+
+void DeviceDescriptionServer::SetUserSelectedModeTimeout(uint16_t val)
+{
+    mUserSelectedModeTimeoutSec = val;
 }
 
 void DeviceDescriptionServer::HandleIdentifyRequest(void *appState, uint64_t nodeId, const IPAddress& nodeAddr,
@@ -72,7 +121,8 @@ void DeviceDescriptionServer::HandleIdentifyRequest(void *appState, uint64_t nod
         sendResp = false;
     }
 
-    if (reqMsg.TargetModes != kTargetDeviceMode_Any && (reqMsg.TargetModes & kTargetDeviceMode_UserSelectedMode) == 0)
+    if ((reqMsg.TargetModes & ~kTargetDeviceMode_UserSelectedMode) != 0 ||
+        ((reqMsg.TargetModes & kTargetDeviceMode_UserSelectedMode) != 0 && !sInstance.IsUserSelectedModeActive()))
     {
         WeaveLogProgress(DeviceLayer, "IdentifyRequest target mode does not match device mode");
         sendResp = false;

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ConnectivityManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ConnectivityManager.h
@@ -147,6 +147,12 @@ public:
     WEAVE_ERROR SetBLEDeviceName(const char * deviceName);
     uint16_t NumBLEConnections(void);
 
+    // User selected mode methods
+    bool IsUserSelectedModeActive(void);
+    void SetUserSelectedMode(bool val);
+    uint16_t GetUserSelectedModeTimeout(void);
+    void SetUserSelectedModeTimeout(uint16_t val);
+
     // Support methods
     static const char * WiFiStationModeToStr(WiFiStationMode mode);
     static const char * WiFiAPModeToStr(WiFiAPMode mode);
@@ -435,6 +441,26 @@ inline WEAVE_ERROR ConnectivityManager::SetBLEDeviceName(const char * deviceName
 inline uint16_t ConnectivityManager::NumBLEConnections(void)
 {
     return static_cast<ImplClass*>(this)->_NumBLEConnections();
+}
+
+inline bool ConnectivityManager::IsUserSelectedModeActive(void)
+{
+    return static_cast<ImplClass*>(this)->_IsUserSelectedModeActive();
+}
+
+inline void ConnectivityManager::SetUserSelectedMode(bool val)
+{
+    static_cast<ImplClass*>(this)->_SetUserSelectedMode(val);
+}
+
+inline uint16_t ConnectivityManager::GetUserSelectedModeTimeout(void)
+{
+    return static_cast<ImplClass*>(this)->_GetUserSelectedModeTimeout();
+}
+
+inline void ConnectivityManager::SetUserSelectedModeTimeout(uint16_t val)
+{
+    static_cast<ImplClass*>(this)->_SetUserSelectedModeTimeout(val);
 }
 
 inline const char * ConnectivityManager::WiFiStationModeToStr(WiFiStationMode mode)

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ESP32/ConnectivityManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ESP32/ConnectivityManagerImpl.h
@@ -20,6 +20,7 @@
 #define CONNECTIVITY_MANAGER_IMPL_H
 
 #include <Weave/DeviceLayer/ConnectivityManager.h>
+#include <Weave/DeviceLayer/internal/GenericConnectivityManagerImpl.h>
 #if WEAVE_DEVICE_CONFIG_ENABLE_WOBLE
 #include <Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_BLE.h>
 #else
@@ -57,6 +58,7 @@ template<class ImplClass> class GenericNetworkProvisioningServerImpl;
  */
 class ConnectivityManagerImpl final
     : public ConnectivityManager,
+      public Internal::GenericConnectivityManagerImpl<ConnectivityManagerImpl>,
 #if WEAVE_DEVICE_CONFIG_ENABLE_WOBLE
       public Internal::GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>,
 #else

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/WeaveDeviceConfig.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/WeaveDeviceConfig.h
@@ -138,6 +138,18 @@
 #define WEAVE_DEVICE_CONFIG_DEVICE_FIRMWARE_REVISION "prerelease"
 #endif
 
+/**
+ * WEAVE_DEVICE_CONFIG_USER_SELECTED_MODE_TIMEOUT_SEC
+ *
+ * The default amount of time (in whole seconds) that the device will remain in "user selected"
+ * mode.  User selected mode is typically initiated by a button press, or other direct interaction
+ * by a user.  While in user selected mode, the device will respond to Device Identify Requests
+ * that have the UserSelectedMode flag set.
+ */
+#ifndef WEAVE_DEVICE_CONFIG_USER_SELECTED_MODE_TIMEOUT_SEC
+#define WEAVE_DEVICE_CONFIG_USER_SELECTED_MODE_TIMEOUT_SEC 30
+#endif // WEAVE_DEVICE_CONFIG_USER_SELECTED_MODE_TIMEOUT_SEC
+
 // -------------------- WiFi Station Configuration --------------------
 
 /**

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/DeviceDescriptionServer.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/DeviceDescriptionServer.h
@@ -46,6 +46,11 @@ public:
 
     WEAVE_ERROR Init();
 
+    bool IsUserSelectedModeActive(void);
+    void SetUserSelectedMode(bool val);
+    uint16_t GetUserSelectedModeTimeout(void);
+    void SetUserSelectedModeTimeout(uint16_t val);
+
     void OnPlatformEvent(const WeaveDeviceEvent * event);
 
 private:
@@ -57,6 +62,14 @@ private:
     static DeviceDescriptionServer sInstance;
 
     // ===== Private members reserved for use by this class only.
+
+    enum
+    {
+        kUserSelectedModeTimeShift = 10
+    };
+
+    uint32_t mUserSelectedModeEndTime; // Monotonic system time scaled to units of 1024ms.
+    uint16_t mUserSelectedModeTimeoutSec;
 
     static void HandleIdentifyRequest(void *appState, uint64_t nodeId, const IPAddress& nodeAddr,
             const ::nl::Weave::Profiles::DeviceDescription::IdentifyRequestMessage& reqMsg, bool& sendResp,

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConnectivityManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConnectivityManagerImpl.h
@@ -1,0 +1,91 @@
+/*
+ *
+ *    Copyright (c) 2019 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Provides an generic implementation of ConnectivityManager features
+ *          for use on various platforms.
+ */
+
+#ifndef GENERIC_CONNECTIVITY_MANAGER_IMPL_H
+#define GENERIC_CONNECTIVITY_MANAGER_IMPL_H
+
+#include <Weave/DeviceLayer/internal/DeviceDescriptionServer.h>
+
+
+namespace nl {
+namespace Weave {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ * Provides a generic implementation of ConnectivityManager features that works on multiple platforms.
+ *
+ * This template contains implementations of select features from the ConnectivityManager abstract
+ * interface that are suitable for use on all platforms.  It is intended to be inherited (directly
+ * or indirectly) by the ConfigurationManagerImpl class, which also appears as the template's ImplClass
+ * parameter.
+ */
+template<class ImplClass>
+class GenericConnectivityManagerImpl
+{
+public:
+
+    // ===== Methods that implement the ConnectivityManager abstract interface.
+
+    bool _IsUserSelectedModeActive(void);
+    void _SetUserSelectedMode(bool val);
+    uint16_t _GetUserSelectedModeTimeout(void);
+    void _SetUserSelectedModeTimeout(uint16_t val);
+
+private:
+
+    ImplClass * Impl() { return static_cast<ImplClass *>(this); }
+};
+
+template<class ImplClass>
+inline bool GenericConnectivityManagerImpl<ImplClass>::_IsUserSelectedModeActive(void)
+{
+    return DeviceDescriptionSvr().IsUserSelectedModeActive();
+}
+
+template<class ImplClass>
+inline void GenericConnectivityManagerImpl<ImplClass>::_SetUserSelectedMode(bool val)
+{
+    DeviceDescriptionSvr().SetUserSelectedMode(val);
+}
+
+template<class ImplClass>
+inline uint16_t GenericConnectivityManagerImpl<ImplClass>::_GetUserSelectedModeTimeout(void)
+{
+    return DeviceDescriptionSvr().GetUserSelectedModeTimeout();
+}
+
+template<class ImplClass>
+inline void GenericConnectivityManagerImpl<ImplClass>::_SetUserSelectedModeTimeout(uint16_t val)
+{
+    DeviceDescriptionSvr().SetUserSelectedModeTimeout(val);
+}
+
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace Weave
+} // namespace nl
+
+#endif // GENERIC_CONNECTIVITY_MANAGER_IMPL_H

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/nRF5/ConnectivityManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/nRF5/ConnectivityManagerImpl.h
@@ -20,6 +20,7 @@
 #define CONNECTIVITY_MANAGER_IMPL_H
 
 #include <Weave/DeviceLayer/ConnectivityManager.h>
+#include <Weave/DeviceLayer/internal/GenericConnectivityManagerImpl.h>
 #if WEAVE_DEVICE_CONFIG_ENABLE_WOBLE
 #include <Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_BLE.h>
 #else
@@ -49,6 +50,7 @@ namespace DeviceLayer {
  */
 class ConnectivityManagerImpl final
     : public ConnectivityManager,
+      public Internal::GenericConnectivityManagerImpl<ConnectivityManagerImpl>,
 #if WEAVE_DEVICE_CONFIG_ENABLE_WOBLE
       public Internal::GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>,
 #else

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -991,6 +991,7 @@ $(nl_public_WeaveDeviceLayer_source_dirstem)/internal/DeviceDescriptionServer.h 
 $(nl_public_WeaveDeviceLayer_source_dirstem)/internal/DeviceIdentityTraitDataSource.h               \
 $(nl_public_WeaveDeviceLayer_source_dirstem)/internal/EchoServer.h                                  \
 $(nl_public_WeaveDeviceLayer_source_dirstem)/internal/FabricProvisioningServer.h                    \
+$(nl_public_WeaveDeviceLayer_source_dirstem)/internal/GenericConnectivityManagerImpl.h              \
 $(nl_public_WeaveDeviceLayer_source_dirstem)/internal/GenericConnectivityManagerImpl_BLE.h          \
 $(nl_public_WeaveDeviceLayer_source_dirstem)/internal/GenericConnectivityManagerImpl_BLE.ipp        \
 $(nl_public_WeaveDeviceLayer_source_dirstem)/internal/GenericConnectivityManagerImpl_NoBLE.h        \

--- a/src/include/Makefile.in
+++ b/src/include/Makefile.in
@@ -626,6 +626,18 @@ localedir = @localedir@
 localstatedir = @localstatedir@
 mandir = @mandir@
 mkdir_p = @mkdir_p@
+nl_filtered_build = @nl_filtered_build@
+nl_filtered_build_cpu = @nl_filtered_build_cpu@
+nl_filtered_build_os = @nl_filtered_build_os@
+nl_filtered_build_vendor = @nl_filtered_build_vendor@
+nl_filtered_host = @nl_filtered_host@
+nl_filtered_host_cpu = @nl_filtered_host_cpu@
+nl_filtered_host_os = @nl_filtered_host_os@
+nl_filtered_host_vendor = @nl_filtered_host_vendor@
+nl_filtered_target = @nl_filtered_target@
+nl_filtered_target_cpu = @nl_filtered_target_cpu@
+nl_filtered_target_os = @nl_filtered_target_os@
+nl_filtered_target_vendor = @nl_filtered_target_vendor@
 nlbuild_autotools_stem = @nlbuild_autotools_stem@
 oldincludedir = @oldincludedir@
 openssl_buildstem = @openssl_buildstem@
@@ -1368,6 +1380,7 @@ dist_weave_common_HEADERS = $(addprefix ../,$(nl_public_WeaveCommon_header_sourc
 @CONFIG_DEVICE_LAYER_TRUE@$(nl_public_WeaveDeviceLayer_source_dirstem)/internal/DeviceIdentityTraitDataSource.h               \
 @CONFIG_DEVICE_LAYER_TRUE@$(nl_public_WeaveDeviceLayer_source_dirstem)/internal/EchoServer.h                                  \
 @CONFIG_DEVICE_LAYER_TRUE@$(nl_public_WeaveDeviceLayer_source_dirstem)/internal/FabricProvisioningServer.h                    \
+@CONFIG_DEVICE_LAYER_TRUE@$(nl_public_WeaveDeviceLayer_source_dirstem)/internal/GenericConnectivityManagerImpl.h              \
 @CONFIG_DEVICE_LAYER_TRUE@$(nl_public_WeaveDeviceLayer_source_dirstem)/internal/GenericConnectivityManagerImpl_BLE.h          \
 @CONFIG_DEVICE_LAYER_TRUE@$(nl_public_WeaveDeviceLayer_source_dirstem)/internal/GenericConnectivityManagerImpl_BLE.ipp        \
 @CONFIG_DEVICE_LAYER_TRUE@$(nl_public_WeaveDeviceLayer_source_dirstem)/internal/GenericConnectivityManagerImpl_NoBLE.h        \


### PR DESCRIPTION
-- Implemented support in the Device Layer for User Selected Mode.

User Selected Mode is a feature of the Weave Device Identify protocol. When a device is placed in User Selected Mode, it will respond to Device Identify requests that have the UserSelectedMode flag set.  A device not in User Selected Mode will ignore such requests. User Selected Mode is typically initiated by a button press or some other form of direct user interaction.  The User Selected Mode feature allows a client, be it a mobile application or another device, to quickly identify a device that has been singled out by the user.  A device will automatically deactivate User Selected Mode after a configurable period of time.  Alternatively, the mode can be expressly deactivated by the application.

Since device UI is the responsibility of the application, the Device Layer exposes APIs (via the ConnectivityMgr singleton) for activating and deactivating User Selected Mode, and for configuring the mode timeout period.  These must be called by the application at the appropriate times.

-- Introduced the GenericConnectivityManagerImpl<> template class, which provides default implementations for the User Selected Mode APIs on the ConnectivityManager interface.  These methods merely delegate the calls to the DeviceDescriptionServer server, which handles all the logic.
