### PR TITLE
Make header importable by Objective-C source files

### DIFF
--- a/src/device-manager/cocoa/NLNetworkInfo.h
+++ b/src/device-manager/cocoa/NLNetworkInfo.h
@@ -29,9 +29,9 @@
 
 typedef int64_t NLNetworkID;
 
-constexpr int64_t NLNetworkID_NotSpecified = -1LL;
-constexpr int NLThreadPANId_NotSpecified = -1;
-constexpr int NLThreadChannel_NotSpecified = -1;
+const int64_t NLNetworkID_NotSpecified = -1LL;
+const int NLThreadPANId_NotSpecified = -1;
+const int NLThreadChannel_NotSpecified = -1;
 
 @interface NLNetworkInfo : NSObject
 

--- a/src/device-manager/cocoa/NLNetworkInfo.h
+++ b/src/device-manager/cocoa/NLNetworkInfo.h
@@ -29,9 +29,9 @@
 
 typedef int64_t NLNetworkID;
 
-const int64_t NLNetworkID_NotSpecified = -1LL;
-const int NLThreadPANId_NotSpecified = -1;
-const int NLThreadChannel_NotSpecified = -1;
+extern const int64_t NLNetworkID_NotSpecified;
+extern const int NLThreadPANId_NotSpecified;
+extern const int NLThreadChannel_NotSpecified;
 
 @interface NLNetworkInfo : NSObject
 

--- a/src/device-manager/cocoa/NLNetworkInfo.mm
+++ b/src/device-manager/cocoa/NLNetworkInfo.mm
@@ -31,6 +31,10 @@ using nl::Weave::Profiles::NetworkProvisioning::WiFiMode;
 using nl::Weave::Profiles::NetworkProvisioning::WiFiRole;
 using nl::Weave::Profiles::NetworkProvisioning::WiFiSecurityType;
 
+const int64_t NLNetworkID_NotSpecified = -1LL;
+const int NLThreadPANId_NotSpecified = -1;
+const int NLThreadChannel_NotSpecified = -1;
+
 @implementation NLNetworkInfo
 
 + (NLNetworkInfo *)createUsing:(NetworkInfo *)pNetworkInfo {


### PR DESCRIPTION
constexpr is not available in Objective-C, only Objective-C++
Using the older form of constness allows this file to be directly imported by Objective-C sources