### PR TITLE
Update to version 3.0 of the Nordic nRF5 SDK

### DIFF
--- a/.travis/prepare_nrf52840.sh
+++ b/.travis/prepare_nrf52840.sh
@@ -25,7 +25,7 @@ TMPDIR=${TMPDIR-/tmp}
 
 # Set tools download links
 #
-NORDIC_SDK_FOR_THREAD_URL=https://www.nordicsemi.com/-/media/Software-and-other-downloads/SDKs/nRF5-SDK-for-Thread/nRF5-SDK-for-Thread-and-Zigbee/nRF5SDKforThreadandZigbee20029775ac.zip
+NORDIC_SDK_FOR_THREAD_URL=https://www.nordicsemi.com/-/media/Software-and-other-downloads/SDKs/nRF5-SDK-for-Thread/nRF5-SDK-for-Thread-and-Zigbee/nRF5SDKforThreadandZigbeev300d310e71.zip
 NORDIC_COMMAND_LINE_TOOLS_URL=https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF5-command-line-tools/sw/nRF-Command-Line-Tools_9_8_1_Linux-x86_64.tar
 ARM_GCC_TOOLCHAIN_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
 

--- a/build/nrf5/nrf5-app.mk
+++ b/build/nrf5/nrf5-app.mk
@@ -187,7 +187,9 @@ endif
 
 NRFJPROG = $(NRF5_TOOLS_ROOT)/nrfjprog/nrfjprog
 
-SOFTDEVICE_IMAGE = $(NRF5_SDK_ROOT)/components/softdevice/s140/hex/s140_nrf52_6.1.0_softdevice.hex
+SOFTDEVICE_IMAGE_DIR = $(NRF5_SDK_ROOT)/components/softdevice/s140/hex
+
+SOFTDEVICE_IMAGE = $(wildcard $(SOFTDEVICE_IMAGE_DIR)/s140_nrf52_*_softdevice.hex)
 
 
 # ==================================================
@@ -258,6 +260,7 @@ endef
 
 # Flash the SoftDevice
 flash-softdevice flash_softdevice :
+	@if test -z "$(SOFTDEVICE_IMAGE)"; then echo "SoftDevice image not found in $(SOFTDEVICE_IMAGE_DIR)"; false; fi
 	@echo "FLASH $(SOFTDEVICE_IMAGE)"
 	$(NO_ECHO)$(NRFJPROG) -f nrf52 --program $(SOFTDEVICE_IMAGE) --sectorerase
 	@echo "RESET DEVICE"

--- a/build/nrf5/nrf5-openthread.mk
+++ b/build/nrf5/nrf5-openthread.mk
@@ -188,8 +188,8 @@ STD_LIBS += \
     -lopenthread-ftd \
     -lopenthread-platform-utils \
     -lopenthread-nrf52840-softdevice-sdk \
-    -lmbedcrypto \
-    -lnrf_cc310_0.9.10
+    -lnordicsemi-nrf52840-radio-driver-softdevice \
+    -lmbedcrypto
     
 # Add the appropriate OpenThread target as a prerequisite to all application
 # compilation targets to ensure that OpenThread gets built and its header
@@ -202,7 +202,8 @@ STD_LINK_PREREQUISITES += \
     $(OPENTHREAD_LIB_DIR)/libopenthread-ftd.a \
     $(OPENTHREAD_LIB_DIR)/libopenthread-platform-utils.a \
     $(OPENTHREAD_LIB_DIR)/libmbedcrypto.a \
-    $(OPENTHREAD_LIB_DIR)/libopenthread-nrf52840-softdevice-sdk.a
+    $(OPENTHREAD_LIB_DIR)/libopenthread-nrf52840-softdevice-sdk.a \
+    $(OPENTHREAD_LIB_DIR)/libnordicsemi-nrf52840-radio-driver-softdevice.a
 
 
 # ==================================================

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.ipp
@@ -315,6 +315,7 @@ err_t GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::SendPacket(struc
     err_t lwipErr = ERR_OK;
     otError otErr;
     otMessage * pktMsg = NULL;
+    const otMessageSettings msgSettings = { true, OT_MESSAGE_PRIORITY_NORMAL };
     uint16_t remainingLen;
 
     // Lock the OpenThread stack.
@@ -322,7 +323,7 @@ err_t GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::SendPacket(struc
     ThreadStackMgrImpl().LockThreadStack();
 
     // Allocate an OpenThread message
-    pktMsg = otIp6NewMessage(ThreadStackMgrImpl().OTInstance(), true);
+    pktMsg = otIp6NewMessage(ThreadStackMgrImpl().OTInstance(), &msgSettings);
     VerifyOrExit(pktMsg != NULL, lwipErr = ERR_MEM);
 
     // Copy data from LwIP's packet buffer chain into the OpenThread message.


### PR DESCRIPTION
-- Updated OpenWeave Device Layer to work with version 3.0 of the Nordic nRF5 SDK for Thread.

-- Modified Device Layer to work with later versions of the OpenThread API.

-- Added logic to nrf-app.mk to check for a minimum required version of the nRF5 SDK.
