### PR TITLE
Fix for warnings

### DIFF
--- a/src/adaptations/device-layer/nRF5/nRF5Config.cpp
+++ b/src/adaptations/device-layer/nRF5/nRF5Config.cpp
@@ -577,6 +577,8 @@ WEAVE_ERROR NRF5Config::DoAsyncFDSOp(FDSAsyncOp & asyncOp)
             // space on the operation queue being available.
             fdsRes = FDS_SUCCESS;
             break;
+        default:
+            WeaveDie();
         }
 
         // If the operation was queued successfully, wait for it to complete and retrieve the result.

--- a/src/lib/support/NonProductionMarker.cpp
+++ b/src/lib/support/NonProductionMarker.cpp
@@ -17,6 +17,9 @@
  */
 #include <Weave/Core/WeaveCore.h>
 
+#ifdef STRINGIFY
+#undef STRINGIFY
+#endif
 #define STRINGIFY(X) #X
 
 #ifdef WEAVE_NON_PRODUCTION_MARKER


### PR DESCRIPTION
Eliminated a couple of warnings when building OpenWeave for the nRF5 SDK.