### PR TITLE
simplify wdm tests

### DIFF
--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_application_key_01.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_application_key_01.py
@@ -66,8 +66,7 @@ class test_weave_wdm_next_application_key_01(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[35:].upper()
-        wdm_next_args['test_case_name'] = ['A01: Mutual Subscribe: Application key: Key distribution',
-                                           'B01: Stress Mutual Subscribe: Application key: Key distribution']
+        wdm_next_args['test_case_name'] = ['B01: Stress Mutual Subscribe: Application key: Key distribution']
         print 'test file: ' + self.__class__.__name__
         print "test_weave_wdm_next_application_key test A01 and B01"
         super(test_weave_wdm_next_application_key_01, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_application_key_02.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_application_key_02.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_application_key_02(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[35:].upper()
-        wdm_next_args['test_case_name'] = ['A02: Mutual Subscribe: Application key: Group key',
-                                           'B02: Stress Mutual Subscribe: Application key: Group key']
+        wdm_next_args['test_case_name'] = ['B02: Stress Mutual Subscribe: Application key: Group key']
         print 'test file: ' + self.__class__.__name__
         print "test_weave_wdm_next_application_key test A02 and B02"
         if "WEAVE_SYSTEM_CONFIG_USE_LWIP" in os.environ.keys() and os.environ["WEAVE_SYSTEM_CONFIG_USE_LWIP"] == "1":

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_01.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_01.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_01(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['E01: Mutual Subscribe: Root path. Null Version. Client in initiator cancels',
-                                           'M01: Stress Mutual Subscribe: Root path. Null Version. Client in initiator cancels'
+        wdm_next_args['test_case_name'] = ['M01: Stress Mutual Subscribe: Root path. Null Version. Client in initiator cancels'
         ]
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test E01 and M01"

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_02.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_02.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_02(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['E02: Mutual Subscribe: Root path. Null Version, Publisher in initiator cancels',
-                                           'M02: Stress Mutual Subscribe: Root path. Null Version. Publisher in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M02: Stress Mutual Subscribe: Root path. Null Version. Publisher in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test E02 and M02"
         super(test_weave_wdm_next_mutual_subscribe_02, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_03.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_03.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_03(weave_wdm_next_test_base):
                                              ('Client->kEvent_OnNotificationProcessed', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['E03: Mutual Subscribe: Root path. Null Version. Client in initiator aborts',
-                                           'M03: Stress Mutual Subscribe: Root path. Null Version. Client in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M03: Stress Mutual Subscribe: Root path. Null Version. Client in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test E03 and M03"
         super(test_weave_wdm_next_mutual_subscribe_03, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_04.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_04.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_04(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['E04: Mutual Subscribe: Root path. Null Version. Publisher in initiator aborts',
-                                           'M04: Stress Mutual Subscribe: Root path. Null Version. Publisher in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M04: Stress Mutual Subscribe: Root path. Null Version. Publisher in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test E04 and M04"
         super(test_weave_wdm_next_mutual_subscribe_04, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_05.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_05.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_05(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)',wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F01: Mutual Subscribe: Root path. Null Version. Idle. Client in initiator cancels',
-                                           'M05: Stress Mutual Subscribe: Root path. Null Version. Idle, Client in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M05: Stress Mutual Subscribe: Root path. Null Version. Idle, Client in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F01 and M05"
         super(test_weave_wdm_next_mutual_subscribe_05, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_06.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_06.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_06(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F02: Mutual Subscribe: Root path. Null Version, Idle. Publisher in initiator cancels',
-                                           'M06: Stress Mutual Subscribe: Root path. Null Version. Idle. Publisher in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M06: Stress Mutual Subscribe: Root path. Null Version. Idle. Publisher in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F02 and M06"
         super(test_weave_wdm_next_mutual_subscribe_06, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_07.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_07.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_07(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F03: Mutual Susbscribe: Root path. Null Version. Idle. Client in initiator aborts',
-                                           'M07: Stress Mutual Susbscribe: Root path. Null Version. Idle. Client in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M07: Stress Mutual Susbscribe: Root path. Null Version. Idle. Client in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F03 and M07"
         super(test_weave_wdm_next_mutual_subscribe_07, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_08.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_08.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_08(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F04: Mutual Subscribe: Root path. Null Version. Idle. Publisher in initiator aborts',
-                                           'M08: Stress Mutual Subscribe: Root path. Null Version. Idle. Publisher in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M08: Stress Mutual Subscribe: Root path. Null Version. Idle. Publisher in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F04 and M08"
         super(test_weave_wdm_next_mutual_subscribe_08, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_09.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_09.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_09(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F05: Mutual Subscribe: Root path. Null Version. Mutate data in initiator. Client in initiator cancels',
-                                           'M09: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator. Client in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M09: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator. Client in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F05 and M09"
         super(test_weave_wdm_next_mutual_subscribe_09, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_10.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_10.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_10(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F06: Mutual Subscribe: Root path. Null Version. Mutate data in initiator. Publisher in initiator cancels',
-                                           'M10: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator. Publisher in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M10: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator. Publisher in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F06 and M10"
         super(test_weave_wdm_next_mutual_subscribe_10, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_11.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_11.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_11(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F07: Mutual Subscribe: Root path. Null Version. Mutate data in initiator. Client in initiator aborts',
-                                           'M11: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator. Client in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M11: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator. Client in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F07 and M11"
         super(test_weave_wdm_next_mutual_subscribe_11, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_12.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_12.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_12(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F08: Mutual Subscribe: Root path. Null Version. Mutate data in initiator. Publisher in initiator aborts',
-                                           'M12: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator.Publisher in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M12: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator.Publisher in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F08 and M12"
         super(test_weave_wdm_next_mutual_subscribe_12, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_13.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_13.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_13(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F09: Mutual Subscribe: Root path. Null Version. Mutate data in responder. Client in initiator cancels',
-                                           'M13: Stress Mutual Subscribe: Root path. Null Version. Mutate data in responder. Client in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M13: Stress Mutual Subscribe: Root path. Null Version. Mutate data in responder. Client in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F09 and M13"
         super(test_weave_wdm_next_mutual_subscribe_13, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_14.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_14.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_14(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F10: Mutual Subscribe: Root path, Null Version, Notification in responder, Publisher in initiator Cancel',
-                                           'M14: Stress Mutual Subscribe: Root path, Null Version, Notification in responder, Publisher in initiator Cancel']
+        wdm_next_args['test_case_name'] = ['M14: Stress Mutual Subscribe: Root path, Null Version, Notification in responder, Publisher in initiator Cancel']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F10 and M14"
         super(test_weave_wdm_next_mutual_subscribe_14, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_15.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_15.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_15(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F11: Mutual Subscribe: Root path. Null Version. Notification in responder. Client in initiator aborts',
-                                           'M15: Stress Mutual Subscribe: Root path. Null Version. Notification in responder. Client in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M15: Stress Mutual Subscribe: Root path. Null Version. Notification in responder. Client in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F11 and M15"
         super(test_weave_wdm_next_mutual_subscribe_15, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_16.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_16.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_16(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F12: Mutual Subscribe: Root path. Null Version. Mutate data in responder. Publisher in initiator aborts',
-                                           'M16: Stress Mutual Subscribe: Root path. Null Version. Mutate data in responder. Publisher in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M16: Stress Mutual Subscribe: Root path. Null Version. Mutate data in responder. Publisher in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F12 and M16"
         super(test_weave_wdm_next_mutual_subscribe_16, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_17.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_17.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_17(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F13: Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Client in initiator cancels',
-                                           'M17: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Client in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M17: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Client in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F13 and M17"
         super(test_weave_wdm_next_mutual_subscribe_17, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_18.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_18.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_18(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F14: Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Publisher in initiator cancels',
-                                           'M18: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Publisher in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M18: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Publisher in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F14 and M18"
         super(test_weave_wdm_next_mutual_subscribe_18, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_19.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_19.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_19(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F15: Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Client in initiator aborts',
-                                           'M19: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Client in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M19: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Client in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F15 and M19"
         super(test_weave_wdm_next_mutual_subscribe_19, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_20.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_20.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_20(weave_wdm_next_test_base):
                                              ('Client\[0\] moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['F16: Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Publisher in initiator aborts',
-                                           'M20: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Publisher in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M20: Stress Mutual Subscribe: Root path. Null Version. Mutate data in initiator and responder. Publisher in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test F16 and M20"
         super(test_weave_wdm_next_mutual_subscribe_20, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_44.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_44.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_44(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I01: Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Client in initiator cancels',
-                                           'M25: Stress Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Client in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M25: Stress Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Client in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I01 and M25"
         super(test_weave_wdm_next_mutual_subscribe_44, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_45.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_45.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_45(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I02: Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Publisher in Initiator cancels',
-                                           'M26: Stress Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Publisher in Initiator cancels']
+        wdm_next_args['test_case_name'] = ['M26: Stress Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Publisher in Initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I02 and M26"
         super(test_weave_wdm_next_mutual_subscribe_45, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_46.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_46.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_46(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I03: Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Client in initiator aborts',
-                                           'M27: Stress Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Client in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M27: Stress Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Client in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I03 and M27"
         super(test_weave_wdm_next_mutual_subscribe_46, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_47.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_47.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_47(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I04: Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Publisher in initiator aborts',
-                                           'M28: Stress Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Publisher in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M28: Stress Mutual Subscribe: Initiator Continuous Events. Mutate data in initiator. Publisher in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I04 and M28"
         super(test_weave_wdm_next_mutual_subscribe_47, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_48.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_48.py
@@ -63,8 +63,7 @@ class test_weave_wdm_next_mutual_subscribe_48(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I05: Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Client in initiator cancels',
-                                           'M29: Stress Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Client in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M29: Stress Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Client in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I05 and M29"
         super(test_weave_wdm_next_mutual_subscribe_48, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_49.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_49.py
@@ -63,8 +63,7 @@ class test_weave_wdm_next_mutual_subscribe_49(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I06: Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Publisher in Initiator cancels',
-                                           'M30: Stress Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Publisher in Initiator cancels']
+        wdm_next_args['test_case_name'] = ['M30: Stress Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Publisher in Initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I06 and M30"
         super(test_weave_wdm_next_mutual_subscribe_49, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_50.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_50.py
@@ -63,8 +63,7 @@ class test_weave_wdm_next_mutual_subscribe_50(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I07: Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Client in initiator aborts',
-                                           'M31: Stress Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Client in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M31: Stress Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Client in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I07 and M31"
         super(test_weave_wdm_next_mutual_subscribe_50, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_51.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_51.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_51(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I08: Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Responder in initiator aborts',
-                                           'M32: Stress Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Publisher in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M32: Stress Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Publisher in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I08 and M32"
         super(test_weave_wdm_next_mutual_subscribe_51, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_52.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_52.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_52(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I09: Mutual Subscribe: Initiator Continuous Events. Client in initiator cancels',
-                                           'M33: Stress Mutual Subscribe: Initiator Continuous Events. Client in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M33: Stress Mutual Subscribe: Initiator Continuous Events. Client in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I09 and M33"
         super(test_weave_wdm_next_mutual_subscribe_52, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_53.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_53.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_53(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I10: Mutual Subscribe: Initiator Continuous Events. Publisher in Initiator cancels',
-                                           'M34: Stress Mutual Subscribe: Initiator Continuous Events. Publisher in Initiator cancels']
+        wdm_next_args['test_case_name'] = ['M34: Stress Mutual Subscribe: Initiator Continuous Events. Publisher in Initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I10 and M34"
         super(test_weave_wdm_next_mutual_subscribe_53, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_54.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_54.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_54(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I11: Mutual Subscribe: Initiator Continuous Events. Client in initiator aborts',
-                                           'M35: Stress Mutual Subscribe: Initiator Continuous Events. Client in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M35: Stress Mutual Subscribe: Initiator Continuous Events. Client in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I11 and M35"
         super(test_weave_wdm_next_mutual_subscribe_54, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_55.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_55.py
@@ -65,8 +65,7 @@ class test_weave_wdm_next_mutual_subscribe_55(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I12: Mutual Subscribe: Initiator Continuous Events. Publisher in initiator aborts',
-                                           'M36: Stress Mutual Subscribe: Initiator Continuous Events. Publisher in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M36: Stress Mutual Subscribe: Initiator Continuous Events. Publisher in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I12 and M36"
         super(test_weave_wdm_next_mutual_subscribe_55, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_56.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_56.py
@@ -63,8 +63,7 @@ class test_weave_wdm_next_mutual_subscribe_56(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I13: Mutual Subscribe: Responder Continuous Events. Client in initiator cancels',
-                                           'M37: Stress Mutual Subscribe: Responder Continuous Events. Client in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M37: Stress Mutual Subscribe: Responder Continuous Events. Client in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I13 and M37"
         super(test_weave_wdm_next_mutual_subscribe_56, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_57.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_57.py
@@ -63,8 +63,7 @@ class test_weave_wdm_next_mutual_subscribe_57(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I14: Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Publisher in Initiator cancels',
-                                           'M38: Stress Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Publisher in Initiator cancels']
+        wdm_next_args['test_case_name'] = ['M38: Stress Mutual Subscribe: Responder Continuous Events. Mutate data in responder. Publisher in Initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I14 and M38"
         super(test_weave_wdm_next_mutual_subscribe_57, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_58.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_58.py
@@ -63,8 +63,7 @@ class test_weave_wdm_next_mutual_subscribe_58(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I15: Mutual Subscribe: Responder Continuous Events. Client in initiator aborts',
-                                           'M39: Stress Mutual Subscribe: Responder Continuous Events. Client in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M39: Stress Mutual Subscribe: Responder Continuous Events. Client in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I15 and M39"
         super(test_weave_wdm_next_mutual_subscribe_58, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_59.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_59.py
@@ -64,8 +64,7 @@ class test_weave_wdm_next_mutual_subscribe_59(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I16: Mutual Subscribe: Responder Continuous Events. Responder in initiator aborts',
-                                           'M40: Stress Mutual Subscribe: Responder Continuous Events. Publisher in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M40: Stress Mutual Subscribe: Responder Continuous Events. Publisher in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I16 and M40"
         super(test_weave_wdm_next_mutual_subscribe_59, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_60.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_60.py
@@ -67,8 +67,7 @@ class test_weave_wdm_next_mutual_subscribe_60(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I17: Mutual Subscribe: Initiator and Responder Continuous Events. Mutate data in initiator responder. Client in initiator cancels',
-                                           'M41: Initiator and Responder Continuous Events. Mutate data in initiator responder. Client in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M41: Initiator and Responder Continuous Events. Mutate data in initiator responder. Client in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I17 and M41"
         super(test_weave_wdm_next_mutual_subscribe_60, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_61.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_61.py
@@ -67,8 +67,7 @@ class test_weave_wdm_next_mutual_subscribe_61(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I18: Mutual Subscribe: Initiator and Responder Continuous Events. Mutate data in initiator and responder. Publisher in initiator cancels',
-                                           'M42: Stress Mutual Subscribe: Initiator and Responder Continuous Events. Mutate data in initiator and responder. Publisher in initiator cancels']
+        wdm_next_args['test_case_name'] = ['M42: Stress Mutual Subscribe: Initiator and Responder Continuous Events. Mutate data in initiator and responder. Publisher in initiator cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I18 and M42"
         super(test_weave_wdm_next_mutual_subscribe_61, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_62.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_62.py
@@ -67,8 +67,7 @@ class test_weave_wdm_next_mutual_subscribe_62(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I19: Mutual Subscribe: Initiator and Responder Continuous Events. Mutate data in initiator and responder. Client in initiator aborts',
-                                           'M43: Stress Mutual Subscribe: Initiator and Responder Continuous Events. Mutate data in initiator and responder. Client in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M43: Stress Mutual Subscribe: Initiator and Responder Continuous Events. Mutate data in initiator and responder. Client in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I19 and M43"
         super(test_weave_wdm_next_mutual_subscribe_62, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_63.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_63.py
@@ -67,8 +67,7 @@ class test_weave_wdm_next_mutual_subscribe_63(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['I20: Mutual Subscribe: Initiator and Responder Continuous Events. Mutate data in initiator and responder. Publisher in initiator aborts',
-                                           'M44: Stress Mutual Subscribe: Initiator and Responder Continuous Events. Mutate data in initiator and responder. Publisher in initiator aborts']
+        wdm_next_args['test_case_name'] = ['M44: Stress Mutual Subscribe: Initiator and Responder Continuous Events. Mutate data in initiator and responder. Publisher in initiator aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test I20 and M44"
         super(test_weave_wdm_next_mutual_subscribe_63, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_01.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_01.py
@@ -62,8 +62,7 @@ class test_weave_wdm_next_one_way_subscribe_01(weave_wdm_next_test_base):
         wdm_next_args['server_log_check'] = [('Handler\[0\] \[(ALIVE|CONFM)\] CancelRequestHandler Ref\(\d+\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['B01: One way Subscribe: Root path. Null Version. Client cancels',
-                                           'L01: Stress One way Subscribe: Root path. Null Version. Client cancels']
+        wdm_next_args['test_case_name'] = ['L01: Stress One way Subscribe: Root path. Null Version. Client cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test B01 and L01"
         super(test_weave_wdm_next_one_way_subscribe_01, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_02.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_02.py
@@ -60,8 +60,7 @@ class test_weave_wdm_next_one_way_subscribe_02(weave_wdm_next_test_base):
                                              ('Handler\[0\] \[(ALIVE|CONFM)\] AbortSubscription Ref\(\d+\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['B02: One way Subscribe: Root path. Null Version. Client aborts',
-                                           'L02: Stress One way Subscribe: Root path. Null Version. Client aborts']
+        wdm_next_args['test_case_name'] = ['L02: Stress One way Subscribe: Root path. Null Version. Client aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test B02 and L02"
         super(test_weave_wdm_next_one_way_subscribe_02, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_03.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_03.py
@@ -60,8 +60,7 @@ class test_weave_wdm_next_one_way_subscribe_03(weave_wdm_next_test_base):
         wdm_next_args['server_log_check'] = [('Handler\[0\] \[(ALIVE|CONFM)\] CancelRequestHandler Ref\(\d+\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['C01: One way Subscribe: Root path. Null Version. Idle. Client cancels',
-                                           'L03: Stress One way Subscribe: Root path. Null Version. Idle. Client cancels']
+        wdm_next_args['test_case_name'] = ['L03: Stress One way Subscribe: Root path. Null Version. Idle. Client cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test C01 and L03"
         super(test_weave_wdm_next_one_way_subscribe_03, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_04.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_04.py
@@ -61,8 +61,7 @@ class test_weave_wdm_next_one_way_subscribe_04(weave_wdm_next_test_base):
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
 
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['C02: One way Subscribe: Root path. Null Version. Idle. Client aborts',
-                                           'L04: Stress One way Subscribe: Root path. Null Version. Idle. Client aborts']
+        wdm_next_args['test_case_name'] = ['L04: Stress One way Subscribe: Root path. Null Version. Idle. Client aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test C02 and L04"
         super(test_weave_wdm_next_one_way_subscribe_04, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_05.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_05.py
@@ -59,8 +59,7 @@ class test_weave_wdm_next_one_way_subscribe_05(weave_wdm_next_test_base):
         wdm_next_args['server_log_check'] = [('Handler\[0\] \[(ALIVE|CONFM)\] CancelRequestHandler Ref\(\d+\)', wdm_next_args['test_client_iterations'] * 1),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'] * 1)]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['C03: One way Subscribe: Root path, Null Version. Mutate data in Publisher. Client cancels',
-                                           'L05: Stress One way Subscribe: Root path, Null Version. Mutate data in Publisher. Client cancels']
+        wdm_next_args['test_case_name'] = ['L05: Stress One way Subscribe: Root path, Null Version. Mutate data in Publisher. Client cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test C03 and L05"
         super(test_weave_wdm_next_one_way_subscribe_05, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_06.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_06.py
@@ -60,8 +60,7 @@ class test_weave_wdm_next_one_way_subscribe_06(weave_wdm_next_test_base):
                                              ('Handler\[0\] \[(ALIVE|CONFM)\] AbortSubscription Ref\(\d+\)', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['C04: One way Subscribe: Root path. Null Version. Mutate data in Publisher. Client aborts',
-                                           'L06: Stress One way Subscribe: Root path. Null Version. Mutate data in Publisher. Client aborts']
+        wdm_next_args['test_case_name'] = ['L06: Stress One way Subscribe: Root path. Null Version. Mutate data in Publisher. Client aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test C04 and L06"
         super(test_weave_wdm_next_one_way_subscribe_06, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_14.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_14.py
@@ -60,8 +60,7 @@ class test_weave_wdm_next_one_way_subscribe_14(weave_wdm_next_test_base):
         wdm_next_args['server_log_check'] = [('Handler\[0\] \[(ALIVE|CONFM)\] CancelRequestHandler', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['H01: One way Subscribe: Publisher Continuous Events. Publisher mutates trait data. Client cancels',
-                                           'L07: Stress One way Subscribe: Publisher Continuous Events. Publisher mutates trait data. Client cancels']
+        wdm_next_args['test_case_name'] = ['L07: Stress One way Subscribe: Publisher Continuous Events. Publisher mutates trait data. Client cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test H01 and L07"
         super(test_weave_wdm_next_one_way_subscribe_14, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_15.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_15.py
@@ -59,8 +59,7 @@ class test_weave_wdm_next_one_way_subscribe_15(weave_wdm_next_test_base):
         wdm_next_args['server_log_check'] = [('Handler\[0\] \[(ALIVE|CONFM)\] HandleSubscriptionTerminated', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['H02: One way Subscribe: Publisher Continuous Events. Publisher mutates trait data. Client aborts',
-                                           'L08: Stress One way Subscribe: Publisher Continuous Events. Publisher mutates trait data. Client aborts']
+        wdm_next_args['test_case_name'] = ['L08: Stress One way Subscribe: Publisher Continuous Events. Publisher mutates trait data. Client aborts']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test H02 and L08"
         super(test_weave_wdm_next_one_way_subscribe_15, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_16.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_16.py
@@ -60,8 +60,7 @@ class test_weave_wdm_next_one_way_subscribe_16(weave_wdm_next_test_base):
         wdm_next_args['server_log_check'] = [('Handler\[0\] \[(ALIVE|CONFM)\] CancelRequestHandler', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['H03: One way Subscribe: Publisher Continuous Events. Client cancels',
-                                           'L09: Stress One way Subscribe: Publisher Continuous Events. Client cancels']
+        wdm_next_args['test_case_name'] = ['L09: Stress One way Subscribe: Publisher Continuous Events. Client cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test B03 and L09"
         super(test_weave_wdm_next_one_way_subscribe_16, self).weave_wdm_next_test_base(wdm_next_args)

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_17.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_one_way_subscribe_17.py
@@ -60,8 +60,7 @@ class test_weave_wdm_next_one_way_subscribe_17(weave_wdm_next_test_base):
         wdm_next_args['server_log_check'] = [('Handler\[0\] \[(ALIVE|CONFM)\] HandleSubscriptionTerminated', wdm_next_args['test_client_iterations']),
                                              ('Handler\[0\] Moving to \[ FREE\] Ref\(0\)', wdm_next_args['test_client_iterations'])]
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['H04: One way Subscribe: Publisher Continuous Events. Client cancels',
-                                           'L10: Stress One way Subscribe: Publisher Continuous Events. Client cancels']
+        wdm_next_args['test_case_name'] = ['L10: Stress One way Subscribe: Publisher Continuous Events. Client cancels']
         print 'test file: ' + self.__class__.__name__
         print "weave-wdm-next test H04 and L10"
         super(test_weave_wdm_next_one_way_subscribe_17, self).weave_wdm_next_test_base(wdm_next_args)


### PR DESCRIPTION
1. removed sanity test because sanity is covered in stress test.
2. use count in wdm_next_args['client_log_check'] for easy
understanding.
3. use function for common code block in weave_wdm_next_test_base.py