### PR TITLE
Fixed bug in DisarmFailSafe

### DIFF
--- a/src/adaptations/device-layer/DeviceControlServer.cpp
+++ b/src/adaptations/device-layer/DeviceControlServer.cpp
@@ -129,7 +129,7 @@ WEAVE_ERROR DeviceControlServer::OnFailSafeDisarmed(void)
 {
     WEAVE_ERROR err;
 
-    err = ConfigurationMgr().SetFailSafeArmed(true);
+    err = ConfigurationMgr().SetFailSafeArmed(false);
     SuccessOrExit(err);
 
 exit:


### PR DESCRIPTION
-- Fixed a cut-and-paste error in the Device Layer’s implementation of DisarmFailSafe that resulted in the fail-safe not being disarmed.