### PR TITLE
Fix a delayed resource deallocation

### DIFF
--- a/src/lib/profiles/echo/Current/WeaveEchoClient.cpp
+++ b/src/lib/profiles/echo/Current/WeaveEchoClient.cpp
@@ -232,8 +232,10 @@ void WeaveEchoClient::HandleResponse(ExchangeContext *ec, const IPPacketInfo *pk
 #endif // WEAVE_CONFIG_ENABLE_RELIABLE_MESSAGING
     {
         // Remove the EC from the app state now. OnEchoResponseReceived can call
-        // SendEchoRequest and install a new one.
-        echoApp->ExchangeCtx->Close();
+        // SendEchoRequest and install a new one. We abort rather than close
+        // because we no longer care whether the echo request message has been
+        // acknowledged at the transport layer.
+        echoApp->ExchangeCtx->Abort();
         echoApp->ExchangeCtx = NULL;
     }
 


### PR DESCRIPTION
One of the fault injection tests was failing on weave-ping in a case
where a WRMP echo request was responded to but not acknowledged.  The
proper behavior for the echo client is to abort the exchange (which
implies not worrying about the pending retransmissions) when the valid
echo response was received and there is no pending action on a WRMP
ack.