### PR TITLE
Group test instances run within happy by PID of the makefile

### DIFF
--- a/src/test-apps/Makefile.am
+++ b/src/test-apps/Makefile.am
@@ -23,6 +23,8 @@
 #
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
+SHELL := /bin/bash
+AM_LOG_DRIVER_FLAGS := --build-num $(shell echo $$PPID|tail -c5)
 
 #
 # Other files we do want to distribute with the Weave source SDK.

--- a/src/test-apps/Makefile.in
+++ b/src/test-apps/Makefile.in
@@ -2722,7 +2722,7 @@ PYTHON_VERSION = @PYTHON_VERSION@
 RANLIB = @RANLIB@
 SED = @SED@
 SET_MAKE = @SET_MAKE@
-SHELL = @SHELL@
+SHELL := /bin/bash
 SOCKETS_CPPFLAGS = @SOCKETS_CPPFLAGS@
 SOCKETS_LDFLAGS = @SOCKETS_LDFLAGS@
 SOCKETS_LIBS = @SOCKETS_LIBS@
@@ -2828,6 +2828,7 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+AM_LOG_DRIVER_FLAGS := --build-num $(shell echo $$PPID|tail -c5)
 
 #
 # Other files we do want to distribute with the Weave source SDK.
@@ -8598,11 +8599,11 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
+@WEAVE_BUILD_TESTS_FALSE@install-exec-local:
 @WEAVE_BUILD_COVERAGE_FALSE@clean-local:
 @WEAVE_BUILD_COVERAGE_REPORTS_FALSE@clean-local:
 @WEAVE_BUILD_TESTS_FALSE@clean-local:
 @WEAVE_BUILD_TESTS_FALSE@uninstall-local:
-@WEAVE_BUILD_TESTS_FALSE@install-exec-local:
 clean: clean-recursive
 
 clean-am: clean-checkPROGRAMS clean-generic clean-libexecPROGRAMS \

--- a/src/test-apps/weave-parallel-test-engine
+++ b/src/test-apps/weave-parallel-test-engine
@@ -1,7 +1,7 @@
 #! /bin/bash
 # test-driver - basic testsuite driver script.
 
-scriptversion=2017-06-20.23; # UTC
+scriptversion=2019-05-31.23; # UTC
 
 # Copyright (C) 2011-2013 Free Software Foundation, Inc.
 #
@@ -56,6 +56,7 @@ trs_file=  # Where to save the metadata of the test run.
 expect_failure=no
 color_tests=no
 enable_hard_errors=yes
+build_num=
 while test $# -gt 0; do
   case $1 in
   --help) print_usage; exit $?;;
@@ -66,6 +67,7 @@ while test $# -gt 0; do
   --color-tests) color_tests=$2; shift;;
   --expect-failure) expect_failure=$2; shift;;
   --enable-hard-errors) enable_hard_errors=$2; shift;;
+  --build-num) build_num=$2; shift;;
   --) shift; break;;
   -*) usage_error "invalid option: '$1'";;
    *) break;;
@@ -113,12 +115,16 @@ lock_path="/tmp/fabric_offset"
 FABRIC_OFFSET=0
 
 if [ -z ${SERVICE+"mock"} ]; then
-    TIER="mock"
+    TIER="mck"
 else
 TIER=$(echo $SERVICE | cut -d "." -f 4 | cut -c1-3)
 if [ -z "$TIER" ]; then
-    TIER="test"
+    TIER="tst"
 fi
+fi
+
+if [ x${build_num} != x ]; then
+TIER=${build_num}${TIER}
 fi
 
 WAS_KILLED=0
@@ -155,7 +161,7 @@ fi
 
 # Temporary fix for flaky tests: give them up to 3 chances to succeed
 for ((i=0; i < ${NUM_GRACE_RUNS}; i++)); do
-    HAPPY_STATE_ID=happy${TIER}${FABRIC_OFFSET} FABRIC_OFFSET=$FABRIC_OFFSET "$@" >$log_file 2>&1
+    HAPPY_STATE_ID=h${TIER}${FABRIC_OFFSET} FABRIC_OFFSET=$FABRIC_OFFSET "$@" >$log_file 2>&1
     estatus=$?
     if test $enable_hard_errors = no && test $estatus -eq 99; then
         estatus=1


### PR DESCRIPTION
The changes in this commit add a PID-based prefix to all happy tests
run within a particular instance of the build.  This enables a
non-conflicting way to run multiple simultaneous execution of Weave
tests on the same machine, as the "happy" simulator instances are
non-overlapping.