### PR TITLE
Fix a test edge case in working with non-persistent counters

### DIFF
--- a/src/lib/profiles/data-management/Current/LoggingManagement.cpp
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.cpp
@@ -531,6 +531,34 @@ LoggingManagement::LoggingManagement(nl::Weave::WeaveExchangeManager * inMgr,
 
 /**
  * @brief
+ *  Reinitialize the non-persistent counters to values other than 0
+ *
+ * This function, much like the non-persistent counters themselves, should only
+ * be used in test code.
+ *
+ * The function will reinitialize the event ID counters to the current system
+ * time for all importance levels that use the non-persistent counters.  The
+ * counters will get reinitialized only if there were no events logged at that
+ * importance level.
+ */
+void LoggingManagement::ReinitializeMonotonicEventCounters(void)
+{
+    CircularEventBuffer *current = mEventBuffer;
+    while (current != NULL)
+    {
+        if ((current->mEventIdCounter == &(current->mNonPersistedCounter)) &&
+            (current->mFirstEventID == 0) &&
+            (current->mLastEventID == 0))
+        {
+            current->mNonPersistedCounter.Init(System::Timer::GetCurrentEpoch() + 1);
+            current->mFirstEventID = current->mEventIdCounter->GetValue();
+        }
+        current = current->mNext;
+    }
+}
+
+/**
+ * @brief
  *   LoggingManagement default constructor. Provided primarily to make the compiler happy.
  *
 

--- a/src/lib/profiles/data-management/Current/LoggingManagement.h
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.h
@@ -245,6 +245,7 @@ public:
 #if WEAVE_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
     bool CheckShouldRunWDM(void);
 #endif
+    void ReinitializeMonotonicEventCounters(void);
 private:
     event_id_t LogEventPrivate(const EventSchema & inSchema, EventWriterFunct inEventWriter, void * inAppData,
                                const EventOptions * inOptions);

--- a/src/test-apps/MockLoggingManager.cpp
+++ b/src/test-apps/MockLoggingManager.cpp
@@ -149,6 +149,10 @@ void InitializeEventLogging(WeaveExchangeManager * inMgr)
 
     nl::Weave::Profiles::DataManagement::LoggingManagement::CreateLoggingManagement(
         inMgr, sizeof(logStorageResources) / sizeof(logStorageResources[0]), logStorageResources);
+    if (gEnableMockTimestampInitialCounter)
+    {
+        LoggingManagement::GetInstance().ReinitializeMonotonicEventCounters();
+    }
 }
 
 MockEventGenerator * MockEventGenerator::GetInstance(void)


### PR DESCRIPTION
When using the non-persistent counters, the counters, by default,
start at 0; that behavior is exploited in a number of unit tests to
verify the event ID progression.  However, this leads to a delay in
event delivery in a case where only a single event for a particular
importance level has been logged; a number of tests that use fault
injection depend on a single event being delivered immediately.  Prior
to the refactoring of the initialization of the logging subsystem this
issue was addressed by passing an array of non-persistent counters
initialized to the current system time.  This patch restores that
functionality though at a different level: we add a method to the
LoggingManagement class to re-initialize the non-persistent counters
to the current system time.  This method is intended for use only in
test code.