### PR TITLE
Fix typos in Doxygen comments

### DIFF
--- a/src/lib/profiles/bulk-data-transfer/BulkDataTransfer.h
+++ b/src/lib/profiles/bulk-data-transfer/BulkDataTransfer.h
@@ -20,7 +20,7 @@
  *    @file
  *      The bulk data transfer protocol has a number applications
  *      including sensor data upload, in-band firmware download and
- *      log upload. As such, it needs to be flexible and accomodate a
+ *      log upload. As such, it needs to be flexible and accommodate a
  *      wide variety of use cases. The protocol defines a number of
  *      roles or role pairs:
  *

--- a/src/lib/profiles/data-management/Current/EventLoggingTypes.h
+++ b/src/lib/profiles/data-management/Current/EventLoggingTypes.h
@@ -47,7 +47,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
  * make no further provisions to expunge it from the log.
  * The importance level serves to prioritize event storage. If an
  * event of high importance is added to a full buffer, events are
- * dropped in order of importance (and age) to accomodate it. As such,
+ * dropped in order of importance (and age) to accommodate it. As such,
  * importance levels only have relative value. If a system is
  * using only one importance level, events are dropped only in order
  * of age, like a ring buffer.

--- a/src/lib/profiles/data-management/Current/LoggingManagement.h
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.h
@@ -160,7 +160,7 @@ class LogBDXUpload;
 struct LogStorageResources
 {
     void * mBuffer;     ///< Buffer to be used as a storage at the particular importance level and shared with more important events.
-                        ///< Must not be NULL.  Must be large enough to accomodate the largest event emitted by the system.
+                        ///< Must not be NULL.  Must be large enough to accommodate the largest event emitted by the system.
     size_t mBufferSize; ///< The size, in bytes, of the `mBuffer`.
     nl::Weave::Platform::PersistedStorage::Key *
         mCounterKey;        ///< Name of the key naming persistent counter for events of this importance.  When NULL, the persistent

--- a/src/lib/profiles/data-management/Current/MessageDef.h
+++ b/src/lib/profiles/data-management/Current/MessageDef.h
@@ -1551,7 +1551,7 @@ public:
     WEAVE_ERROR GetDataList (DataList::Parser * const apDataList) const;
 
     /**
-     *  @brief Get the UdpateRequestIndex of this request.
+     *  @brief Get the UpdateRequestIndex of this request.
      *
      *  @param [out] apUpdateRequestIndex       A pointer to some variable to receive
      *                                          the index of the payload.

--- a/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
@@ -2432,7 +2432,7 @@ void SubscriptionClient::OnUpdateResponse(WEAVE_ERROR aReason, nl::Weave::Profil
     if (apStatus->mProfileId == nl::Weave::Profiles::kWeaveProfile_Common &&
             apStatus->mStatusCode == nl::Weave::Profiles::Common::kStatus_Success)
     {
-        // If the whole udpate has succeeded, the status list
+        // If the whole update has succeeded, the status list
         // is allowed to be empty.
         wholeRequestSucceeded = true;
 


### PR DESCRIPTION
These were flagging as typos in the openweave.io reference update, so fixing at the source.