### PR TITLE
Changed the initial value of the non-persistent logging counters.

### DIFF
--- a/src/lib/profiles/data-management/Current/LoggingManagement.cpp
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.cpp
@@ -515,6 +515,7 @@ LoggingManagement::LoggingManagement(nl::Weave::WeaveExchangeManager * inMgr,
         {
             // No counter has been provided, so we'll use our
             // "built-in" non-persisted counter.
+            current->mNonPersistedCounter.Init(1);
             current->mEventIdCounter = &(current->mNonPersistedCounter);
         }
 

--- a/src/test-apps/MockLoggingManager.cpp
+++ b/src/test-apps/MockLoggingManager.cpp
@@ -100,7 +100,6 @@ uint64_t gCritEventBuffer[256];
 
 bool gMockEventStop                     = false;
 bool gEventIsStopped                    = false;
-bool gEnableMockTimestampInitialCounter = false;
 
 EventGenerator * GetTestDebugGenerator(void)
 {
@@ -129,11 +128,6 @@ EventGenerator * GetTestTraitGenerator(void)
 {
     static TestTraitEventGenerator gTestTraitGenerator;
     return &gTestTraitGenerator;
-}
-
-void EnableMockEventTimestampInitialCounter(void)
-{
-    gEnableMockTimestampInitialCounter = true;
 }
 
 void InitializeEventLogging(WeaveExchangeManager * inMgr)

--- a/src/test-apps/MockLoggingManager.h
+++ b/src/test-apps/MockLoggingManager.h
@@ -39,8 +39,6 @@ protected:
     size_t mState;
 };
 
-void EnableMockEventTimestampInitialCounter(void);
-
 void InitializeEventLogging(WeaveExchangeManager *inMgr);
 
 class MockEventGenerator

--- a/src/test-apps/TestWdmNext.cpp
+++ b/src/test-apps/TestWdmNext.cpp
@@ -157,11 +157,6 @@ int main(int argc, char *argv[])
 
     InitWeaveStack(true, true);
 
-    if (gTestWdmNextOptions.mEnableMockTimestampInitialCounter)
-    {
-        EnableMockEventTimestampInitialCounter();
-    }
-
     InitializeEventLogging(&ExchangeMgr);
 
     switch (gMockWdmNodeOptions.mWdmRoleInTest)


### PR DESCRIPTION
The logging system treats the counter value `0` as special. We change
the starting value of non-persistent counters to `1`, and modify the
unit tests to reflect this assumption in the code.

This change also enabled us to remove the entire call chain to enable
an option to initialize the event IDs based on the timestamp.