### PR TITLE
organize test log

### DIFF
--- a/src/test-apps/happy/lib/WeaveTest.py
+++ b/src/test-apps/happy/lib/WeaveTest.py
@@ -95,7 +95,7 @@ class WeaveTest(Weave):
         if listen:
             cmd += " --listen"
 
-        persistent_storage_file = self.main_conf['log_directory'] + "/" + self.getStateId() + "_persistent_state." + tag
+        persistent_storage_file = self.getHappyLogDir() + "/" + self.getStateId() + "_persistent_state." + tag
 
         if use_persistent_storage:
             cmd += " --persistent-cntr-file " + persistent_storage_file
@@ -128,7 +128,8 @@ class WeaveTest(Weave):
         else:
             self.logger.debug("Expect that jitter_distribution_curve is integer and not less than 0 %d" % jitter_distribution_curve)
 
-    def start_simple_weave_client(self, cmd_path, client_addr, server_addr, server_id, node_id, tag, quiet = None, strace = True, env = {}, use_persistent_storage=True, reset_persistent_storage=True):
+    def start_simple_weave_client(self, cmd_path, client_addr, server_addr, server_id, node_id, tag,
+                                  quiet=None, strace=True, env={}, use_persistent_storage=True, reset_persistent_storage=True):
         cmd = cmd_path
 
         if client_addr != None:
@@ -137,7 +138,7 @@ class WeaveTest(Weave):
         if server_addr != None:
             cmd += " --dest-addr " + str(server_addr)
 
-        persistent_storage_file = self.main_conf['log_directory'] + "/" + self.getStateId() + "_persistent_state." + tag
+        persistent_storage_file = self.getHappyLogDir() + "/" + self.getStateId() + "_persistent_state." + tag
 
         if use_persistent_storage:
             cmd += " --persistent-cntr-file " + persistent_storage_file

--- a/src/test-apps/weave-parallel-test-engine
+++ b/src/test-apps/weave-parallel-test-engine
@@ -161,7 +161,8 @@ fi
 
 # Temporary fix for flaky tests: give them up to 3 chances to succeed
 for ((i=0; i < ${NUM_GRACE_RUNS}; i++)); do
-    HAPPY_STATE_ID=h${TIER}${FABRIC_OFFSET} FABRIC_OFFSET=$FABRIC_OFFSET "$@" >$log_file 2>&1
+    abslogfile=`readlink -f $log_file`
+    HAPPY_STATE_ID=h${TIER}${FABRIC_OFFSET} FABRIC_OFFSET=$FABRIC_OFFSET HAPPY_LOG_DIR=`dirname $abslogfile` "$@" >$log_file 2>&1
     estatus=$?
     if test $enable_hard_errors = no && test $estatus -eq 99; then
         estatus=1


### PR DESCRIPTION
Made changes based on discussion with @robszewczyk today:
This PR will need one happy PR below as pre-requisition:
https://github.com/openweave/happy/pull/31
 
changes related in this PR:
   a. get hold of HAPPY_LOG_DIR in environment variable in weave-parallel-test-engine
   b. the persistent log file is handled in WeaveTest.py
