### PR TITLE
Add documentation style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Contributing to openweave
+Contributing to OpenWeave
 ========================
 
 Want to contribute? Great! First, read this page (including the small
@@ -28,6 +28,13 @@ avoid frustration later on.
 All submissions, including submissions by project members, require
 review. We use Github pull requests for this purpose.
 
+### Documentation ###
+
+Documentation undergoes the same review process as code and
+contributions may be mirrored on our [openweave.io][ow-io] website.
+See the [Documentation Style Guide][doc-style] for more information on
+how to author and format documentation for contribution.
+
 ### The small print ###
 
 Contributions made by corporations are covered by a different
@@ -35,3 +42,5 @@ agreement than the one above, the [Software Grant and Corporate
 Contributor License Agreement][CLA-CORP].
 
 [CLA-CORP]: https://cla.developers.google.com/about/google-corporate
+[doc-style]: /doc/STYLE_GUIDE.md
+[ow-io]: https://openweave.io

--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -1,0 +1,113 @@
+# OpenWeave Documentation Style Guide
+
+OpenWeave documentation lives in two locations:
+
+*   **GitHub** — All guides and tutorials across the complete [OpenWeave organization](https://github/openweave).
+*   **openweave.io** - OpenWeave news and features, educational material, API reference, and all guides and tutorials found on GitHub.
+
+All documentation contributions are done on GitHub and mirrored on [openweave.io](https://openweave.io), and will be reviewed for clarity, accuracy, spelling, and grammar prior to acceptance.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for general information on contributing to this project.
+
+## Location
+
+Place all documentation contributions in the appropriate location in the [`/doc`](./) directory. If you are unsure of the best location for your contribution, let us know in your pull request.
+
+## Style
+
+OpenWeave follows the [Google Developers Style Guide](https://developers.google.com/style/). See the [Highlights](https://developers.google.com/style/highlights) page for a quick overview.
+
+## Markdown guidelines
+
+Use standard Markdown when authoring OpenWeave documentation. While HTML may be used for more complex content such as tables, use Markdown as much as possible. To ease mirroring and to keep formatting consistent with openweave.io, we ask that you follow the specific guidelines listed here.
+
+> Note: Edit this file to see the Markdown behind the examples.
+
+### Command line examples
+
+Feel free to use either `$` or `%` to preface command line examples, but be consistent within the same doc or set of docs:
+
+```
+$ git clone https://github.com/openweave/openweave-core.git
+% git clone https://github.com/openweave/openweave-core.git
+```
+
+### Terminal prompts
+
+If you need use a full terminal prompt with username and hostname, use the format of `root@{hostname}{special-characters}#`.
+
+For example, when logged into a Docker container, you might have a prompt like this:
+```
+root@c0f3912a74ff:/#
+```
+
+Or in a Happy node, you might have:
+```
+root@BorderRouter:#
+```
+
+### Commands and output
+
+All example commands and output should be in code blocks with backticks or indented:
+
+```
+code in backticks
+```
+
+    code indented
+
+### Code blocks in step lists
+
+When writing procedures that feature code blocks, indent the content for the code blocks:
+
+1.	Step one.
+
+        $ git clone https://github.com/openweave/openweave-core.git
+        $ cd openweave-core
+
+    More about step one.
+
+1.  Step two, do something else.
+
+        $ ./configure
+
+### Inline code
+
+Use backticks for `inline code`. This includes file paths and file or binary names.
+
+### Replaceable variables
+
+In code examples, denote a replaceable variable with curly braces:
+
+```
+--with-weave-inet-project-includes={directory}        
+```
+
+### Step header numbers
+
+If you want your headers to render with nice-looking step numbers on openweave.io, use level 2 Markdown headers in this format:
+
+    ## Step 1: Text of the step
+    ## Step 2: Text of the next step
+    ## Step 3: Text of the last step
+
+See the **OpenWeave + Happy Cross Network Multicast Inet Layer HOWTO** for an example of this:
+
+*   [GitHub version](/guides/cross-network-inet-multicast-howto.md)
+*   [openweave.io version](https://openweave.io/guides/cross-network-inet-multicast-howto)
+
+### Callouts
+
+Use a blockquote `>` with one of these callout types:
+
+* 	Note
+*   Caution
+*   Warning
+
+For example:
+
+> Note: This is something to be aware of.
+
+Or:
+
+> Caution: The user should be careful running the next command.

--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -93,7 +93,7 @@ If you want your headers to render with nice-looking step numbers on openweave.i
 
 See the **OpenWeave + Happy Cross Network Multicast Inet Layer HOWTO** for an example of this:
 
-*   [GitHub version](/guides/cross-network-inet-multicast-howto.md)
+*   [GitHub version](./guides/cross-network-inet-multicast-howto.md)
 *   [openweave.io version](https://openweave.io/guides/cross-network-inet-multicast-howto)
 
 ### Callouts

--- a/doc/guides/cross-network-inet-multicast-howto.md
+++ b/doc/guides/cross-network-inet-multicast-howto.md
@@ -34,7 +34,7 @@ While it is not particularly important where you clone and build the `mcproxy` d
 % make
 ```
 
-## Step 4: Establish the happy topology
+## Step 4: Establish the Happy topology
 
 This creates a topology very similar to the [Happy Codelab](https://codelabs.developers.google.com/codelabs/happy-weave-getting-started/#0).
 

--- a/doc/guides/cross-network-inet-multicast-howto.md
+++ b/doc/guides/cross-network-inet-multicast-howto.md
@@ -2,11 +2,11 @@
 
 You have decided that you would like to experiment with cross-network multicast using OpenWeave. This how-to guide illustrates using the Happy network simulation tool to set up a virtual topology that demonstrates using OpenWeave's Inet layer across two distinct networks with a multicast proxy.
 
-## Step 1: Download and Build mcproxy
+## Step 1: Download and build mcproxy
 
-The IPv6 multicast proxy daemon, _mcproxy_, serves to proxy / forward / route IPv6 multicast traffic across two disjoint IPv6 network links.
+The IPv6 multicast proxy daemon, `mcproxy`, serves to proxy / forward / route IPv6 multicast traffic across two disjoint IPv6 network links.
 
-While it is not particularly important where you clone and build the _mcproxy_ daemon executable, please take note of the location where you create it as a relative or absolute path to it will be necessary in Step 6 below.
+While it is not particularly important where you clone and build the `mcproxy` daemon executable, please take note of the location where you create it as a relative or absolute path to it is necessary in Step 6 below.
 
 ```
 % git clone https://github.com/mcproxy/mcproxy.git mcproxy
@@ -16,7 +16,7 @@ While it is not particularly important where you clone and build the _mcproxy_ d
 % make
 ```
 
-## Step 2: Download, Build, and Install happy
+## Step 2: Download, build, and install happy
 
 ```
 % git clone https://github.com/openweave/happy.git happy
@@ -25,7 +25,7 @@ While it is not particularly important where you clone and build the _mcproxy_ d
 % sudo make install
 ```
 
-## Step 3: Download and Build openweave-core
+## Step 3: Download and build openweave-core
 
 ```
 % git clone https://github.com/openweave/openweave-core.git openweave-core
@@ -34,7 +34,7 @@ While it is not particularly important where you clone and build the _mcproxy_ d
 % make
 ```
 
-## Step 4: Establish the Happy Topology
+## Step 4: Establish the happy topology
 
 This creates a topology very similar to the [Happy Codelab](https://codelabs.developers.google.com/codelabs/happy-weave-getting-started/#0).
 
@@ -56,11 +56,11 @@ This creates a topology very similar to the [Happy Codelab](https://codelabs.dev
 % happy-network-route --prefix 192.168.1.0 WiFiNetwork BorderRouter
 ```
 
-## Step 5: Create the mcproxy Configuration for the Happy Topology
+## Step 5: Create the mcproxy configuration for the Happy topology
 
 This creates an IPv6 multicast proxy configuration between the simulated "Thread" network interface on "wpan0" and the simulated "WiFi" network interface on "wlan0" in the Happy topology we created above in Step 4.
 
-While it is not particularly important where you create the _mcproxy.conf_ file, please take note of the location where you create it as a relative or absolute path to it will be necessary in Step 6 below.
+While it is not particularly important where you create the `mcproxy.conf` file, please take note of the location where you create it as a relative or absolute path to it is necessary in Step 6.
 
 ```
 % cat > mcproxy.conf << EOF
@@ -69,41 +69,43 @@ pinstance myProxy: wpan0 ==> wlan0;
 EOF
 ```
 
-## Step 6: Run the Demonstration
+## Step 6: Run the demonstration
 
-This will run the IPv6 multicast proxy, _mcproxy_, on the "BorderRouter" node and then will launch the Inet layer multicast functional test sender and receiver on the simulated "Thread" and "WiFi" nodes, respectively.
+This runs the IPv6 multicast proxy, `mcproxy`, on the "BorderRouter" node and then launches the Inet layer multicast functional test sender and receiver on the simulated "Thread" and "WiFi" nodes, respectively.
 
 If you'd like, you can transpose the sender and the receiver nodes and the example will work equally as well.
 
 Each of the following sets of commands should be run from parallel, independent shells.
 
-### Border Router
+### Border router
 
 ```
 % happy-shell BorderRouter
-$ <absolute or relative path to mcproxy daemon executable from Step 1>/mcproxy -f <absolute or relative path to mcproxy configuration file from Step 5>/mcproxy.conf
+root@BorderRouter:# {path-to-mcproxy-from-step1}/mcproxy -f {path-to-mcproxy-config-from-step5}/mcproxy.conf
 ```
 
 ### Receiver
 
 ```
 % happy-shell WiFiNode
-$ openweave-core/src/test-apps/TestInetLayerMulticast -6 --udp -I wlan0 -g 5 --group-expected-rx-packets 5 --group-expected-tx-packets 0 -l
+root@WiFiNode:# openweave-core/src/test-apps/TestInetLayerMulticast -6 --udp -I wlan0 -g 5 --group-expected-rx-packets 5 --group-expected-tx-packets 0 -l
 ```
 
 ### Sender
 
 ```
 % happy-shell ThreadNode
-$ openweave-core/src/test-apps/TestInetLayerMulticast -6 --udp -I wpan0 -g 5 --group-expected-rx-packets 0 --group-expected-tx-packets 5 -L
+root@ThreadNode:# openweave-core/src/test-apps/TestInetLayerMulticast -6 --udp -I wpan0 -g 5 --group-expected-rx-packets 0 --group-expected-tx-packets 5 -L
 ```
 
-### Output[^1]
+### Output
+
+> Note: Your output may vary slightly around the process IDs and source addresses displayed by the receiver.
 
 #### Sender
 
 ```
-$ openweave-core/src/test-apps/TestInetLayerMulticast -6 --udp -I wlan0 -g 5 ... -L
+% openweave-core/src/test-apps/TestInetLayerMulticast -6 --udp -I wlan0 -g 5 ... -L
 Weave Node ready to service events; PID: 50845; PPID: 46482
 Using UDP/IPv6, device interface: wpan0 (w/o LwIP)
 Will join multicast group ff15::5
@@ -122,7 +124,7 @@ WEAVE:IN: Async DNS worker thread exiting.
 #### Receiver
 
 ```
-$ openweave-core/src/test-apps/TestInetLayerMulticast -6 --udp -I wlan0 -g 5 ... -l
+% openweave-core/src/test-apps/TestInetLayerMulticast -6 --udp -I wlan0 -g 5 ... -l
 Weave Node ready to service events; PID: 50826; PPID: 46499
 Using UDP/IPv6, device interface: wlan0 (w/o LwIP)
 Will join multicast group ff15::5
@@ -143,5 +145,3 @@ WEAVE:IN: Async DNS worker thread exiting.
 WEAVE:IN: Async DNS worker thread woke up.
 WEAVE:IN: Async DNS worker thread exiting.
 ```
-
-[^1]: Your output may vary slightly around the process IDs and source addresses displayed by the receiver.


### PR DESCRIPTION
Also:

- updated CONTRIBUTING.md to cover documentation
- moved the Cross Network HOWTO to a new "guides" directory under docs
- minor revisions to the Cross Network HOWTO for 1) formatting so it can be more easily mirrored on openweave.io and 2) style to adhere to Google Developers style

Fixes #256