### PR TITLE
Fix install-headers target

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -469,6 +469,12 @@ $(filter %.hpp,$(nl_public_WeaveSupport_header_destinations)): $(nl_public_Weave
 # from the build directory which may not be the same as the source
 # directory in a non-colocated build.
 
+$(abs_builddir)/../$(nl_public_WeaveSupport_source_dirstem)/ASN1OID.h:
+	(cd $(abs_builddir)/../$(nl_public_WeaveSupport_source_dirstem) && $(MAKE) $(AM_MAKEFLAGS) ASN1OID.h)
+
+$(addprefix ../,$(nl_public_WeaveSupport_ASN1OID_base_header_sources)):
+	(cd $(abs_builddir)/../$(nl_public_WeaveSupport_source_dirstem) && $(MAKE) $(AM_MAKEFLAGS) ASN1OID.h)
+
 $(nl_public_WeaveSupport_destination_dirstem)/ASN1OID.h: $(abs_builddir)/../$(nl_public_WeaveSupport_source_dirstem)/ASN1OID.h | $(nl_public_WeaveSupport_ASN1OID_header_dirs)
 	$(call create-link)
 

--- a/src/include/Makefile.in
+++ b/src/include/Makefile.in
@@ -3428,6 +3428,12 @@ $(filter %.hpp,$(nl_public_WeaveSupport_header_destinations)): $(nl_public_Weave
 # from the build directory which may not be the same as the source
 # directory in a non-colocated build.
 
+$(abs_builddir)/../$(nl_public_WeaveSupport_source_dirstem)/ASN1OID.h:
+	(cd $(abs_builddir)/../$(nl_public_WeaveSupport_source_dirstem) && $(MAKE) $(AM_MAKEFLAGS) ASN1OID.h)
+
+$(addprefix ../,$(nl_public_WeaveSupport_ASN1OID_base_header_sources)):
+	(cd $(abs_builddir)/../$(nl_public_WeaveSupport_source_dirstem) && $(MAKE) $(AM_MAKEFLAGS) ASN1OID.h)
+
 $(nl_public_WeaveSupport_destination_dirstem)/ASN1OID.h: $(abs_builddir)/../$(nl_public_WeaveSupport_source_dirstem)/ASN1OID.h | $(nl_public_WeaveSupport_ASN1OID_header_dirs)
 	$(call create-link)
 


### PR DESCRIPTION
Some builds may desire to run the install-headers target prior to
building the entire tree.  Add dependencies and rules to generate the
ASN1OID.h header whenever appropriate.