### PR TITLE
Expose pairing compatibility major and minor versions in Java code

### DIFF
--- a/src/device-manager/WeaveDeviceManager-JNI.cpp
+++ b/src/device-manager/WeaveDeviceManager-JNI.cpp
@@ -3214,7 +3214,7 @@ WEAVE_ERROR N2J_DeviceDescriptor(JNIEnv *env, const WeaveDeviceDescriptor& inDev
         SuccessOrExit(err);
     }
 
-    constructor = env->GetMethodID(sWeaveDeviceDescriptorCls, "<init>", "(IIIIII[B[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;II)V");
+    constructor = env->GetMethodID(sWeaveDeviceDescriptorCls, "<init>", "(IIIIII[B[BLjava/lang/String;Ljava/lang/String;Ljava/lang/String;JJLjava/lang/String;IIII)V");
     VerifyOrExit(constructor != NULL, err = WDM_JNI_ERROR_METHOD_NOT_FOUND);
 
     env->ExceptionClear();
@@ -3224,6 +3224,8 @@ WEAVE_ERROR N2J_DeviceDescriptor(JNIEnv *env, const WeaveDeviceDescriptor& inDev
                                                primary802154MACAddress, primaryWiFiMACAddress,
                                                serialNumber, rendezvousWiFiESSID, pairingCode,
                                                (jlong)inDeviceDesc.DeviceId, (jlong)inDeviceDesc.FabricId, softwareVersion,
+                                               (jint)inDeviceDesc.PairingCompatibilityVersionMajor,
+                                               (jint)inDeviceDesc.PairingCompatibilityVersionMinor,
                                                (jint)inDeviceDesc.DeviceFeatures, (jint)inDeviceDesc.Flags);
     VerifyOrExit(!env->ExceptionCheck(), err = WDM_JNI_ERROR_EXCEPTION_THROWN);
 

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/WeaveDeviceDescriptor.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/WeaveDeviceDescriptor.java
@@ -1,6 +1,7 @@
 /*
 
-    Copyright (c) 013-2017 Nest Labs, Inc.
+    Copyright (c) 2019 Google LLC.
+    Copyright (c) 2013-2017 Nest Labs, Inc.
     All rights reserved.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,10 +59,18 @@ public class WeaveDeviceDescriptor
         */
     public String softwareVersion;
 
+    /** Pairing compatibility major version (0 = not specified)
+     */
+    public int pairingCompatibilityVersionMajor;
+
+    /** Pairing compatibility minor version (0 = not specified)
+     */
+    public int pairingCompatibilityVersionMinor;
+
     /** ESSID or ESSID suffix for device's rendezvous WiFi network (null = not present).
         */
     public String rendezvousWiFiESSID;
-    
+
     /** True if the rendezvousWiFiESSID field contains a suffix string.
         */
     public boolean isRendezvousWiFiESSIDSuffix;
@@ -89,6 +98,19 @@ public class WeaveDeviceDescriptor
                                  long deviceId, long fabricId, String softwareVersion, int deviceFeatures,
                                  int flags)
     {
+        this(vendorCode, productCode, productRevision, manufacturingYear, manufacturingMonth, manufacturingDay,
+             primary802154MACAddress, primaryWiFiMACAddress, serialNumber, rendezvousWiFiESSID, pairingCode,
+             deviceId, fabricId, softwareVersion, 0, 0, deviceFeatures, flags);
+    }
+
+    public WeaveDeviceDescriptor(int vendorCode, int productCode, int productRevision,
+                                 int manufacturingYear, int manufacturingMonth, int manufacturingDay,
+                                 byte[] primary802154MACAddress, byte[] primaryWiFiMACAddress,
+                                 String serialNumber, String rendezvousWiFiESSID, String pairingCode,
+                                 long deviceId, long fabricId, String softwareVersion,
+                                 int pairingCompatibilityVersionMajor, int pairingCompatibilityVersionMinor,
+                                 int deviceFeatures, int flags)
+    {
         this.vendorCode = vendorCode;
         this.productCode = productCode;
         this.productRevision = productRevision;
@@ -109,6 +131,8 @@ public class WeaveDeviceDescriptor
         this.deviceId = deviceId;
         this.fabricId = fabricId;
         this.softwareVersion = softwareVersion;
+        this.pairingCompatibilityVersionMajor = pairingCompatibilityVersionMajor;
+        this.pairingCompatibilityVersionMinor = pairingCompatibilityVersionMinor;
         this.deviceFeatures = DeviceFeatures.fromFlags(deviceFeatures);
         this.isRendezvousWiFiESSIDSuffix = ((flags & FLAG_IS_RENDEZVOUS_WIFI_ESSID_SUFFIX) != 0);
     }
@@ -118,6 +142,6 @@ public class WeaveDeviceDescriptor
     static {
         System.loadLibrary("WeaveDeviceManager");
     }
-    
+
     static final int FLAG_IS_RENDEZVOUS_WIFI_ESSID_SUFFIX = 0x01;
 }

--- a/src/lib/profiles/device-description/DeviceDescription.cpp
+++ b/src/lib/profiles/device-description/DeviceDescription.cpp
@@ -708,6 +708,8 @@ WEAVE_ERROR WeaveDeviceDescriptor::DecodeText(const char *data, uint32_t dataLen
     bool mfgDateIncluded = false;
     bool serialNumIncluded = false;
 
+    outDesc.Clear();
+
     if (reader.Version != kEncodingVersion)
         return WEAVE_ERROR_UNSUPPORTED_DEVICE_DESCRIPTOR_VERSION;
 
@@ -822,6 +824,8 @@ WEAVE_ERROR WeaveDeviceDescriptor::DecodeTLV(const uint8_t *data, uint32_t dataL
 {
     WEAVE_ERROR err;
     TLVReader reader;
+
+    outDesc.Clear();
 
     reader.Init(data, dataLen);
 


### PR DESCRIPTION
Expose pairing compatibility major and minor versions in Java to bring
it into parity with Objective C code.  While reviewing decoding logic
in the device descriptor, we noticed that the behavior was not
consistent w.r.t. clearing the device descriptor; now all Decode*
methods clear the output descriptor.