### PR TITLE
Fix issue in WeaveSecurityMgr where error callbacks are dropped

### DIFF
--- a/src/lib/core/WeaveSecurityMgr.cpp
+++ b/src/lib/core/WeaveSecurityMgr.cpp
@@ -386,12 +386,11 @@ void WeaveSecurityManager::StartPASESession(void)
 {
     WEAVE_ERROR err;
 
-    err = SendPASEInitiatorStep1(kPASEConfig_ConfigDefault);
-    SuccessOrExit(err);
-
     mEC->OnMessageReceived = HandlePASEMessageInitiator;
     mEC->OnConnectionClosed = HandleConnectionClosed;
 
+    err = SendPASEInitiatorStep1(kPASEConfig_ConfigDefault);
+    SuccessOrExit(err);
     // Time limit overall PASE duration.
     StartSessionTimer();
 


### PR DESCRIPTION
Bug: If Connection is closed before StartPASESession registered handlers, Weave is unable to execute registered Error handlers.

Solution: Move handler registration inside StartPASESession above the SendPASEInitiatorStep1 step

More Info:
The issue is that if we do not respond to the `HandleConnectionClosed` callback, `WeaveDeviceManager` responds to its own `HandleConnectionClosed` and calls `Close` which in turn calls `CloseDeviceConnection` which sets     
`mConState = kConnectionState_NotConnected;`.  
`SendPASEInitiatorStep1` returns an error and `HandleSessionError` is called which executes:
`            userOnError(this, con, reqState, err, peerNodeId, statusReportPtr);`
Which translates to `HandleSessionError` in `WeaveDeviceManager`.
Since `WeaveDeviceManager` reset itself when it handled the closed connection we run into this scenario where execution stops:
```
    // Bail immediately if not in the correct state. May occur if the connection closes abruptly and the
    // SecurityManager's HandleConnectionClosed callback fires _after_ the DeviceManager's own callback.
    // In this case, con is already closed and mOnError has already been called, so we should just exit.
    if (devMgr->mConState != kConnectionState_StartSession)
    {
        return;
    }
```
So if we allow `WeaveSecurityMgr` to handle `HandleConnectionClosed` we get proper error propagation.