### PR TITLE
remove copy log from tmp

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -49,11 +49,10 @@ gcc_check_happy()
         build_folder="x86_64-unknown-linux-gnu"
     fi
 
-    mkdir -p $TRAVIS_BUILD_DIR/happy-test-logs/$1/from-tmp
+    mkdir -p $TRAVIS_BUILD_DIR/happy-test-logs/$1
     eval $build_cmd
     make_status=${?}
     cp $TRAVIS_BUILD_DIR/build/$build_folder/src/test-apps/happy $TRAVIS_BUILD_DIR/happy-test-logs/$1 -rf
-    cp /tmp/happy* $TRAVIS_BUILD_DIR/happy-test-logs/$1/from-tmp
     echo "please check happy-test-log/<UTC time> under link: https://storage.cloud.google.com/openweave"
     return ${make_status}
 }


### PR DESCRIPTION
Given the changes from openweave-core PR#265 and happy PR#31 happy no longer puts the logs in /tmp and thus the copying logs from /tmp is no longer required.