### PR TITLE
Fix for Issue #283: Invalid Weave BLE scan response from nRF5 Device Layer

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ConfigurationManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ConfigurationManager.h
@@ -29,6 +29,12 @@
 #include <Weave/Profiles/network-provisioning/NetworkProvisioning.h>
 
 namespace nl {
+namespace Ble {
+struct WeaveBLEDeviceIdentificationInfo;
+}
+}
+
+namespace nl {
 namespace Weave {
 namespace DeviceLayer {
 
@@ -97,6 +103,8 @@ public:
     WEAVE_ERROR GetQRCodeString(char * buf, size_t bufSize);
 
     WEAVE_ERROR GetWiFiAPSSID(char * buf, size_t bufSize);
+
+    WEAVE_ERROR GetBLEDeviceIdentificationInfo(Ble::WeaveBLEDeviceIdentificationInfo & deviceIdInfo);
 
     bool IsServiceProvisioned();
     bool IsPairedToAccount();
@@ -360,6 +368,11 @@ inline WEAVE_ERROR ConfigurationManager::GetQRCodeString(char * buf, size_t bufS
 inline WEAVE_ERROR ConfigurationManager::GetWiFiAPSSID(char * buf, size_t bufSize)
 {
     return static_cast<ImplClass*>(this)->_GetWiFiAPSSID(buf, bufSize);
+}
+
+inline WEAVE_ERROR ConfigurationManager::GetBLEDeviceIdentificationInfo(Ble::WeaveBLEDeviceIdentificationInfo & deviceIdInfo)
+{
+    return static_cast<ImplClass*>(this)->_GetBLEDeviceIdentificationInfo(deviceIdInfo);
 }
 
 inline bool ConfigurationManager::IsServiceProvisioned()

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.h
@@ -85,6 +85,7 @@ public:
     WEAVE_ERROR _GetDeviceDescriptorTLV(uint8_t * buf, size_t bufSize, size_t & encodedLen);
     WEAVE_ERROR _GetQRCodeString(char * buf, size_t bufSize);
     WEAVE_ERROR _GetWiFiAPSSID(char * buf, size_t bufSize);
+    WEAVE_ERROR _GetBLEDeviceIdentificationInfo(Ble::WeaveBLEDeviceIdentificationInfo & deviceIdInfo);
     bool _IsServiceProvisioned();
     bool _IsMemberOfFabric();
     bool _IsPairedToAccount();

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.ipp
@@ -27,6 +27,7 @@
 
 #include <Weave/DeviceLayer/internal/WeaveDeviceLayerInternal.h>
 #include <Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.h>
+#include <BleLayer/WeaveBleServiceData.h>
 
 
 namespace nl {
@@ -610,6 +611,32 @@ WEAVE_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetWiFiAPSSID(char * bu
     ExitNow(err = WEAVE_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
 #endif // WEAVE_DEVICE_CONFIG_WIFI_AP_SSID_PREFIX
+
+exit:
+    return err;
+}
+
+template<class ImplClass>
+WEAVE_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetBLEDeviceIdentificationInfo(Ble::WeaveBLEDeviceIdentificationInfo & deviceIdInfo)
+{
+    WEAVE_ERROR err;
+    uint16_t id;
+
+    deviceIdInfo.Init();
+
+    err = Impl()->_GetVendorId(id);
+    SuccessOrExit(err);
+    deviceIdInfo.SetVendorId(id);
+
+    err = Impl()->_GetProductId(id);
+    SuccessOrExit(err);
+    deviceIdInfo.SetProductId(id);
+
+    deviceIdInfo.SetDeviceId(FabricState.LocalNodeId);
+
+    deviceIdInfo.PairingStatus = Impl()->_IsPairedToAccount()
+        ? Ble::WeaveBLEDeviceIdentificationInfo::kPairingStatus_Paired
+        : Ble::WeaveBLEDeviceIdentificationInfo::kPairingStatus_Unpaired;
 
 exit:
     return err;

--- a/src/ble/WeaveBleServiceData.h
+++ b/src/ble/WeaveBleServiceData.h
@@ -1,0 +1,111 @@
+/*
+ *
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Definitions for Weave BLE service advertisement data.
+ */
+
+#ifndef WEAVE_BLE_SERVICE_DATA_H
+#define WEAVE_BLE_SERVICE_DATA_H
+
+namespace nl {
+namespace Ble {
+
+/**
+ * Weave data block types that may appear with Weave BLE service advertisement data.
+ */
+enum WeaveBLEServiceDataType
+{
+    kWeaveBLEServiceDataType_DeviceIdentificationInfo       = 0x01,
+    kWeaveBLEServiceDataType_TokenIdentificationInfo        = 0x02,
+};
+
+/**
+ * Weave BLE Device Identification Information Block
+ *
+ * Defines the over-the-air encoded format of the device identification information block that appears
+ * within Weave BLE service advertisement data.
+ */
+struct WeaveBLEDeviceIdentificationInfo
+{
+    enum
+    {
+        kMajorVersion           = 0,
+        kMinorVersion           = 1,
+    };
+
+    enum
+    {
+        kPairingStatus_Unpaired = 0,
+        kPairingStatus_Paired   = 1,
+    };
+
+    uint8_t BlockLen;
+    uint8_t BlockType;
+    uint8_t MajorVersion;
+    uint8_t MinorVersion;
+    uint8_t DeviceVendorId[2];
+    uint8_t DeviceProductId[2];
+    uint8_t DeviceId[8];
+    uint8_t PairingStatus;
+
+    void Init()
+    {
+        memset(this, 0, sizeof(*this));
+        BlockLen = sizeof(*this) - sizeof(BlockLen); // size of all fields EXCEPT BlockLen
+        BlockType = kWeaveBLEServiceDataType_DeviceIdentificationInfo;
+        MajorVersion = kMajorVersion;
+        MinorVersion = kMinorVersion;
+    }
+
+    uint16_t GetVendorId(void)
+    {
+        return nl::Weave::Encoding::LittleEndian::Get16(DeviceVendorId);
+    }
+
+    void SetVendorId(uint16_t vendorId)
+    {
+        nl::Weave::Encoding::LittleEndian::Put16(DeviceVendorId, vendorId);
+    }
+
+    uint16_t GetProductId(void)
+    {
+        return nl::Weave::Encoding::LittleEndian::Get16(DeviceProductId);
+    }
+
+    void SetProductId(uint16_t productId)
+    {
+        nl::Weave::Encoding::LittleEndian::Put16(DeviceProductId, productId);
+    }
+
+    uint64_t GetDeviceId(void)
+    {
+        return nl::Weave::Encoding::LittleEndian::Get64(DeviceId);
+    }
+
+    void SetDeviceId(uint64_t deviceId)
+    {
+        nl::Weave::Encoding::LittleEndian::Put64(DeviceId, deviceId);
+    }
+} __attribute__((packed));
+
+} /* namespace Ble */
+} /* namespace nl */
+
+#endif // WEAVE_BLE_SERVICE_DATA_H

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -81,6 +81,7 @@ $(nl_public_BleLayer_ble_source_dirstem)/BleLayer.h \
 $(nl_public_BleLayer_ble_source_dirstem)/BlePlatformDelegate.h \
 $(nl_public_BleLayer_ble_source_dirstem)/BleUUID.h \
 $(nl_public_BleLayer_ble_source_dirstem)/WoBle.h \
+$(nl_public_BleLayer_ble_source_dirstem)/WeaveBleServiceData.h \
 $(NULL)
 
 dist_ble_ble_HEADERS = $(addprefix ../,$(nl_public_BleLayer_ble_header_sources))

--- a/src/include/Makefile.in
+++ b/src/include/Makefile.in
@@ -717,6 +717,7 @@ $(nl_public_BleLayer_ble_source_dirstem)/BleLayer.h \
 $(nl_public_BleLayer_ble_source_dirstem)/BlePlatformDelegate.h \
 $(nl_public_BleLayer_ble_source_dirstem)/BleUUID.h \
 $(nl_public_BleLayer_ble_source_dirstem)/WoBle.h \
+$(nl_public_BleLayer_ble_source_dirstem)/WeaveBleServiceData.h \
 $(NULL)
 
 dist_ble_ble_HEADERS = $(addprefix ../,$(nl_public_BleLayer_ble_header_sources))


### PR DESCRIPTION
-- Corrected a mistake in the encoding of the Weave BLE device identification block that gets sent as BLE service advertisement data by the nRF52840.  The previous version of the code omitted two fields, which caused considerable heartburn for the Nest mobile application.

-- Corrected another minor mistake in the encoding of the device identification block on the ESP32 which resulted in the wrong data block type being sent.  This bug didn’t seem to bother the mobile application.

-- Created a common data structure for encoding and decoding a Weave BLE device identification block and refactored the nRF5 and ESP32 code bases to use this structure.