### PR TITLE
Enable interface selection in rendezvous and device enumeration

### DIFF
--- a/src/device-manager/WeaveDeviceManager.h
+++ b/src/device-manager/WeaveDeviceManager.h
@@ -181,6 +181,7 @@ public:
     WEAVE_ERROR EnableConnectionMonitor(uint16_t interval, uint16_t timeout, void* appReqState, CompleteFunct onComplete, ErrorFunct onError);
     WEAVE_ERROR DisableConnectionMonitor(void* appReqState, CompleteFunct onComplete, ErrorFunct onError);
     WEAVE_ERROR SetRendezvousAddress(IPAddress addr);
+    WEAVE_ERROR SetRendezvousAddress(IPAddress addr, InterfaceId rendezvousIntf);
     WEAVE_ERROR SetAutoReconnect(bool autoReconnect);
     WEAVE_ERROR SetUseAccessToken(bool useAccessToken);
     WEAVE_ERROR SetRendezvousLinkLocal(bool RendezvousLinkLocal);
@@ -388,6 +389,7 @@ private:
     IPAddress mRemoteDeviceAddr;
     InterfaceId mDeviceIntf;
     InterfaceId mAssistingDeviceIntf;
+    InterfaceId mRendezvousIntf;
     IdentifyDeviceCriteria mDeviceCriteria;
     uint64_t mDeviceId;
     uint64_t mAssistingDeviceId;

--- a/src/device-manager/python/WeaveDeviceManager-ScriptBinding.cpp
+++ b/src/device-manager/python/WeaveDeviceManager-ScriptBinding.cpp
@@ -221,7 +221,7 @@ extern "C" {
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_GetFabricConfig(WeaveDeviceManager *devMgr, GetFabricConfigCompleteFunct onComplete, ErrorFunct onError);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_JoinExistingFabric(WeaveDeviceManager *devMgr, const uint8_t *fabricConfig, uint32_t fabricConfigLen, CompleteFunct onComplete, ErrorFunct onError);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_Ping(WeaveDeviceManager *devMgr, CompleteFunct onComplete, ErrorFunct onError);
-NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetRendezvousAddress(WeaveDeviceManager *devMgr, const char *rendezvousAddr, const char *rendezvousAddrIntf);
+    NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetRendezvousAddress(WeaveDeviceManager *devMgr, const char *rendezvousAddr, const char *rendezvousAddrIntf);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetAutoReconnect(WeaveDeviceManager *devMgr, bool autoReconnect);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetRendezvousLinkLocal(WeaveDeviceManager *devMgr, bool RendezvousLinkLocal);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetConnectTimeout(WeaveDeviceManager *devMgr, uint32_t timeoutMS);

--- a/src/device-manager/python/WeaveDeviceManager-ScriptBinding.cpp
+++ b/src/device-manager/python/WeaveDeviceManager-ScriptBinding.cpp
@@ -221,7 +221,7 @@ extern "C" {
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_GetFabricConfig(WeaveDeviceManager *devMgr, GetFabricConfigCompleteFunct onComplete, ErrorFunct onError);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_JoinExistingFabric(WeaveDeviceManager *devMgr, const uint8_t *fabricConfig, uint32_t fabricConfigLen, CompleteFunct onComplete, ErrorFunct onError);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_Ping(WeaveDeviceManager *devMgr, CompleteFunct onComplete, ErrorFunct onError);
-    NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetRendezvousAddress(WeaveDeviceManager *devMgr, const char *rendezvousAddr);
+NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetRendezvousAddress(WeaveDeviceManager *devMgr, const char *rendezvousAddr, const char *rendezvousAddrIntf);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetAutoReconnect(WeaveDeviceManager *devMgr, bool autoReconnect);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetRendezvousLinkLocal(WeaveDeviceManager *devMgr, bool RendezvousLinkLocal);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetConnectTimeout(WeaveDeviceManager *devMgr, uint32_t timeoutMS);
@@ -1033,14 +1033,27 @@ WEAVE_ERROR nl_Weave_DeviceManager_Ping(WeaveDeviceManager *devMgr, CompleteFunc
     return devMgr->Ping(NULL, onComplete, onError);
 }
 
-WEAVE_ERROR nl_Weave_DeviceManager_SetRendezvousAddress(WeaveDeviceManager *devMgr, const char *rendezvousAddrStr)
+WEAVE_ERROR nl_Weave_DeviceManager_SetRendezvousAddress(WeaveDeviceManager *devMgr, const char *rendezvousAddrStr, const char *rendezvousIntfStr)
 {
     IPAddress rendezvousAddr;
+    InterfaceId rendezvousIntf;
 
     if (!IPAddress::FromString(rendezvousAddrStr, rendezvousAddr))
         return WEAVE_ERROR_INVALID_ADDRESS;
 
-    return devMgr->SetWiFiRendezvousAddress(rendezvousAddr);
+    if (rendezvousIntfStr == NULL || strlen(rendezvousIntfStr) == 0)
+    {
+        rendezvousIntf = INET_NULL_INTERFACEID;
+    }
+    else
+    {
+        WEAVE_ERROR err;
+        err = InterfaceNameToId(rendezvousIntfStr, rendezvousIntf);
+        if (err != WEAVE_NO_ERROR)
+            return err;
+    }
+
+    return devMgr->SetRendezvousAddress(rendezvousAddr, rendezvousIntf);
 }
 
 WEAVE_ERROR nl_Weave_DeviceManager_SetAutoReconnect(WeaveDeviceManager *devMgr, bool autoReconnect)

--- a/src/device-manager/python/openweave/WeaveDeviceMgr.py
+++ b/src/device-manager/python/openweave/WeaveDeviceMgr.py
@@ -580,11 +580,12 @@ class WeaveDeviceManager:
             lambda: _dmLib.nl_Weave_DeviceManager_DeviceAddress(self.devMgr)
         )
 
-    def SetRendezvousAddress(self, addr):
+    def SetRendezvousAddress(self, addr, intf = None):
         if addr is not None and "\x00" in addr:
             raise ValueError("Unexpected NUL character in addr");
+
         res = self._CallDevMgr(
-            lambda: _dmLib.nl_Weave_DeviceManager_SetRendezvousAddress(self.devMgr, addr)
+            lambda: _dmLib.nl_Weave_DeviceManager_SetRendezvousAddress(self.devMgr, addr, intf)
         )
         if (res != 0):
             raise self._ErrorToException(res)
@@ -1254,7 +1255,7 @@ class WeaveDeviceManager:
             _dmLib.nl_Weave_DeviceManager_Ping.argtypes = [ c_void_p, _CompleteFunct, _ErrorFunct ]
             _dmLib.nl_Weave_DeviceManager_Ping.restype = c_uint32
 
-            _dmLib.nl_Weave_DeviceManager_SetRendezvousAddress.argtypes = [ c_void_p, c_char_p ]
+            _dmLib.nl_Weave_DeviceManager_SetRendezvousAddress.argtypes = [ c_void_p, c_char_p, c_char_p ]
             _dmLib.nl_Weave_DeviceManager_SetRendezvousAddress.restype = c_uint32
 
             _dmLib.nl_Weave_DeviceManager_SetConnectTimeout.argtypes = [ c_void_p, c_uint32 ]

--- a/src/device-manager/python/weave-device-mgr.py
+++ b/src/device-manager/python/weave-device-mgr.py
@@ -2037,11 +2037,15 @@ class DeviceMgrCmd(Cmd):
 
     def do_setrendezvousaddr(self, line):
         """
-          set-rendezvous-addr <addr>
+          set-rendezvous-addr <addr> [ <intf> ]
 
           Set the device IP address to be used when rendezvousing with a device.
           <addr> can be an IPv4 or IPv6 address. Specify the IPv6 link-local, all
-          nodes multicast address (ff02::1) to use multicast rendezvous.
+          nodes multicast address (ff02::1) to use multicast rendezvous. Additionally,
+          the user may specify the name of the interface to be used to rendezvous with
+          with the device; this is useful to limit the IPv6 link local multicasts to a
+          specific interface or to override the default interface settings for IPv4
+          broadcasts.
         """
 
         args = shlex.split(line)
@@ -2053,8 +2057,12 @@ class DeviceMgrCmd(Cmd):
 
         addr = args[0]
 
+        intf = None
+        if (len(args) > 1):
+            intf = args[1]
+
         try:
-            self.devMgr.SetRendezvousAddress(addr)
+            self.devMgr.SetRendezvousAddress(addr, intf)
         except WeaveDeviceMgr.DeviceManagerException, ex:
             print str(ex)
             return

--- a/src/inet/IPEndPointBasis.cpp
+++ b/src/inet/IPEndPointBasis.cpp
@@ -741,7 +741,7 @@ INET_ERROR IPEndPointBasis::SendTo(const IPAddress &aAddress, uint16_t aPort, In
     if (aInterfaceId == INET_NULL_INTERFACEID)
         aInterfaceId = mBoundIntfId;
 
-    if (aInterfaceId != INET_NULL_INTERFACEID && false)
+    if (aInterfaceId != INET_NULL_INTERFACEID)
     {
 #if defined(IP_PKTINFO) || defined(IPV6_PKTINFO)
         memset(controlData, 0, sizeof (controlData));
@@ -788,7 +788,7 @@ INET_ERROR IPEndPointBasis::SendTo(const IPAddress &aAddress, uint16_t aPort, In
     {
         // Send IP packet.
 
-        const ssize_t lenSent = sendto(mSocket, msgHeader.msg_iov[0].iov_base, msgHeader.msg_iov[0].iov_len, 0, &lPeerSockAddr.any, msgHeader.msg_namelen);
+        const ssize_t lenSent = sendmsg(mSocket, &msgHeader, 0);
 
         if (lenSent == -1)
             lRetval = Weave::System::MapErrorPOSIX(errno);


### PR DESCRIPTION
Enabled an additional `rendenzvousIntf` parameter in
WeaveDeviceManager::SetRendezvousAddress so that the Identify messages
can be sent on a specific interface.  Currently the plumbing is
enabled for Python only.  The change required re-enabling older
codepaths that would use `sendmsg` instead of `sendto`.