### PR TITLE
Fixed Typo In The ConvertExtension() Function.

### DIFF
--- a/src/lib/profiles/security/X509ToWeave.cpp
+++ b/src/lib/profiles/security/X509ToWeave.cpp
@@ -434,7 +434,7 @@ static WEAVE_ERROR ConvertExtension(ASN1Reader& reader, TLVWriter& writer)
 
                 if (critical)
                 {
-                    err = writer.PutBoolean(ContextTag(kTag_SubjectKeyIdentifier_Critical), critical);
+                    err = writer.PutBoolean(ContextTag(kTag_KeyUsage_Critical), critical);
                     SuccessOrExit(err);
                 }
 


### PR DESCRIPTION
Replaced kTag_SubjectKeyIdentifier_Critical with kTag_KeyUsage_Critical
when converting Key Usage Extension.
This is not a functional bug because both enums have the same value "1".