### PR TITLE
add wdm update integration tests

### DIFF
--- a/src/test-apps/Makefile.am
+++ b/src/test-apps/Makefile.am
@@ -1027,12 +1027,15 @@ check_SCRIPTS                                 +=                \
     happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_63.py     \
     happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_64.py     \
     happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_65.py     \
-    happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_faults_happy.sh \
+    happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_faults_happy.sh       \
     happy/tests/standalone/wdmNext/test_weave_wdm_next_application_key_01.py      \
     happy/tests/standalone/wdmNext/test_weave_wdm_next_application_key_02.py      \
     happy/tests/standalone/wdmNext/test_weave_wdm_next_oneway_resub.py            \
     happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_resub.py            \
     happy/tests/standalone/wdmNext/test_weave_wdm_next_subless_notify_01.py       \
+    happy/tests/standalone/wdmNext/test_weave_wdm_next_update_01.py       \
+    happy/tests/standalone/wdmNext/test_weave_wdm_next_update_02.py       \
+    happy/tests/standalone/wdmNext/test_weave_wdm_next_update_03.py       \
     $(NULL)
 
 endif # WEAVE_RUN_HAPPY_WDM

--- a/src/test-apps/Makefile.in
+++ b/src/test-apps/Makefile.in
@@ -526,12 +526,15 @@ target_triplet = @target@
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_63.py     \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_64.py     \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_65.py     \
-@WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_faults_happy.sh \
+@WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_subscribe_faults_happy.sh       \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_application_key_01.py      \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_application_key_02.py      \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_oneway_resub.py            \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_resub.py            \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_subless_notify_01.py       \
+@WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_update_01.py       \
+@WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_update_02.py       \
+@WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    happy/tests/standalone/wdmNext/test_weave_wdm_next_update_03.py       \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@    $(NULL)
 
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_BDX_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@am__append_33 = \
@@ -2432,7 +2435,10 @@ RECHECK_LOGS = $(TEST_LOGS)
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@	happy/tests/standalone/wdmNext/test_weave_wdm_next_application_key_02.py \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@	happy/tests/standalone/wdmNext/test_weave_wdm_next_oneway_resub.py \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@	happy/tests/standalone/wdmNext/test_weave_wdm_next_mutual_resub.py \
-@WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@	happy/tests/standalone/wdmNext/test_weave_wdm_next_subless_notify_01.py
+@WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@	happy/tests/standalone/wdmNext/test_weave_wdm_next_subless_notify_01.py \
+@WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@	happy/tests/standalone/wdmNext/test_weave_wdm_next_update_01.py \
+@WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@	happy/tests/standalone/wdmNext/test_weave_wdm_next_update_02.py \
+@WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@@WEAVE_RUN_HAPPY_WDM_TRUE@	happy/tests/standalone/wdmNext/test_weave_wdm_next_update_03.py
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_BDX_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@am__EXEEXT_28 = happy/tests/standalone/bdx/test_weave_bdx_01.py \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_BDX_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@	happy/tests/standalone/bdx/test_weave_bdx_02.py \
 @WEAVE_BUILD_TESTS_TRUE@@WEAVE_RUN_HAPPY_BDX_TRUE@@WEAVE_RUN_HAPPY_SERVICE_FALSE@@WEAVE_RUN_HAPPY_TRUE@	happy/tests/standalone/bdx/test_weave_bdx_03.py \
@@ -8265,6 +8271,27 @@ happy/tests/standalone/wdmNext/test_weave_wdm_next_subless_notify_01.py.log: hap
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+happy/tests/standalone/wdmNext/test_weave_wdm_next_update_01.py.log: happy/tests/standalone/wdmNext/test_weave_wdm_next_update_01.py
+	@p='happy/tests/standalone/wdmNext/test_weave_wdm_next_update_01.py'; \
+	b='happy/tests/standalone/wdmNext/test_weave_wdm_next_update_01.py'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
+happy/tests/standalone/wdmNext/test_weave_wdm_next_update_02.py.log: happy/tests/standalone/wdmNext/test_weave_wdm_next_update_02.py
+	@p='happy/tests/standalone/wdmNext/test_weave_wdm_next_update_02.py'; \
+	b='happy/tests/standalone/wdmNext/test_weave_wdm_next_update_02.py'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
+happy/tests/standalone/wdmNext/test_weave_wdm_next_update_03.py.log: happy/tests/standalone/wdmNext/test_weave_wdm_next_update_03.py
+	@p='happy/tests/standalone/wdmNext/test_weave_wdm_next_update_03.py'; \
+	b='happy/tests/standalone/wdmNext/test_weave_wdm_next_update_03.py'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 happy/tests/standalone/bdx/test_weave_bdx_01.py.log: happy/tests/standalone/bdx/test_weave_bdx_01.py
 	@p='happy/tests/standalone/bdx/test_weave_bdx_01.py'; \
 	b='happy/tests/standalone/bdx/test_weave_bdx_01.py'; \
@@ -8599,11 +8626,11 @@ distclean-generic:
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
+@WEAVE_BUILD_TESTS_FALSE@uninstall-local:
+@WEAVE_BUILD_TESTS_FALSE@install-exec-local:
 @WEAVE_BUILD_COVERAGE_FALSE@clean-local:
 @WEAVE_BUILD_COVERAGE_REPORTS_FALSE@clean-local:
 @WEAVE_BUILD_TESTS_FALSE@clean-local:
-@WEAVE_BUILD_TESTS_FALSE@install-exec-local:
-@WEAVE_BUILD_TESTS_FALSE@uninstall-local:
 clean: clean-recursive
 
 clean-am: clean-checkPROGRAMS clean-generic clean-libexecPROGRAMS \

--- a/src/test-apps/MockWdmNodeOptions.cpp
+++ b/src/test-apps/MockWdmNodeOptions.cpp
@@ -51,7 +51,7 @@ MockWdmNodeOptions::MockWdmNodeOptions() :
 #endif // WDM_ENABLE_SUBSCRIPTIONLESS_NOTIFICATION
     mWdmUpdateConditionality(kConditionality_Conditional),
     mWdmUpdateMutation(kMutation_OneLeaf),
-    mWdmUpdateNumberOfTraits(1),
+    mWdmUpdateNumberOfTraits(0),
     mWdmUpdateNumberOfMutations(1),
     mWdmUpdateNumberOfRepeatedMutations(1),
     mWdmUpdateTiming(kTiming_AfterSub),
@@ -284,7 +284,8 @@ const char **MockWdmNodeOptions::GetUpdateTimingStrings(void)
     static const char *updateTimingStrings[kTiming_NumItems] = {
         "BeforeSub",
         "DuringSub",
-        "AfterSub"
+        "AfterSub",
+        "NoSub"
     };
 
     return updateTimingStrings;

--- a/src/test-apps/MockWdmNodeOptions.h
+++ b/src/test-apps/MockWdmNodeOptions.h
@@ -87,7 +87,7 @@ public:
         kTiming_BeforeSub = 0,
         kTiming_DuringSub,
         kTiming_AfterSub,
-
+        kTiming_NoSub,
         kTiming_NumItems
     };
 

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_update_01.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_update_01.py
@@ -2,6 +2,7 @@
 
 
 #
+#    Copyright (c) 2019 Google, LLC.
 #    Copyright (c) 2016-2018 Nest Labs, Inc.
 #    All rights reserved.
 #
@@ -21,7 +22,8 @@
 #
 #    @file
 #       Calls Weave WDM Update between nodes.
-#       O01: Update: Client send conditional update request to publisher, and receive status report
+#       Update 01: Client creates mutual subscription, sends conditional update request to publisher,
+#       and receives notification and status report
 #
 
 import unittest
@@ -36,13 +38,15 @@ class test_weave_wdm_next_update_01(weave_wdm_next_test_base):
         wdm_next_args = {}
         wdm_next_args['wdm_option'] = "mutual_subscribe"
 
-        wdm_next_args['total_client_count'] = 16
+        wdm_next_args['total_client_count'] = 1
         wdm_next_args['final_client_status'] = 0
         wdm_next_args['timer_client_period'] = 10000
-        wdm_next_args['test_client_iterations'] = 2
+        wdm_next_args['test_client_iterations'] = 1
         wdm_next_args['test_client_delay'] = 2000
         wdm_next_args['enable_client_flip'] = 1
-        wdm_next_args['test_client_case'] = 10 # kTestCase_TestUpdatableTrait_OneTraitConditional
+        wdm_next_args['test_client_case'] = 10 # kTestCase_TestUpdatableTrait
+
+        wdm_next_args['enable_retry'] = True
 
         wdm_next_args['total_server_count'] = 0
         wdm_next_args['final_server_status'] = 4
@@ -53,12 +57,17 @@ class test_weave_wdm_next_update_01(weave_wdm_next_test_base):
         wdm_next_args['client_clear_state_between_iterations'] = False
         wdm_next_args['server_clear_state_between_iterations'] = False
 
-        wdm_next_args['client_log_check'] = [('Update: Good Iteration', wdm_next_args['test_client_iterations'] * wdm_next_args['total_client_count'])]
+        wdm_next_args['client_update_mutation'] = "OneLeaf"
+        wdm_next_args['client_update_conditionality'] = "Conditional"
+        wdm_next_args['client_update_num_mutations'] = 1
+        wdm_next_args['client_update_timing'] = "AfterSub"
+
+        wdm_next_args['client_log_check'] = [('Update: path result: success', wdm_next_args['test_client_iterations'] * wdm_next_args['total_client_count'])]
         wdm_next_args['server_log_check'] = []
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['O01: Update: Client creates mutual subscription, sends conditional update request to publisher, and receives status report']
+        wdm_next_args['test_case_name'] = ['Update 01: Client creates mutual subscription, sends conditional update request to publisher, and receives notification and status report']
         print 'test file: ' + self.__class__.__name__
-        print "weave-wdm-next update test O01"
+        print "weave-wdm-next update test 01"
         super(test_weave_wdm_next_update_01, self).weave_wdm_next_test_base(wdm_next_args)
 
 

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_update_02.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_update_02.py
@@ -2,6 +2,7 @@
 
 
 #
+#    Copyright (c) 2019 Google, LLC.
 #    Copyright (c) 2016-2018 Nest Labs, Inc.
 #    All rights reserved.
 #
@@ -21,7 +22,8 @@
 #
 #    @file
 #       Calls Weave WDM Update between nodes.
-#       O02: Update: Client send unconditional update request to publisher, and receive status report
+#       Update 02: Client creates mutual subscription, sends unconditional update request to publisher,
+#       and receives notification and status report
 #
 
 import unittest
@@ -32,17 +34,19 @@ import WeaveUtilities
 
 class test_weave_wdm_next_update_02(weave_wdm_next_test_base):
 
-    def test_weave_wdm_next_mutual_subscribe_01(self):
+    def test_weave_wdm_next_mutual_subscribe_02(self):
         wdm_next_args = {}
         wdm_next_args['wdm_option'] = "mutual_subscribe"
 
-        wdm_next_args['total_client_count'] = 16
+        wdm_next_args['total_client_count'] = 1
         wdm_next_args['final_client_status'] = 0
         wdm_next_args['timer_client_period'] = 10000
-        wdm_next_args['test_client_iterations'] = 2
+        wdm_next_args['test_client_iterations'] = 1
         wdm_next_args['test_client_delay'] = 2000
         wdm_next_args['enable_client_flip'] = 1
-        wdm_next_args['test_client_case'] = 11 # kTestCase_TestUpdatableTrait_OneTraitUnconditional
+        wdm_next_args['test_client_case'] = 10 # kTestCase_TestUpdatableTrait
+
+        wdm_next_args['enable_retry'] = True
 
         wdm_next_args['total_server_count'] = 0
         wdm_next_args['final_server_status'] = 4
@@ -53,12 +57,17 @@ class test_weave_wdm_next_update_02(weave_wdm_next_test_base):
         wdm_next_args['client_clear_state_between_iterations'] = False
         wdm_next_args['server_clear_state_between_iterations'] = False
 
-        wdm_next_args['client_log_check'] = [('Update: Good Iteration', wdm_next_args['test_client_iterations'] * wdm_next_args['total_client_count'])]
+        wdm_next_args['client_update_mutation'] = "OneLeaf"
+        wdm_next_args['client_update_conditionality'] = "Unconditional"
+        wdm_next_args['client_update_num_mutations'] = 1
+        wdm_next_args['client_update_timing'] = "AfterSub"
+
+        wdm_next_args['client_log_check'] = [('Update: path result: success', wdm_next_args['test_client_iterations'] * wdm_next_args['total_client_count'])]
         wdm_next_args['server_log_check'] = []
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['O02: Update: Client creates mutual subscription, sends unconditional update request to publisher, and receives status report']
+        wdm_next_args['test_case_name'] = ['Update 02: Client creates mutual subscription, sends unconditional update request to publisher, and receives notification and status report']
         print 'test file: ' + self.__class__.__name__
-        print "weave-wdm-next update test O02"
+        print "weave-wdm-next update test 02"
         super(test_weave_wdm_next_update_02, self).weave_wdm_next_test_base(wdm_next_args)
 
 

--- a/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_update_03.py
+++ b/src/test-apps/happy/tests/standalone/wdmNext/test_weave_wdm_next_update_03.py
@@ -2,6 +2,7 @@
 
 
 #
+#    Copyright (c) 2019 Google, LLC.
 #    Copyright (c) 2016-2018 Nest Labs, Inc.
 #    All rights reserved.
 #
@@ -21,7 +22,7 @@
 #
 #    @file
 #       Calls Weave WDM Update between nodes.
-#       O01: Update: Client sends mixed update request to publisher, and receives status report
+#       Update 03: Client sends standalone unconditional update request to publisher, and receives status report
 #
 
 import unittest
@@ -34,15 +35,17 @@ class test_weave_wdm_next_update_03(weave_wdm_next_test_base):
 
     def test_weave_wdm_next_mutual_subscribe_03(self):
         wdm_next_args = {}
+        wdm_next_args['wdm_option'] = "one_way_subscribe"
 
-        wdm_next_args['wdm_option'] = "mutual_subscribe"
+        wdm_next_args['total_client_count'] = 1
         wdm_next_args['final_client_status'] = 0
-        wdm_next_args['enable_client_flip'] = 1
-        wdm_next_args['test_client_iterations'] = 2
+        wdm_next_args['timer_client_period'] = 10000
+        wdm_next_args['test_client_iterations'] = 1
         wdm_next_args['test_client_delay'] = 2000
-        wdm_next_args['client_clear_state_between_iterations'] = False
-        wdm_next_args['test_client_case'] = 12 # kTestCase_TestUpdatableTrait_ThreeTraitsMixed
-        wdm_next_args['total_client_count'] = 8
+        wdm_next_args['enable_client_flip'] = 1
+        wdm_next_args['test_client_case'] = 10 # kTestCase_TestUpdatableTrait
+
+        wdm_next_args['enable_retry'] = True
 
         wdm_next_args['total_server_count'] = 0
         wdm_next_args['final_server_status'] = 4
@@ -53,12 +56,17 @@ class test_weave_wdm_next_update_03(weave_wdm_next_test_base):
         wdm_next_args['client_clear_state_between_iterations'] = False
         wdm_next_args['server_clear_state_between_iterations'] = False
 
-        wdm_next_args['client_log_check'] = [('Update: Good Iteration', wdm_next_args['test_client_iterations'] * wdm_next_args['total_client_count'])]
+        wdm_next_args['client_update_mutation'] = "OneLeaf"
+        wdm_next_args['client_update_conditionality'] = "Unconditional"
+        wdm_next_args['client_update_num_mutations'] = 1
+        wdm_next_args['client_update_timing'] = "NoSub"
+
+        wdm_next_args['client_log_check'] = [('Update: path result: success', wdm_next_args['test_client_iterations'] * wdm_next_args['total_client_count'])]
         wdm_next_args['server_log_check'] = []
         wdm_next_args['test_tag'] = self.__class__.__name__[19:].upper()
-        wdm_next_args['test_case_name'] = ['O03: Update: Client creates mutual subscription, sends an update request to publisher with conditional and unconditional changes, and receives status report']
+        wdm_next_args['test_case_name'] = ['Update 03: Client sends standalone unconditional update request to publisher, and receives status report']
         print 'test file: ' + self.__class__.__name__
-        print "weave-wdm-next update test O03"
+        print "weave-wdm-next update test 03"
         super(test_weave_wdm_next_update_03, self).weave_wdm_next_test_base(wdm_next_args)
 
 


### PR DESCRIPTION
-- add wdm conditional update integration test and unconditional update integration
test along with subscription.
-- add standalone wdm unconditional integration test without
subscription.
-- remove smoke check for wdm test since we should only rely on the log-check
in test application script, and reduce the log check confusion.
-- add NoSub enum value in WdmUpdateTiming, currently it include before
sub, during sub, and after sub, possibly it is good place to add no sub.
-- during no sub, MonitorClientCurrentState would be triggered when all
update iteracton completes.
-- with sub, update shutdown would be handled in existing sub shutdown
codepth.
-- delete the dead code in MockWdmSubscriptionInitiator.cpp and
MockWdmSubscriptionResponder.cpp.