### PR TITLE
Populate 802.15.4 MAC address on Nordic

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -77,6 +77,7 @@ protected:
     WEAVE_ERROR _GetAndLogThreadStatsCounters(void);
     WEAVE_ERROR _GetAndLogThreadTopologyMinimal(void);
     WEAVE_ERROR _GetAndLogThreadTopologyFull(void);
+    WEAVE_ERROR _GetPrimary802154MACAddress(uint8_t *buf);
 
     // ===== Members available to the implementation subclass.
 

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -807,6 +807,14 @@ exit:
 }
 
 template<class ImplClass>
+WEAVE_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetPrimary802154MACAddress(uint8_t *buf)
+{
+    const otExtAddress *extendedAddr = otLinkGetExtendedAddress(mOTInst);
+    memcpy(buf, extendedAddr, sizeof(otExtAddress));
+    return WEAVE_NO_ERROR;
+};
+
+template<class ImplClass>
 WEAVE_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstance * otInst)
 {
     WEAVE_ERROR err = WEAVE_NO_ERROR;
@@ -870,7 +878,6 @@ bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::IsThreadAttachedNoLock
     otDeviceRole curRole = otThreadGetDeviceRole(mOTInst);
     return (curRole != OT_DEVICE_ROLE_DISABLED && curRole != OT_DEVICE_ROLE_DETACHED);
 }
-
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ThreadStackManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ThreadStackManager.h
@@ -66,6 +66,7 @@ public:
     WEAVE_ERROR GetAndLogThreadStatsCounters(void);
     WEAVE_ERROR GetAndLogThreadTopologyMinimal(void);
     WEAVE_ERROR GetAndLogThreadTopologyFull(void);
+    WEAVE_ERROR GetPrimary802154MACAddress(uint8_t *buf);
 
 private:
 
@@ -75,6 +76,7 @@ private:
     friend class ConfigurationManagerImpl;
     friend class Internal::DeviceControlServer;
     template<class> friend class Internal::GenericPlatformManagerImpl;
+    template<class> friend class Internal::GenericConfigurationManagerImpl;
     template<class> friend class Internal::GenericPlatformManagerImpl_FreeRTOS;
     template<class> friend class Internal::GenericConnectivityManagerImpl_Thread;
     template<class> friend class Internal::GenericThreadStackManagerImpl_OpenThread;
@@ -234,6 +236,11 @@ inline WEAVE_ERROR ThreadStackManager::GetAndLogThreadTopologyMinimal(void)
 inline WEAVE_ERROR ThreadStackManager::GetAndLogThreadTopologyFull(void)
 {
     return static_cast<ImplClass*>(this)->_GetAndLogThreadTopologyFull();
+}
+
+inline WEAVE_ERROR ThreadStackManager::GetPrimary802154MACAddress(uint8_t * buf)
+{
+    return static_cast<ImplClass*>(this)->_GetPrimary802154MACAddress(buf);
 }
 
 } // namespace DeviceLayer

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.ipp
@@ -28,6 +28,9 @@
 #include <Weave/DeviceLayer/internal/WeaveDeviceLayerInternal.h>
 #include <Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.h>
 
+#if WEAVE_DEVICE_CONFIG_ENABLE_THREAD
+#include <Weave/DeviceLayer/ThreadStackManager.h>
+#endif
 
 namespace nl {
 namespace Weave {
@@ -194,7 +197,11 @@ WEAVE_ERROR GenericConfigurationManagerImpl<ImplClass>::_StorePrimaryWiFiMACAddr
 template<class ImplClass>
 WEAVE_ERROR GenericConfigurationManagerImpl<ImplClass>::_GetPrimary802154MACAddress(uint8_t * buf)
 {
+#if WEAVE_DEVICE_CONFIG_ENABLE_THREAD
+    return ThreadStackManager().GetPrimary802154MACAddress(buf);
+#else
     return WEAVE_DEVICE_ERROR_CONFIG_NOT_FOUND;
+#endif // WEAVE_DEVICE_CONFIG_ENABLE_THREAD
 }
 
 template<class ImplClass>


### PR DESCRIPTION
On Nordic, populate 802.15.4 extended address. This address may be a
meaningless set of numbers -- there is no guarantee that the address
populated will be the same as the address used in joining (or
re-attaching) to any particular Thread network or that it will
correspond to the factory provisioned EUI64.