### PR TITLE
upload logs to gcs after failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
+after_failure:
+  - .travis/after_failure.sh
+
 matrix:
   include:
     - name: "Linux with Defaults against GCC Distribution Sanity Check"
@@ -99,3 +102,6 @@ deploy:
   on:
     repo: openweave/openweave-core
     tags: true
+env:
+  global:
+    secure: PJdNS8L51Y+Op8xc2C9U13Y6eQUAszDEKigB0jn9LsXB8BZwJsu3mjmtLTQBU99nqAhsCKiN85kxry6APi/xjcDJ3/iRP8IpP8KJ/VV68CChdu1X/2iatSS/EOAT4ZBoo3sUCmP98w4k5G6HiVCpnNprhZOg8xsD9bflVkX9Au67hcwfHfKWyX1c/kbYYyegSWd+7GgkNZRGAws1yuwL1MwGppDqKQJ1bOciALaA1LMzzl1wvrle6t+CWvLH51YoIgndFsTJaphGqXp/hveCIsXEGKY5ZN8RkfuSvs9JupsfoXjA9Nxg2WfLC5c4MeyJV9yvzF9zZNglra9+PTlHFMxnuSvyIKRiHb9rwXMwgtb8Tqwhe0Cikj77gHdRUfZjUNBS34nNRqACSFjSFDM9N862z17BqfMZu0A0znquM24vfm+JV1i7OZ8USdbbmBqtL5qJgimQv2/Y/j3H/o6IrqOLEhuzOXQynclf6xi6AdXlcJ1QmTTicU5JbETJuzkvOYsnUs7TBV0FaPf+j98LEHTXZUPlDtQz4sIu757SiYUuR6Jm357yOwyv+x/PMk250g2op0TtMksjR3HQahnz8HJPYLenOxogYqarqY6E4TNm2P+bRDCPgxQ+dTSvlrcH8qhl+PHImn38q38ghm98WUvqdwxAApI3cZdy4Ja/3WA=

--- a/.travis/after_failure.sh
+++ b/.travis/after_failure.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#
+#    Copyright 2018-2019 Google LLC All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+#
+#    Description:
+#      This file is the script for Travis CI hosted, distributed continuous
+#      integration 'after_failure' trigger of 'failure' step.
+#	   How dpl works: https://github.com/travis-ci/dpl
+#	   How to encrypt gcs key: https://docs.travis-ci.com/user/encryption-keys/#usage
+
+sudo apt-get remove ruby
+sudo apt update
+sudo apt install git curl libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+
+cd $HOME
+git clone https://github.com/travis-ci/dpl.git
+cd $HOME/dpl/bin
+gem install dpl
+gem install bundler
+bundle update
+
+dpl --provider=gcs --access-key-id=GOOGNPZYTVTEPZM5VBRAVVUU \
+	--secret-access-key=$GCSKEY --bucket=openweave \
+	--local-dir=$TRAVIS_BUILD_DIR/happy-test-logs --upload-dir=happy-test-log/$TRAVIS_BUILD_NUMBER \
+	--acl=public-read --skip_cleanup=true


### PR DESCRIPTION
Hi @gerickson @jaylogue @robszewczyk :
   This is the PR to address issue of "not uploading logs after test failure", please help to review.
I have tested it on one of my test branch, which I did return value 2 by intention to make test fail everytime:
https://github.com/openweave/openweave-core/tree/lwip_upload_fail_log
result link for test branch when test failedis:
https://travis-ci.org/openweave/openweave-core/builds/557980883

Thanks
Jennie