### PR TITLE
Support brew prefix not equal to /usr/local

### DIFF
--- a/Makefile-Standalone
+++ b/Makefile-Standalone
@@ -111,8 +111,7 @@ ifeq ($(NO_OPENSSL),1)
 OPENSSL                         = no
 else
 ifeq ($(HOSTOS),darwin)
-OSX_OPENSSL_DIR                 = /usr/local/opt/openssl
-OPENSSL                        ?= $(shell if which brew > /dev/null && brew ls --versions openssl > /dev/null; then echo $(OSX_OPENSSL_DIR); else echo "internal"; fi) 
+OPENSSL                        ?= $(shell if which brew > /dev/null && brew ls --versions openssl > /dev/null; then brew --prefix openssl; else echo "internal"; fi)
 else
 OPENSSL                        ?= $(shell if which pkg-config > /dev/null && pkg-config --exists openssl; then echo ""; else echo "internal"; fi)
 endif


### PR DESCRIPTION
Homebrew is not always installed in /usr/local. This use standard way to
get Homebrew's prefix.