### PR TITLE
[Thread] add thread pskc to network provisioning

### DIFF
--- a/src/adaptations/device-layer/DeviceNetworkInfo.cpp
+++ b/src/adaptations/device-layer/DeviceNetworkInfo.cpp
@@ -136,7 +136,12 @@ WEAVE_ERROR DeviceNetworkInfo::Encode(nl::Weave::TLV::TLVWriter & writer) const
         SuccessOrExit(err);
     }
 
-    // TODO: Add support for ThreadPSKc field.
+    if (FieldPresent.ThreadPSKc)
+    {
+        err = writer.PutBytes(ProfileTag(kWeaveProfile_NetworkProvisioning, kTag_ThreadNetworkPSKc),
+                ThreadNetworkPSKc, kThreadPSKcLength);
+        SuccessOrExit(err);
+    }
 
     if (ThreadPANId != kThreadPANId_NotSpecified)
     {
@@ -286,7 +291,14 @@ WEAVE_ERROR DeviceNetworkInfo::Decode(nl::Weave::TLV::TLVReader & reader)
             SuccessOrExit(err);
             FieldPresent.ThreadNetworkKey = true;
             break;
-        // TODO: Add case for ThreadPSKc field.
+        case kTag_ThreadPSKc:
+            VerifyOrExit(reader.GetType() == kTLVType_ByteString, err = WEAVE_ERROR_INVALID_TLV_ELEMENT);
+            val = reader.GetLength();
+            VerifyOrExit(val == kThreadPSKcLength, err = WEAVE_ERROR_INVALID_TLV_ELEMENT);
+            err = reader.GetBytes(ThreadPSKc, sizeof(ThreadPSKc));
+            SuccessOrExit(err);
+            FieldPresent.ThreadPSKc = true;
+            break;
         case kTag_ThreadPANId:
             VerifyOrExit(reader.GetType() == kTLVType_UnsignedInteger, err = WEAVE_ERROR_INVALID_TLV_ELEMENT);
             err = reader.Get(val);
@@ -306,7 +318,7 @@ WEAVE_ERROR DeviceNetworkInfo::Decode(nl::Weave::TLV::TLVReader & reader)
         case kTag_ThreadExtendedPANId:
         case kTag_ThreadMeshPrefix:
         case kTag_ThreadNetworkKey:
-        // TODO: Add case for ThreadPSKc field.
+        case kTag_ThreadPSKc:
         case kTag_ThreadPANId:
         case kTag_ThreadChannel:
             ExitNow(err = WEAVE_ERROR_UNSUPPORTED_WEAVE_FEATURE);

--- a/src/device-manager/cocoa/NLNetworkInfo.h
+++ b/src/device-manager/cocoa/NLNetworkInfo.h
@@ -57,6 +57,7 @@ extern const int NLThreadChannel_NotSpecified;
 @property (nonatomic)
     int ThreadPANId; // The Thread PAN identifier (short) or NLThreadPANId_NotSpecified if not available/applicable.
 @property (nonatomic) int ThreadChannel; // The Thread channel or NLThreadChannel_NotSpecified if not available/applicable.
+@property (nonatomic, strong) NSData * ThreadPSKc; // The Thread pre-shared key commissioner, or NULL if not specified.
 
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;

--- a/src/device-manager/cocoa/NLNetworkInfo.mm
+++ b/src/device-manager/cocoa/NLNetworkInfo.mm
@@ -86,13 +86,12 @@ const int NLThreadChannel_NotSpecified = -1;
             _ThreadNetworkName = [[NSString alloc] initWithCString:pNetworkInfo->ThreadNetworkName encoding:NSUTF8StringEncoding];
 
         if (pNetworkInfo->ThreadExtendedPANId) {
-            _ThreadExtendedPANId = [[NSData alloc] initWithBytes:pNetworkInfo->ThreadExtendedPANId length:8];
+            _ThreadExtendedPANId = [[NSData alloc] initWithBytes:pNetworkInfo->ThreadExtendedPANId length:nl::Weave::DeviceManager::NetworkInfo::kThreadExtendedPANIdLength];
         }
 
         if (pNetworkInfo->ThreadNetworkKey) {
-            NSLog(@"Copying ThreadNetworkKey with length: %d", pNetworkInfo->ThreadNetworkKeyLen);
             _ThreadNetworkKey = [[NSData alloc] initWithBytes:pNetworkInfo->ThreadNetworkKey
-                                                       length:pNetworkInfo->ThreadNetworkKeyLen];
+                                                       length:nl::Weave::DeviceManager::NetworkInfo::kThreadNetworkKeyLength];
             NSLog(@"_ThreadNetworkKey: %@", _ThreadNetworkKey);
         }
         _ThreadPANId = pNetworkInfo->ThreadPANId;
@@ -163,9 +162,8 @@ const int NLThreadChannel_NotSpecified = -1;
     }
 
     if (_ThreadNetworkKey) {
-        networkInfo.ThreadNetworkKeyLen = [_ThreadNetworkKey length];
-        networkInfo.ThreadNetworkKey = (uint8_t *) malloc(networkInfo.ThreadNetworkKeyLen);
-        memcpy(networkInfo.ThreadNetworkKey, [_ThreadNetworkKey bytes], networkInfo.ThreadNetworkKeyLen);
+        networkInfo.ThreadNetworkKey = (uint8_t *) malloc(NetworkInfo::kThreadNetworkKeyLength);
+        memcpy(networkInfo.ThreadNetworkKey, [_ThreadNetworkKey bytes], NetworkInfo::kThreadNetworkKeyLength);
     }
 
     networkInfo.ThreadPANId = _ThreadPANId;
@@ -281,7 +279,6 @@ const int NLThreadChannel_NotSpecified = -1;
                                     "\tThreadNetworkName: %s\n"
                                     "\tThreadPANId: %04x\n"
                                     "\tThreadExtendedPANId: %s\n"
-                                    "\tThreadNetworkKeyLen: %d\n"
                                     "\tThreadChannel: %d\n"
                                     "\tWirelessSignalStrength: %d",
                   self, pNetworkInfo->NetworkType, pNetworkInfo->NetworkId, pNetworkInfo->WiFiSSID, pNetworkInfo->WiFiMode,
@@ -290,7 +287,7 @@ const int NLThreadChannel_NotSpecified = -1;
                   pNetworkInfo->WiFiKey ? "*********" : "none",
 #endif
                   pNetworkInfo->ThreadNetworkName, pNetworkInfo->ThreadPANId, pNetworkInfo->ThreadExtendedPANId,
-                  pNetworkInfo->ThreadNetworkKeyLen, pNetworkInfo->ThreadChannel, pNetworkInfo->WirelessSignalStrength];
+                  pNetworkInfo->ThreadChannel, pNetworkInfo->WirelessSignalStrength];
 
     return descr;
 }

--- a/src/device-manager/cocoa/NLNetworkInfo.mm
+++ b/src/device-manager/cocoa/NLNetworkInfo.mm
@@ -94,6 +94,13 @@ const int NLThreadChannel_NotSpecified = -1;
                                                        length:nl::Weave::DeviceManager::NetworkInfo::kThreadNetworkKeyLength];
             NSLog(@"_ThreadNetworkKey: %@", _ThreadNetworkKey);
         }
+
+        if (pNetworkInfo->ThreadPSKc) {
+            _ThreadPSKc = [[NSData alloc] initWithBytes:pNetworkInfo->ThreadPSKc
+                                                       length:nl::Weave::DeviceManager::NetworkInfo::kThreadPSKcLength];
+            NSLog(@"_ThreadPSKc: %@", _ThreadPSKc);
+        }
+
         _ThreadPANId = pNetworkInfo->ThreadPANId;
         _ThreadChannel = pNetworkInfo->ThreadChannel;
 
@@ -120,6 +127,7 @@ const int NLThreadChannel_NotSpecified = -1;
     networkInfo.ThreadNetworkName = [self.ThreadNetworkName copy];
     networkInfo.ThreadExtendedPANId = [self.ThreadExtendedPANId copy];
     networkInfo.ThreadNetworkKey = [self.ThreadNetworkKey copy];
+    networkInfo.ThreadPSKc = [self.ThreadPSKc copy];
     networkInfo.ThreadPANId = self.ThreadPANId;
     networkInfo.ThreadChannel = self.ThreadChannel;
 
@@ -164,6 +172,11 @@ const int NLThreadChannel_NotSpecified = -1;
     if (_ThreadNetworkKey) {
         networkInfo.ThreadNetworkKey = (uint8_t *) malloc(NetworkInfo::kThreadNetworkKeyLength);
         memcpy(networkInfo.ThreadNetworkKey, [_ThreadNetworkKey bytes], NetworkInfo::kThreadNetworkKeyLength);
+    }
+
+    if (_ThreadPSKc) {
+        networkInfo.ThreadPSKc = (uint8_t *) malloc(NetworkInfo::kThreadPSKcLength);
+        memcpy(networkInfo.ThreadPSKc, [_ThreadPSKc bytes], NetworkInfo::kThreadPSKcLength);
     }
 
     networkInfo.ThreadPANId = _ThreadPANId;
@@ -341,6 +354,11 @@ const int NLThreadChannel_NotSpecified = -1;
 
     if (_ThreadNetworkKey) {
         line = [NSString stringWithFormat:@"\tThreadNetworkKey: %@\n", _ThreadNetworkKey];
+        [descr appendString:line];
+    }
+
+    if (_ThreadPSKc) {
+        line = [NSString stringWithFormat:@"\tThreadPSKc: %@\n", _ThreadPSKc];
         [descr appendString:line];
     }
 

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/NetworkInfo.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/NetworkInfo.java
@@ -45,6 +45,7 @@ public class NetworkInfo
         ThreadNetworkName = null;
         ThreadExtendedPANId = null;
         ThreadNetworkKey = null;
+        ThreadPSKc = null;
         ThreadPANId = THREAD_PANID_NOTSPECIFIED;
         ThreadChannel = THREAD_CHANNEL_NOTSPECIFIED;
         WirelessSignalStrength = Short.MIN_VALUE;
@@ -90,6 +91,10 @@ public class NetworkInfo
     /** The Thread network key, or NULL if not specified.
          */
     public byte[] ThreadNetworkKey;
+
+    /** The Thread PSKc, or NULL if not specified.
+         */
+    public byte[] ThreadPSKc;
 
     /** The 16-bit Thread PAN ID, or kThreadPANId_NotSpecified 
          */

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/NetworkInfo.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/NetworkInfo.java
@@ -123,7 +123,7 @@ public class NetworkInfo
     }
 
     public static NetworkInfo MakeThread(String threadNetworkName, byte[] threadExtendedPANId, byte[] threadNetworkKey,
-                                         int threadPANId, int threadChannel)
+                                         int threadPANId, int threadChannel, byte[] threadPSKc)
     {
         NetworkInfo netInfo = new NetworkInfo();
         netInfo.NetworkType = nl.Weave.DeviceManager.NetworkType.Thread;
@@ -132,7 +132,14 @@ public class NetworkInfo
         netInfo.ThreadNetworkKey = threadNetworkKey;
         netInfo.ThreadPANId = threadPANId;
         netInfo.ThreadChannel = threadChannel;
+        netInfo.ThreadPSKc = threadPSKc;
         return netInfo;
+    }
+
+    public static NetworkInfo MakeThread(String threadNetworkName, byte[] threadExtendedPANId, byte[] threadNetworkKey,
+                                         int threadPANId, int threadChannel)
+    {
+        return MakeThread(threadNetworkName, threadExtendedPANId, threadNetworkKey, threadPANId, threadChannel, null);
     }
 
     public static NetworkInfo MakeThread(String threadNetworkName, byte[] threadExtendedPANId, byte[] threadNetworkKey)
@@ -144,7 +151,7 @@ public class NetworkInfo
     public static NetworkInfo Make(int networkType, long networkId,
                                    String wifiSSID, int wifiMode, int wifiRole, int wifiSecurityType, byte[] wifiKey,
                                    String threadNetworkName, byte[] threadExtendedPANId, byte[] threadNetworkKey,
-                                   short wirelessSignalStrength, int threadPANId, int threadChannel)
+                                   byte[] threadPSKc, short wirelessSignalStrength, int threadPANId, int threadChannel)
     {
         NetworkInfo netInfo = new NetworkInfo();
         netInfo.NetworkType = nl.Weave.DeviceManager.NetworkType.fromVal(networkType);
@@ -157,6 +164,7 @@ public class NetworkInfo
         netInfo.ThreadNetworkName = threadNetworkName;
         netInfo.ThreadExtendedPANId = threadExtendedPANId;
         netInfo.ThreadNetworkKey = threadNetworkKey;
+        netInfo.ThreadPSKc = threadPSKc;
         netInfo.ThreadPANId = threadPANId;
         netInfo.ThreadChannel = threadChannel;
         netInfo.WirelessSignalStrength = wirelessSignalStrength;
@@ -169,7 +177,7 @@ public class NetworkInfo
                                    short wirelessSignalStrength)
     {
         return Make(networkType, networkId, wifiSSID, wifiMode, wifiRole, wifiSecurityType, wifiKey, threadNetworkName,
-                    threadExtendedPANId, threadNetworkKey, wirelessSignalStrength, THREAD_PANID_NOTSPECIFIED,
+                    threadExtendedPANId, threadNetworkKey, null, wirelessSignalStrength, THREAD_PANID_NOTSPECIFIED,
                     THREAD_CHANNEL_NOTSPECIFIED);
     }
 }

--- a/src/device-manager/python/openweave/WeaveDeviceMgr.py
+++ b/src/device-manager/python/openweave/WeaveDeviceMgr.py
@@ -359,7 +359,7 @@ class _NetworkInfoStruct(Structure):
         ('ThreadNetworkName', c_char_p),    # The name of the Thread network.
         ('ThreadExtendedPANId', c_void_p),  # The Thread extended PAN id (8 bytes).
         ('ThreadNetworkKey', c_void_p),     # The Thread master network key.
-        ('ThreadPSKc', c_void_p),           # The Thread preshared key for commissioner
+        ('ThreadPSKc', c_void_p),           # The Thread pre-shared key for commissioner
         ('ThreadPANId', c_uint32),          # The 16-bit Thread PAN ID, or kThreadPANId_NotSpecified
         ('ThreadChannel', c_uint8),         # The current channel on which the Thread network operates, or kThreadChannel_NotSpecified
         ('WirelessSignalStrength', c_int16),# The signal strength of the network, or INT16_MIN if not available/applicable.

--- a/src/device-manager/python/openweave/WeaveDeviceMgr.py
+++ b/src/device-manager/python/openweave/WeaveDeviceMgr.py
@@ -148,7 +148,7 @@ def _LocateWeaveDLL():
 class NetworkInfo:
     def __init__(self, networkType=None, networkId=None, wifiSSID=None, wifiMode=None, wifiRole=None,
                  wifiSecurityType=None, wifiKey=None,
-                 threadNetworkName=None, threadExtendedPANId=None, threadNetworkKey=None,
+                 threadNetworkName=None, threadExtendedPANId=None, threadNetworkKey=None, threadPSKc=None,
                  wirelessSignalStrength=None, threadPANId=None, threadChannel=None):
         self.NetworkType = networkType
         self.NetworkId = networkId
@@ -160,6 +160,7 @@ class NetworkInfo:
         self.ThreadNetworkName = threadNetworkName
         self.ThreadExtendedPANId = threadExtendedPANId
         self.ThreadNetworkKey = threadNetworkKey
+        self.ThreadPSKc = threadPSKc
         self.ThreadPANId = threadPANId
         self.ThreadChannel = threadChannel
         self.WirelessSignalStrength = wirelessSignalStrength
@@ -184,6 +185,8 @@ class NetworkInfo:
             print "%sThread Extended PAN Id: %s" % (prefix, _ByteArrayToHex(self.ThreadExtendedPANId))
         if self.ThreadNetworkKey != None:
             print "%sThread Network Key: %s" % (prefix, _ByteArrayToHex(self.ThreadNetworkKey))
+        if self.ThreadPSKc != None:
+            print "%sThread Network PSKc: %s" % (prefix, _ByteArrayToHex(self.ThreadPSKc))
         if self.ThreadPANId != None:
             print "%sThread PAN Id: %04x" % (prefix, self.ThreadPANId)
         if self.ThreadChannel != None:
@@ -213,6 +216,8 @@ class NetworkInfo:
             self.ThreadExtendedPANId = val
         elif (name == 'threadnetworkkey' or name == 'thread-network-key' or name == 'thread-key'):
             self.ThreadNetworkKey = val
+        elif (name == 'threadpskc' or name == 'thread-pskc' or name == 'pskc'):
+            self.ThreadPSKc = val
         elif (name == 'threadpanid' or name == 'thread-pan-id' or name == 'pan-id'):
             self.ThreadPANId = val
         elif (name == 'threadchannel' or name == 'thread-channel'):
@@ -354,7 +359,7 @@ class _NetworkInfoStruct(Structure):
         ('ThreadNetworkName', c_char_p),    # The name of the Thread network.
         ('ThreadExtendedPANId', c_void_p),  # The Thread extended PAN id (8 bytes).
         ('ThreadNetworkKey', c_void_p),     # The Thread master network key.
-        ('ThreadNetworkKeyLen', c_uint32),  # The length in bytes of the Thread master network key.
+        ('ThreadPSKc', c_void_p),           # The Thread preshared key for commissioner
         ('ThreadPANId', c_uint32),          # The 16-bit Thread PAN ID, or kThreadPANId_NotSpecified
         ('ThreadChannel', c_uint8),         # The current channel on which the Thread network operates, or kThreadChannel_NotSpecified
         ('WirelessSignalStrength', c_int16),# The signal strength of the network, or INT16_MIN if not available/applicable.
@@ -372,7 +377,8 @@ class _NetworkInfoStruct(Structure):
             wifiKey = _VoidPtrToByteArray(self.WiFiKey, self.WiFiKeyLen),
             threadNetworkName = self.ThreadNetworkName,
             threadExtendedPANId = _VoidPtrToByteArray(self.ThreadExtendedPANId, 8),
-            threadNetworkKey = _VoidPtrToByteArray(self.ThreadNetworkKey, self.ThreadNetworkKeyLen),
+            threadNetworkKey = _VoidPtrToByteArray(self.ThreadNetworkKey, 16),
+            threadPSKc = _VoidPtrToByteArray(self.ThreadPSKc, 16),
             threadPANId = self.ThreadPANId if self.ThreadPANId != ThreadPANId_NotSpecified else None,
             threadChannel = self.ThreadChannel if self.ThreadChannel != ThreadChannel_NotSpecified else None,
             wirelessSignalStrength = self.WirelessSignalStrength if self.WirelessSignalStrength != -32768 else None
@@ -392,7 +398,7 @@ class _NetworkInfoStruct(Structure):
         networkInfoStruct.ThreadNetworkName = networkInfo.ThreadNetworkName
         networkInfoStruct.ThreadExtendedPANId = _ByteArrayToVoidPtr(networkInfo.ThreadExtendedPANId)
         networkInfoStruct.ThreadNetworkKey = _ByteArrayToVoidPtr(networkInfo.ThreadNetworkKey)
-        networkInfoStruct.ThreadNetworkKeyLen = len(networkInfo.ThreadNetworkKey) if (networkInfo.ThreadNetworkKey != None) else 0
+        networkInfoStruct.ThreadPSKc = _ByteArrayToVoidPtr(networkInfo.ThreadPSKc)
         networkInfoStruct.ThreadPANId = networkInfo.ThreadPANId if networkInfo.ThreadPANId != None else ThreadPANId_NotSpecified
         networkInfoStruct.ThreadChannel = networkInfo.ThreadChannel if networkInfo.ThreadChannel != None else ThreadChannel_NotSpecified
         networkInfoStruct.WirelessSignalStrength = networkInfo.WirelessSignalStrength if networkInfo.WirelessSignalStrength != None else -32768

--- a/src/device-manager/python/weave-device-mgr.py
+++ b/src/device-manager/python/weave-device-mgr.py
@@ -22,6 +22,7 @@
 #      This file implements the Python-based Weave Device Manager Shell.
 #
 
+from builtins import range
 import sys
 import os
 import platform
@@ -34,9 +35,13 @@ import random
 import textwrap
 import traceback
 import string
+import struct
 from copy import copy
 from cmd import Cmd
 from string import lower
+
+from Cryptodome.Hash import CMAC
+from Cryptodome.Cipher import AES
 
 # Extend sys.path with one or more directories, relative to the location of the
 # running script, in which the openweave package might be found .  This makes it
@@ -123,7 +128,6 @@ dummyAccessToken = (
 )
 
 
-
 def DecodeBase64Option(option, opt, value):
     try:
         return base64.standard_b64decode(value)
@@ -137,6 +141,39 @@ def DecodeHexIntOption(option, opt, value):
     except ValueError:
         raise OptionValueError(
             "option %s: invalid value: %r" % (opt, value))
+
+
+def aes_cmac(key, message):
+    cipher = CMAC.new(key, ciphermod=AES)
+    cipher.update(message)
+    return cipher.digest()
+
+
+#see RFC-4615
+def aes_cmac_prf_128(key, message):
+    if len(key) != 16:
+        key = aes_cmac(('00' * 16).decode('hex'), key)
+    return aes_cmac(key, message)
+
+
+def compute_pskc(passphrase, network_name, network_xpanid):
+    pbkdf_iter_count = 16384
+    pskc_len = 16
+    pskc = b''
+    salt = bytes('Thread') + network_xpanid + bytes(network_name)
+    block_counter = 0
+    prf_out = None
+    block_counter = 1
+    prf_in = salt + struct.pack('>I', block_counter)
+    prf_out = aes_cmac_prf_128(passphrase, prf_in)
+    key_block = prf_out
+    for i in range(1, pbkdf_iter_count):
+        prf_in = prf_out
+        prf_out = aes_cmac_prf_128(passphrase, prf_in)
+        key_block = ''.join([struct.pack('B', ord(v0) ^ ord(v1)) for v0, v1 in zip(key_block, prf_out)])
+
+    return key_block
+
 
 class ExtendedOption (Option):
     TYPES = Option.TYPES + ("base64", "hexint", )
@@ -1167,6 +1204,7 @@ class DeviceMgrCmd(Cmd):
               thread-pan-id or pan-id
               thread-channel or channel
               thread-pskc or pskc
+              passphrase
               ...
         """
 
@@ -1202,6 +1240,8 @@ class DeviceMgrCmd(Cmd):
                 print "Invalid value for Thread Network Key"
                 return
 
+        passphrase = None
+
         for addedVal in args[kvstart:]:
             pair = addedVal.split('=', 1)
             if (len(pair) < 2):
@@ -1231,17 +1271,33 @@ class DeviceMgrCmd(Cmd):
                     val = bytearray(binascii.unhexlify(val))
                 elif (name == 'threadpanid' or name == 'thread-pan-id' or name == 'pan-id'):
                     val = int(val, 16)
+                elif (name == 'passphrase'):
+                    passphrase = val
             except ValueError:
                 print "Invalid value specified for <" + name + "> field"
                 return
 
             try:
-                networkInfo.SetField(name, val)
+                if name != 'passphrase':
+                    networkInfo.SetField(name, val)
             except Exception, ex:
                 print str(ex)
                 return
 
-        if networkInfo.ThreadPANId  != None:
+        if passphrase != None:
+            if networkInfo.ThreadPSKc:
+                print('PSKc already specified')
+                return
+            if networkInfo.ThreadNetworkName == None:
+                print('Thread network name not specified, cannot compute pskc')
+                return
+            if networkInfo.ThreadExtendedPANId == None:
+                print('Thread xpanid not specified, cannot compute pskc')
+                return
+            networkInfo.ThreadPSKc = bytearray(compute_pskc(passphrase, networkInfo.ThreadNetworkName, 
+                                                            networkInfo.ThreadExtendedPANId))
+
+        if networkInfo.ThreadPANId != None:
             panId=networkInfo.ThreadPANId
             if panId < 1 or panId > 0xffff:
                 print "Thread PAN Id must be non-zero and 2 bytes in hex"
@@ -1289,7 +1345,7 @@ class DeviceMgrCmd(Cmd):
         optParser = OptionParser(usage=optparse.SUPPRESS_USAGE, option_class=ExtendedOption)
         optParser.add_option("-n", "--name", action="store", dest="threadNetworkName", type="string")
         optParser.add_option("-k", "--key", action="store", dest="threadNetworkKey", type="string")
-        optParser.add_option("-s", "--pskc", action="store", dest="threadPskc", type="string")
+        optParser.add_option("-s", "--pskc", action="store", dest="threadPSKc", type="string")
         optParser.add_option("-p", "--panid", action="store", dest="threadPANId", type="hexint")
         optParser.add_option("-c", "--channel", action="store", dest="threadChannel", type="int")
 
@@ -1309,8 +1365,8 @@ class DeviceMgrCmd(Cmd):
             networkInfo.ThreadNetworkName = options.threadNetworkName
         if (options.threadNetworkKey):
             networkInfo.ThreadNetworkKey = bytearray(binascii.unhexlify(options.threadNetworkKey))
-        if (options.threadPskc):
-            networkInfo.ThreadPskc = bytearray(binascii.unhexlify(options.threadPskc))
+        if (options.threadPSKc):
+            networkInfo.ThreadPSKc = bytearray(binascii.unhexlify(options.threadPSKc))
         if (options.threadPANId):
             networkInfo.ThreadPANId = options.threadPANId
             if (networkInfo.ThreadPANId > 0xffff):

--- a/src/device-manager/python/weave-device-mgr.py
+++ b/src/device-manager/python/weave-device-mgr.py
@@ -1166,6 +1166,7 @@ class DeviceMgrCmd(Cmd):
               thread-key or key
               thread-pan-id or pan-id
               thread-channel or channel
+              thread-pskc or pskc
               ...
         """
 
@@ -1216,11 +1217,15 @@ class DeviceMgrCmd(Cmd):
                 name = 'threadchannel'
             elif name == 'extended-pan-id':
                 name = 'threadextendedpanid'
+            elif name == 'pskc':
+                name = 'threadpskc'
 
             try:
                 if (name == 'threadchannel' or name == 'thread-channel'):
                     val = int(val, 10)
                 elif (name == 'threadnetworkkey' or name == 'thread-network-key' or name == 'thread-key'):
+                    val = bytearray(binascii.unhexlify(val))
+                elif (name == 'threadpskc' or name == 'thread-pskc'):
                     val = bytearray(binascii.unhexlify(val))
                 elif (name == 'threadextendedpanid' or name == 'thread-extended-pan-id'):
                     val = bytearray(binascii.unhexlify(val))
@@ -1284,6 +1289,7 @@ class DeviceMgrCmd(Cmd):
         optParser = OptionParser(usage=optparse.SUPPRESS_USAGE, option_class=ExtendedOption)
         optParser.add_option("-n", "--name", action="store", dest="threadNetworkName", type="string")
         optParser.add_option("-k", "--key", action="store", dest="threadNetworkKey", type="string")
+        optParser.add_option("-s", "--pskc", action="store", dest="threadPskc", type="string")
         optParser.add_option("-p", "--panid", action="store", dest="threadPANId", type="hexint")
         optParser.add_option("-c", "--channel", action="store", dest="threadChannel", type="int")
 
@@ -1303,6 +1309,8 @@ class DeviceMgrCmd(Cmd):
             networkInfo.ThreadNetworkName = options.threadNetworkName
         if (options.threadNetworkKey):
             networkInfo.ThreadNetworkKey = bytearray(binascii.unhexlify(options.threadNetworkKey))
+        if (options.threadPskc):
+            networkInfo.ThreadPskc = bytearray(binascii.unhexlify(options.threadPskc))
         if (options.threadPANId):
             networkInfo.ThreadPANId = options.threadPANId
             if (networkInfo.ThreadPANId > 0xffff):
@@ -1339,6 +1347,7 @@ class DeviceMgrCmd(Cmd):
               thread-network-name or thread-name
               thread-extended-pan-id or pan-id
               network-key or thread-key
+              pskc or thread-pskc
         """
 
         args = shlex.split(line)

--- a/src/lib/profiles/network-provisioning/NetworkInfo.h
+++ b/src/lib/profiles/network-provisioning/NetworkInfo.h
@@ -73,6 +73,13 @@ public:
     uint32_t WiFiKeyLen;            /**< The length in bytes of the WiFi key. */
 
     // ---- Thread-specific Fields ----
+    enum
+    {
+        kThreadNetworkKeyLength = 16,
+        kThreadExtendedPANIdLength = 8,
+        kThreadPSKcLength = 16,
+    };
+
     char *ThreadNetworkName;        /**< The name of the Thread network, or NULL if not specified. It is a
                                      * NUL-terminated, dynamically-allocated C-string, owned by the class.  Destroyed
                                      * on any condition that calls `Clear()` on the object. */
@@ -80,10 +87,14 @@ public:
                                      * owned by the class.  Destroyed on any condition that calls `Clear()` on
                                      * the object. */
     uint8_t *ThreadNetworkKey;      /**< The Thread master network key , or NULL if not specified. It is a dynamically
-                                     * allocated array of arbitrary octets, owned by the class, with length specified
-                                     * by `ThreadNetworkKeyLen`.  Destroyed on any condition that calls `Clear()` on
+                                     * allocated array of arbitrary octets, owned by the class
+                                     * Destroyed on any condition that calls `Clear()` on
                                      * the object. */
-    uint32_t ThreadNetworkKeyLen;   /**< The length in bytes of the Thread master network key. */
+    uint8_t *ThreadPSKc;            /**< Thread pre-shared key for commissioner, or NULL if not specified. It is a
+                                     * dynamically * allocated array of arbitrary octets, owned by the class
+                                     * Destroyed on any condition that calls `Clear()` on
+                                     * the object. */
+
     uint32_t ThreadPANId;           /**< The 16-bit Thread PAN ID, or kThreadPANId_NotSpecified */
     uint8_t ThreadChannel;          /**< The current channel (currently [11..26]) on which the Thread network operates,
                                      * or kThreadChannel_NotSpecified */

--- a/src/lib/profiles/network-provisioning/NetworkInfo.h
+++ b/src/lib/profiles/network-provisioning/NetworkInfo.h
@@ -91,7 +91,7 @@ public:
                                      * Destroyed on any condition that calls `Clear()` on
                                      * the object. */
     uint8_t *ThreadPSKc;            /**< Thread pre-shared key for commissioner, or NULL if not specified. It is a
-                                     * dynamically * allocated array of arbitrary octets, owned by the class
+                                     * dynamically allocated array of arbitrary octets, owned by the class
                                      * Destroyed on any condition that calls `Clear()` on
                                      * the object. */
 

--- a/src/lib/profiles/network-provisioning/NetworkProvisioning.h
+++ b/src/lib/profiles/network-provisioning/NetworkProvisioning.h
@@ -137,7 +137,8 @@ enum
     kTag_ThreadNetworkKey                       = 82,   /**< [ bytes string ] The Thread master network key. */
     kTag_ThreadMeshPrefix                       = 83,   /**< [ bytes string, exactly 8 bytes ] Thread mesh IPv6 /64 prefix (optional). */
     kTag_ThreadChannel                          = 84,   /**< [ uint, 8-bit max ] Thread channel number (optional). */
-    kTag_ThreadPANId                            = 85    /**< [ uint, 16-bit max ] Thread PAN ID (optional). */
+    kTag_ThreadPANId                            = 85,   /**< [ uint, 16-bit max ] Thread PAN ID (optional). */
+    kTag_ThreadPSKc                             = 86,   /**< [ uint, 16-bit max ] Thread PSKc (optional). */
 };
 
 /**

--- a/src/test-apps/MockNPServer.cpp
+++ b/src/test-apps/MockNPServer.cpp
@@ -128,7 +128,6 @@ void MockNetworkProvisioningServer::Preconfig()
     for (int i = 0; i < 8; i++)
         ProvisionedNetworks[1].ThreadExtendedPANId[i] = i + 1;
     ProvisionedNetworks[1].ThreadNetworkKey = (uint8_t *)strdup("thisisathreadkey"); // must be 16 bytes
-    ProvisionedNetworks[1].ThreadNetworkKeyLen = strlen((const char *)ProvisionedNetworks[1].ThreadNetworkKey);
 }
 
 WEAVE_ERROR MockNetworkProvisioningServer::HandleScanNetworks(uint8_t networkType)
@@ -247,14 +246,6 @@ WEAVE_ERROR MockNetworkProvisioningServer::ValidateNetworkConfig(NetworkInfo& ne
             if (netConfig.ThreadNetworkKey == NULL)
             {
                 printf("Invalid network configuration: Missing Thread network key\n");
-                err = SendStatusReport(kWeaveProfile_NetworkProvisioning, kStatusCode_InvalidNetworkConfiguration);
-                SuccessOrExit(err);
-                ExitNow(err = WEAVE_ERROR_INVALID_ARGUMENT);
-            }
-
-            if (netConfig.ThreadNetworkKeyLen == 0)
-            {
-                printf("Invalid network configuration: Zero-length Thread network key\n");
                 err = SendStatusReport(kWeaveProfile_NetworkProvisioning, kStatusCode_InvalidNetworkConfiguration);
                 SuccessOrExit(err);
                 ExitNow(err = WEAVE_ERROR_INVALID_ARGUMENT);
@@ -883,7 +874,7 @@ void MockNetworkProvisioningServer::PrintNetworkInfo(NetworkInfo& netInfo, const
     if (netInfo.ThreadNetworkKey != NULL)
     {
         printf("%sThread Network Key: ", prefix);
-        for (uint32_t i = 0; i < netInfo.ThreadNetworkKeyLen; i++)
+        for (uint32_t i = 0; i < NetworkInfo::kThreadNetworkKeyLength; i++)
             printf("%02X", netInfo.ThreadNetworkKey[i]);
         printf("\n");
     }

--- a/src/test-apps/TestNetworkInfo.cpp
+++ b/src/test-apps/TestNetworkInfo.cpp
@@ -69,7 +69,6 @@ void WeaveTestNetworkInfo(nlTestSuite *inSuite, void *inContext)
     buf = new uint8_t[16];
     memcpy(buf, key1, 16);
     elemArray[0].ThreadNetworkKey = buf;
-    elemArray[0].ThreadNetworkKeyLen = 16;
 
     // PAN-1 has new-style credentials (with PAN ID, channel)
     elemArray[1].NetworkType = kNetworkType_Thread;
@@ -87,7 +86,6 @@ void WeaveTestNetworkInfo(nlTestSuite *inSuite, void *inContext)
     buf = new uint8_t[16];
     memcpy(buf, key2, 16);
     elemArray[1].ThreadNetworkKey = buf;
-    elemArray[1].ThreadNetworkKeyLen = 16;
     elemArray[1].ThreadPANId = 0x1234;
     elemArray[1].ThreadChannel = 15;
 


### PR DESCRIPTION
This change allow users to set PSKc in network provisioning.
PSKc is used to authenticate thread commissioner. The unimplemented
part of PSKc configuration is completed.