### PR TITLE
Device Layer support for Thread device type and polling control

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ConnectivityManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ConnectivityManager.h
@@ -88,6 +88,17 @@ public:
         kWoBLEServiceMode_Disabled                  = 2,
     };
 
+    enum ThreadDeviceType
+    {
+        kThreadDeviceType_NotSupported              = 0,
+        kThreadDeviceType_Router                    = 1,
+        kThreadDeviceType_FullEndDevice             = 2,
+        kThreadDeviceType_MinimalEndDevice          = 3,
+        kThreadDeviceType_SleepyEndDevice           = 4,
+    };
+
+    struct ThreadPollingConfig;
+
     // WiFi station methods
     WiFiStationMode GetWiFiStationMode(void);
     WEAVE_ERROR SetWiFiStationMode(WiFiStationMode val);
@@ -98,6 +109,7 @@ public:
     WEAVE_ERROR SetWiFiStationReconnectIntervalMS(uint32_t val);
     bool IsWiFiStationProvisioned(void);
     void ClearWiFiStationProvision(void);
+    WEAVE_ERROR GetAndLogWifiStatsCounters(void);
 
     // WiFi AP methods
     WiFiAPMode GetWiFiAPMode(void);
@@ -110,13 +122,15 @@ public:
     uint32_t GetWiFiAPIdleTimeoutMS(void);
     void SetWiFiAPIdleTimeoutMS(uint32_t val);
 
-    WEAVE_ERROR GetAndLogWifiStatsCounters(void);
-
     // Thread Methods
     ThreadMode GetThreadMode(void);
     WEAVE_ERROR SetThreadMode(ThreadMode val);
     bool IsThreadEnabled(void);
     bool IsThreadApplicationControlled(void);
+    ThreadDeviceType GetThreadDeviceType(void);
+    WEAVE_ERROR SetThreadDeviceType(ThreadDeviceType deviceType);
+    void GetThreadPollingConfig(ThreadPollingConfig & pollingConfig);
+    WEAVE_ERROR SetThreadPollingConfig(const ThreadPollingConfig & pollingConfig);
     bool IsThreadAttached(void);
     bool IsThreadProvisioned(void);
     void ClearThreadProvision(void);
@@ -186,6 +200,23 @@ protected:
     ConnectivityManager(const ConnectivityManager &&) = delete;
     ConnectivityManager & operator=(const ConnectivityManager &) = delete;
 };
+
+/**
+ * Information describing the desired Thread polling behavior of a device.
+ */
+struct ConnectivityManager::ThreadPollingConfig
+{
+    uint32_t ActivePollingIntervalMS;                   /**< Interval at which the device polls its parent Thread router when
+                                                             when there are active Weave exchanges in progress. Only meaningful
+                                                             when the device is acting as a sleepy end node. */
+
+    uint32_t InactivePollingIntervalMS;                 /**< Interval at which the device polls its parent Thread router when
+                                                             when there are NO active Weave exchanges in progress. Only meaningful
+                                                             when the device is acting as a sleepy end node. */
+
+    void Clear() { memset(this, 0, sizeof(*this)); }
+};
+
 
 /**
  * Returns a reference to the public interface of the ConnectivityManager singleton object.
@@ -376,6 +407,26 @@ inline bool ConnectivityManager::IsThreadEnabled(void)
 inline bool ConnectivityManager::IsThreadApplicationControlled(void)
 {
     return static_cast<ImplClass*>(this)->_IsThreadApplicationControlled();
+}
+
+inline ConnectivityManager::ThreadDeviceType ConnectivityManager::GetThreadDeviceType(void)
+{
+    return static_cast<ImplClass*>(this)->_GetThreadDeviceType();
+}
+
+inline WEAVE_ERROR ConnectivityManager::SetThreadDeviceType(ThreadDeviceType deviceType)
+{
+    return static_cast<ImplClass*>(this)->_SetThreadDeviceType(deviceType);
+}
+
+inline void ConnectivityManager::GetThreadPollingConfig(ThreadPollingConfig & pollingConfig)
+{
+    return static_cast<ImplClass*>(this)->_GetThreadPollingConfig(pollingConfig);
+}
+
+inline WEAVE_ERROR ConnectivityManager::SetThreadPollingConfig(const ThreadPollingConfig & pollingConfig)
+{
+    return static_cast<ImplClass*>(this)->_SetThreadPollingConfig(pollingConfig);
 }
 
 inline bool ConnectivityManager::IsThreadAttached(void)

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -73,7 +73,12 @@ protected:
     WEAVE_ERROR _GetThreadProvision(DeviceNetworkInfo & netInfo, bool includeCredentials);
     WEAVE_ERROR _SetThreadProvision(const DeviceNetworkInfo & netInfo);
     void _ClearThreadProvision(void);
+    ConnectivityManager::ThreadDeviceType _GetThreadDeviceType(void);
+    WEAVE_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
+    void _GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig);
+    WEAVE_ERROR _SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig);
     bool _HaveMeshConnectivity(void);
+    void _OnMessageLayerActivityChanged(bool messageLayerIsActive);
     WEAVE_ERROR _GetAndLogThreadStatsCounters(void);
     WEAVE_ERROR _GetAndLogThreadTopologyMinimal(void);
     WEAVE_ERROR _GetAndLogThreadTopologyFull(void);
@@ -83,12 +88,14 @@ protected:
 
     WEAVE_ERROR DoInit(otInstance * otInst);
     bool IsThreadAttachedNoLock(void);
+    WEAVE_ERROR AdjustPollingInterval(void);
 
 private:
 
     // ===== Private members for use by this class only.
 
     otInstance * mOTInst;
+    ConnectivityManager::ThreadPollingConfig mPollingConfig;
 
     inline ImplClass * Impl() { return static_cast<ImplClass*>(this); }
 };

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ThreadStackManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ThreadStackManager.h
@@ -92,7 +92,12 @@ private:
     WEAVE_ERROR GetThreadProvision(Internal::DeviceNetworkInfo & netInfo, bool includeCredentials);
     WEAVE_ERROR SetThreadProvision(const Internal::DeviceNetworkInfo & netInfo);
     void ClearThreadProvision(void);
+    ConnectivityManager::ThreadDeviceType GetThreadDeviceType(void);
+    WEAVE_ERROR SetThreadDeviceType(ConnectivityManager::ThreadDeviceType threadRole);
+    void GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig);
+    WEAVE_ERROR SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig);
     bool HaveMeshConnectivity(void);
+    void OnMessageLayerActivityChanged(bool messageLayerIsActive);
 
 protected:
 
@@ -218,9 +223,34 @@ inline void ThreadStackManager::ClearThreadProvision(void)
     static_cast<ImplClass*>(this)->_ClearThreadProvision();
 }
 
+inline ConnectivityManager::ThreadDeviceType ThreadStackManager::GetThreadDeviceType(void)
+{
+    return static_cast<ImplClass*>(this)->_GetThreadDeviceType();
+}
+
+inline WEAVE_ERROR ThreadStackManager::SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType)
+{
+    return static_cast<ImplClass*>(this)->_SetThreadDeviceType(deviceType);
+}
+
+inline void ThreadStackManager::GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig)
+{
+    static_cast<ImplClass*>(this)->_GetThreadPollingConfig(pollingConfig);
+}
+
+inline WEAVE_ERROR ThreadStackManager::SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig)
+{
+    return static_cast<ImplClass*>(this)->_SetThreadPollingConfig(pollingConfig);
+}
+
 inline bool ThreadStackManager::HaveMeshConnectivity(void)
 {
     return static_cast<ImplClass*>(this)->_HaveMeshConnectivity();
+}
+
+inline void ThreadStackManager::OnMessageLayerActivityChanged(bool messageLayerIsActive)
+{
+    return static_cast<ImplClass*>(this)->_OnMessageLayerActivityChanged(messageLayerIsActive);
 }
 
 inline WEAVE_ERROR ThreadStackManager::GetAndLogThreadStatsCounters(void)

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_NoThread.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_NoThread.h
@@ -18,7 +18,7 @@
 
 /**
  *    @file
- *          Provides an generic implementation of ConnectivityManager features
+ *          Provides a generic implementation of ConnectivityManager features
  *          for use on platforms that do NOT support Thread.
  */
 
@@ -49,6 +49,10 @@ protected:
     WEAVE_ERROR _SetThreadMode(ConnectivityManager::ThreadMode val);
     bool _IsThreadEnabled(void);
     bool _IsThreadApplicationControlled(void);
+    ConnectivityManager::ThreadDeviceType _GetThreadDeviceType(void);
+    WEAVE_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
+    void _GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig);
+    WEAVE_ERROR _SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig);
     bool _IsThreadAttached(void);
     bool _IsThreadProvisioned(void);
     void _ClearThreadProvision(void);
@@ -96,6 +100,30 @@ inline bool GenericConnectivityManagerImpl_NoThread<ImplClass>::_IsThreadProvisi
 template<class ImplClass>
 inline void GenericConnectivityManagerImpl_NoThread<ImplClass>::_ClearThreadProvision(void)
 {
+}
+
+template<class ImplClass>
+inline ConnectivityManager::ThreadDeviceType GenericConnectivityManagerImpl_NoThread<ImplClass>::_GetThreadDeviceType(void)
+{
+    return ConnectivityManager::kThreadDeviceType_NotSupported;
+}
+
+template<class ImplClass>
+inline WEAVE_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType)
+{
+    return WEAVE_ERROR_UNSUPPORTED_WEAVE_FEATURE;
+}
+
+template<class ImplClass>
+inline void GenericConnectivityManagerImpl_NoThread<ImplClass>::_GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig)
+{
+    pollingConfig.Clear();
+}
+
+template<class ImplClass>
+inline WEAVE_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig)
+{
+    return WEAVE_ERROR_UNSUPPORTED_WEAVE_FEATURE;
 }
 
 template<class ImplClass>

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_Thread.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_Thread.h
@@ -60,6 +60,10 @@ protected:
     WEAVE_ERROR _SetThreadMode(ConnectivityManager::ThreadMode val);
     bool _IsThreadEnabled(void);
     bool _IsThreadApplicationControlled(void);
+    ConnectivityManager::ThreadDeviceType _GetThreadDeviceType(void);
+    WEAVE_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
+    void _GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig);
+    WEAVE_ERROR _SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig);
     bool _IsThreadAttached(void);
     bool _IsThreadProvisioned(void);
     void _ClearThreadProvision(void);
@@ -121,6 +125,30 @@ template<class ImplClass>
 inline void GenericConnectivityManagerImpl_Thread<ImplClass>::_ClearThreadProvision(void)
 {
     ThreadStackMgrImpl().ClearThreadProvision();
+}
+
+template<class ImplClass>
+inline ConnectivityManager::ThreadDeviceType GenericConnectivityManagerImpl_Thread<ImplClass>::_GetThreadDeviceType(void)
+{
+    return ThreadStackMgrImpl().GetThreadDeviceType();
+}
+
+template<class ImplClass>
+inline WEAVE_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType)
+{
+    return ThreadStackMgrImpl().SetThreadDeviceType(deviceType);
+}
+
+template<class ImplClass>
+inline void GenericConnectivityManagerImpl_Thread<ImplClass>::_GetThreadPollingConfig(ConnectivityManager::ThreadPollingConfig & pollingConfig)
+{
+    ThreadStackMgrImpl().GetThreadPollingConfig(pollingConfig);
+}
+
+template<class ImplClass>
+inline WEAVE_ERROR GenericConnectivityManagerImpl_Thread<ImplClass>::_SetThreadPollingConfig(const ConnectivityManager::ThreadPollingConfig & pollingConfig)
+{
+    return ThreadStackMgrImpl().SetThreadPollingConfig(pollingConfig);
 }
 
 template<class ImplClass>

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericPlatformManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericPlatformManagerImpl.h
@@ -67,8 +67,11 @@ protected:
     void DispatchEventToApplication(const WeaveDeviceEvent * event);
     static void HandleSessionEstablished(WeaveSecurityManager * sm, WeaveConnection * con,
             void * reqState, uint16_t sessionKeyId, uint64_t peerNodeId, uint8_t encType);
+    static void HandleMessageLayerActivityChanged(bool messageLayerIsActive);
 
 private:
+    bool mMsgLayerWasActive;
+
     ImplClass * Impl() { return static_cast<ImplClass*>(this); }
 };
 

--- a/src/lib/core/WeaveMessageLayer.cpp
+++ b/src/lib/core/WeaveMessageLayer.cpp
@@ -2308,6 +2308,15 @@ void WeaveMessageLayer::SetSignalMessageLayerActivityChanged(MessageLayerActivit
     OnMessageLayerActivityChange = messageLayerActivityChangeHandler;
 }
 
+bool WeaveMessageLayer::IsMessageLayerActive(void)
+{
+    return (ExchangeMgr->mContextsInUse != 0)
+#if WEAVE_CONFIG_USE_APP_GROUP_KEYS_FOR_MSG_ENC
+           || FabricState->IsMsgCounterSyncReqInProgress()
+#endif
+           ;
+}
+
 /**
  *  This method is called every time the message layer activity changes.
  *  Specifically, it will be called every time:
@@ -2320,16 +2329,9 @@ void WeaveMessageLayer::SetSignalMessageLayerActivityChanged(MessageLayerActivit
  */
 void WeaveMessageLayer::SignalMessageLayerActivityChanged(void)
 {
-    bool messageLayerIsActive;
-
     if (OnMessageLayerActivityChange)
     {
-        messageLayerIsActive = (ExchangeMgr->mContextsInUse != 0)
-#if WEAVE_CONFIG_USE_APP_GROUP_KEYS_FOR_MSG_ENC
-                               || FabricState->IsMsgCounterSyncReqInProgress()
-#endif
-                               ;
-
+        bool messageLayerIsActive = IsMessageLayerActive();
         OnMessageLayerActivityChange(messageLayerIsActive);
     }
 }

--- a/src/lib/core/WeaveMessageLayer.h
+++ b/src/lib/core/WeaveMessageLayer.h
@@ -474,6 +474,7 @@ class NL_DLL_EXPORT WeaveMessageLayer
     friend class WeaveConnection;
     friend class WeaveExchangeManager;
     friend class ExchangeContext;
+    friend class WeaveFabricState;
 public:
     /**
      *  @enum State
@@ -673,7 +674,7 @@ public:
      */
     typedef void (*MessageLayerActivityChangeHandlerFunct)(bool messageLayerIsActive);
     void SetSignalMessageLayerActivityChanged(MessageLayerActivityChangeHandlerFunct messageLayerActivityChangeHandler);
-    void SignalMessageLayerActivityChanged(void);
+    bool IsMessageLayerActive(void);
 
     static uint32_t GetMaxWeavePayloadSize(const PacketBuffer *msgBuf, bool isUDP, uint32_t udpMTU);
 
@@ -722,6 +723,8 @@ private:
     WEAVE_ERROR EnableUnsecuredListen(void);
     WEAVE_ERROR DisableUnsecuredListen(void);
     bool IsUnsecuredListenEnabled(void) const;
+
+    void SignalMessageLayerActivityChanged(void);
 
     WEAVE_ERROR SendMessage(const IPAddress &destAddr, uint16_t destPort, InterfaceId sendIntfId, PacketBuffer *payload, uint16_t udpSendFlags);
     WEAVE_ERROR SelectDestNodeIdAndAddress(uint64_t& destNodeId, IPAddress& destAddr);


### PR DESCRIPTION
-- Added APIs to the Device Layer’s ConfigurationManager object to control the Thread device type on Thread-enabled platforms.  Four standard Thread device types are supported: Router, Full End Device, Minimal End Device and Sleepy End Device.

-- Added APIs to the ConfigurationManager object to control polling behavior on devices that are operating as Thread sleepy end devices.  Two distinct polling intervals are configurable: one for when the device is engaged in active Weave message exchanges and one for when the device is idle.

-- Extended the following generic implementation classes to support the above APIs: GenericThreadStackManagerImpl_OpenThread<>, GenericConnectivityManagerImpl_Thread<> and GenericConnectivityManagerImpl_NoThread<>.

-- Added IsMessageLayerActive() method to the WeaveMessageLayer object.

-- Made WeaveMessageLayer::SignalMessageLayerActivityChanged() a private method which it makes accessible (via friendship) to other core Weave components.
