### PR TITLE
Name an empty union to build with clang 9

### DIFF
--- a/src/lib/profiles/data-management/Current/UpdateClient.h
+++ b/src/lib/profiles/data-management/Current/UpdateClient.h
@@ -122,7 +122,7 @@ struct UpdateClient::InEventParam
 struct UpdateClient::OutEventParam
 {
     bool DefaultHandlerCalled;
-    union
+    union _ // make clang 9 happy. remove name when adding members.
     {
     };
     void Clear() { memset(this, 0, sizeof(*this)); }


### PR DESCRIPTION
This empty anonymous union builds correctly with clang 8, but clang 9
would emit a warning 'declaration does not declare anything', and would
prevent weave from building because we have '-Werror' on.

To keep the interface consistent, the union is temporarily named rather
than removed. Please be sure to remove the name when adding members.