### PR TITLE
Support for publishing wdm events

### DIFF
--- a/src/adaptations/device-layer/EventLogging.cpp
+++ b/src/adaptations/device-layer/EventLogging.cpp
@@ -101,26 +101,3 @@ WEAVE_ERROR InitWeaveEventLogging(void)
 } // namespace DeviceLayer
 } // namespace Weave
 } // namespace nl
-
-
-namespace nl {
-namespace Weave {
-namespace Profiles {
-namespace DataManagement_Current {
-namespace Platform {
-
-void CriticalSectionEnter(void)
-{
-    return PlatformMgr().LockWeaveStack();
-}
-
-void CriticalSectionExit(void)
-{
-    return PlatformMgr().UnlockWeaveStack();
-}
-
-} // namespace Platform
-} // namespace DataManagement_Current
-} // namespace Profiles
-} // namespace Weave
-} // namespace nl

--- a/src/lib/core/WeaveEventLoggingConfig.h
+++ b/src/lib/core/WeaveEventLoggingConfig.h
@@ -61,7 +61,7 @@
 #endif /* WEAVE_CONFIG_EVENT_LOGGING_BDX_OFFLOAD */
 
 /**
- *  @def WEAVE_CONFIG_EVENT_LOGGING_BDX_OFFLOAD
+ *  @def WEAVE_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  *  @brief
  *    Control whether the logs are offloaded using the WDM profile


### PR DESCRIPTION
-- Remove definition of CriticalSectorEnter and Exit methods
   from EventLogging.cpp so that application can define them
   as required.
   This fixes an issue where the notification engine while gathering wdm
   events was waiting indefinitely for the weave stack lock to be
   acquired since it was already locked when the event loop on the weave
   task ran to handle the notification run asynchronous request.