### PR TITLE
Minor code cleanup in GenericSoftwareUpdateManagerImpl

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/SoftwareUpdateManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/SoftwareUpdateManager.h
@@ -191,9 +191,9 @@ public:
          *  Allows application to manage the rest of the phases of software update such as
          *  download, image integrity validation and install. Software update manager
          *  state machine will move to the ApplicationManaged state. Scheduled software update checks (if enabled)
-         *  will be suspended till application calls Abort or InstallationComplete API.
+         *  will be suspended till application calls Abort or ImageInstallComplete API.
          */
-        kAction_Defer_To_Application,
+        kAction_ApplicationManaged,
     };
 
     /**

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericSoftwareUpdateManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericSoftwareUpdateManagerImpl.h
@@ -132,7 +132,6 @@ private:
     bool mHaveServiceConnectivity;
     bool mScheduledCheckEnabled;
     bool mShouldRetry;
-    bool mWasAborted;
 
     uint64_t mNumBytesToDownload;
     uint64_t mStartOffset;


### PR DESCRIPTION
-- No need to track if software update was aborted in a separate
   variable. Instead test if the internal state is the expected state
   right after we return from an event callback.
-- Rename kAction_Defer_To_Application to kAction_ApplicationManaged in
   the SoftwareUpdateManager public interface