### PR TITLE
fix thread_wifi_on_tap_ap_service.json to be consistent as its shell script

### DIFF
--- a/src/test-apps/happy/topologies/standalone/thread_wifi_on_tap_ap_service.json
+++ b/src/test-apps/happy/topologies/standalone/thread_wifi_on_tap_ap_service.json
@@ -150,7 +150,7 @@
             "node": "cloud", 
             "node_end": "happy032", 
             "number": 1, 
-            "tap": false, 
+            "tap": true, 
             "type": "wan"
         }, 
         "wifi0": {
@@ -175,13 +175,13 @@
         }
     }, 
     "netns": {
+        "BorderRouter": "009", 
         "HomeThread": "000", 
         "HomeWiFi": "001", 
         "Internet": "002", 
+        "ThreadNode": "003", 
         "cloud": "031", 
         "onhub": "020", 
-        "BorderRouter": "009", 
-        "ThreadNode": "003", 
         "thread0": "008", 
         "thread0bridge": "007", 
         "thread0net": "005", 
@@ -225,13 +225,6 @@
                     "mask": 64
                 }
             }, 
-            "route": {
-                "default_v4": {
-                    "prefix": null, 
-                    "to": "default", 
-                    "via": "BorderRouter"
-                }
-            }, 
             "state": "UP", 
             "type": "thread"
         }, 
@@ -247,13 +240,6 @@
                 }, 
                 "2001:0db8:0222:0002": {
                     "mask": 64
-                }
-            }, 
-            "route": {
-                "default_v4": {
-                    "prefix": "10.0.1.0", 
-                    "to": "default", 
-                    "via": "onhub"
                 }
             }, 
             "state": "UP", 
@@ -275,14 +261,53 @@
         }
     }, 
     "node": {
+        "BorderRouter": {
+            "interface": {
+                "wlan0": {
+                    "ip": {
+                        "fd00:0000:fab1:0001:2af4:1ac8:b2ec:11e9": {
+                            "mask": 64
+                        }
+                    }, 
+                    "link": "wifi0", 
+                    "type": "wifi"
+                }, 
+                "wpan0": {
+                    "ip": {
+                        "fd00:0000:fab1:0006:2af4:1ac8:b2ec:11e9": {
+                            "mask": 64
+                        }
+                    }, 
+                    "link": "thread1", 
+                    "type": "thread"
+                }
+            }, 
+            "process": {}, 
+            "route": {}, 
+            "tmux": {}, 
+            "type": null
+        }, 
+        "ThreadNode": {
+            "interface": {
+                "wpan0": {
+                    "ip": {
+                        "fd00:0000:fab1:0006:2af4:1ac9:b2ec:11e9": {
+                            "mask": 64
+                        }
+                    }, 
+                    "link": "thread0", 
+                    "type": "thread"
+                }
+            }, 
+            "process": {}, 
+            "route": {}, 
+            "tmux": {}, 
+            "type": null
+        }, 
         "cloud": {
             "interface": {
                 "eth0": {
-                    "ip": {
-                        "192.168.100.3": {
-                            "mask": 24
-                        }
-                    }, 
+                    "ip": {}, 
                     "link": "wan1", 
                     "type": "wan"
                 }
@@ -305,10 +330,10 @@
                 }, 
                 "wlan0": {
                     "ip": {
-                        "10.0.1.3": {
+                        "10.0.1.2": {
                             "mask": 24
                         }, 
-                        "2001:0db8:0222:0002:4632:c5ff:fe4a:b49f": {
+                        "2001:0db8:0222:0002:86a3:8aff:fea5:1800": {
                             "mask": 64
                         }
                     }, 
@@ -320,73 +345,6 @@
             "route": {}, 
             "tmux": {}, 
             "type": "ap"
-        }, 
-        "BorderRouter": {
-            "interface": {
-                "wlan0": {
-                    "ip": {
-                        "10.0.1.2": {
-                            "mask": 24
-                        }, 
-                        "2001:0db8:0222:0002:72dd:45ff:fee5:1a4d": {
-                            "mask": 64
-                        }, 
-                        "fd00:0000:fab1:0001:1ab4:3000:0000:0005": {
-                            "mask": 64
-                        }
-                    }, 
-                    "link": "wifi0", 
-                    "type": "wifi"
-                }, 
-                "wpan0": {
-                    "ip": {
-                        "2001:0db8:0111:0001:aebc:bcff:fe9e:a95b": {
-                            "mask": 64
-                        }, 
-                        "fd00:0000:fab1:0006:1ab4:3000:0000:0005": {
-                            "mask": 64
-                        }
-                    }, 
-                    "link": "thread1", 
-                    "type": "thread"
-                }
-            }, 
-            "process": {}, 
-            "route": {
-                "default_v4": {
-                    "prefix": "10.0.1", 
-                    "to": "default", 
-                    "via": "onhub"
-                }
-            }, 
-            "tmux": {}, 
-            "type": null
-        }, 
-        "ThreadNode": {
-            "interface": {
-                "wpan0": {
-                    "ip": {
-                        "2001:0db8:0111:0001:f207:e2ff:fe95:334f": {
-                            "mask": 64
-                        }, 
-                        "fd00:0000:fab1:0006:1ab4:3000:0000:000a": {
-                            "mask": 64
-                        }
-                    }, 
-                    "link": "thread0", 
-                    "type": "thread"
-                }
-            }, 
-            "process": {}, 
-            "route": {
-                "default_v4": {
-                    "prefix": null, 
-                    "to": "default", 
-                    "via": "BorderRouter"
-                }
-            }, 
-            "tmux": {}, 
-            "type": null
         }
     }, 
     "weave": {
@@ -397,20 +355,16 @@
         "network": {}, 
         "node": {
             "BorderRouter": {
-                "eui64": "18-B4-30-00-00-00-00-05", 
-                "iid": "1ab4:3000:0000:0005", 
-                "pairing_code": "AAA123", 
-                "private_key": "${WEAVE_HOME}/certs/development/device/test-dev-18B4300000000005-key.pem", 
-                "weave_certificate": "${WEAVE_HOME}/certs/development/device/test-dev-18B4300000000005-cert.pem", 
-                "weave_node_id": "18B4300000000005"
+                "eui64": "28-f4-1a-c8-b2-ec-11-e9", 
+                "iid": "2af4:1ac8:b2ec:11e9", 
+                "pairing_code": "UF4IRJ", 
+                "weave_node_id": "28f41ac8b2ec11e9"
             }, 
             "ThreadNode": {
-                "eui64": "18-B4-30-00-00-00-00-0A", 
-                "iid": "1ab4:3000:0000:000a", 
-                "pairing_code": "AAA123", 
-                "private_key": "${WEAVE_HOME}/certs/development/device/test-dev-18B430000000000A-key.pem", 
-                "weave_certificate": "${WEAVE_HOME}/certs/development/device/test-dev-18B430000000000A-cert.pem", 
-                "weave_node_id": "18B430000000000A"
+                "eui64": "28-f4-1a-c9-b2-ec-11-e9", 
+                "iid": "2af4:1ac9:b2ec:11e9", 
+                "pairing_code": "8JFQ55", 
+                "weave_node_id": "28f41ac9b2ec11e9"
             }
         }
     }


### PR DESCRIPTION
In PR https://github.com/openweave/openweave-core/pull/295, we fixed the [topology shell script ](https://github.com/openweave/openweave-core/pull/295/files?file-filters%5B%5D=.sh#diff-bc7d815637b60f39bb32ae8ad76c6579) to work with lwip tests, I did not update topology json file because not sure if it will break other tests.

As separate follow up PR, I copied .happy_state.json which generated by src/test-apps/happy/topologies/standalone/thread_wifi_on_tap_ap_service.sh to replace thread_wifi_on_tap_ap_service.json, so that json topology file content is consistent with it's shell script.

From the commit comparison, there is weave cert config not covered by shell script, Will see if it can pass the CI tests first.