### PR TITLE
Fix for ESP32 demo app not responding to IPv6 neighbor discovery

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/LwIP/WarmSupport.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/LwIP/WarmSupport.h
@@ -33,6 +33,7 @@ namespace DeviceLayer {
 namespace Internal {
 
 extern WEAVE_ERROR GetLwIPNetifForWarmInterfaceType(::nl::Weave::Warm::InterfaceType inInterfaceType, struct netif *& netif);
+extern bool LwIPNetifSupportsMLD(struct netif * netif);
 extern const char * WarmInterfaceTypeToStr(::nl::Weave::Warm::InterfaceType inInterfaceType);
 
 } // namespace Internal


### PR DESCRIPTION
[ This change addresses the following issue: [issue#10](https://github.com/openweave/openweave-esp32-demo/issues/10) ]

-- Added code to the LwIP-specific WARM code within the Device Layer such that a device joins/leaves the appropriate IPv6 solicited-node multicast group whenever Weave IPv6 addresses are added/removed from the device's network interfaces.  Although LwIP has logic to do this automatically, when the LWIP_IPV6_MLD LwIP feature is enabled, this behavior is tightly bound to duplicate address detection, which is not invoked by the WARM layer.