### PR TITLE
minor fix to support weave address on service node

### DIFF
--- a/src/test-apps/happy/lib/WeaveNodeConfigure.py
+++ b/src/test-apps/happy/lib/WeaveNodeConfigure.py
@@ -331,8 +331,14 @@ class WeaveNodeConfigure():
             self.logger.error("[localhost] WeaveNodeConfigure: %s" % emsg)
             return
 
-        if self.weave_state.getNodeType(node) in ['ap', 'service']:
-            emsg = "ignoring initialization for nodes types 'ap' and 'service'"
+        # configure weave state including weave address for non-AP nodes,
+        # because current infra only support AP joined as a non-weave device, 
+        # all other nodes can be joined as weave devices.
+        # ToDo: Actually, AP should be able to joined as weave device or non-weave device, 
+        # Some infra work need to be sorted out to support that.
+        # Tracked issue link: https://github.com/openweave/openweave-core/issues/360
+        if self.weave_state.getNodeType(node) in ['ap']:
+            emsg = "ignoring initialization for nodes types 'ap'"
             self.logger.debug("[localhost] WeaveNodeConfigure: %s" % emsg)
             return
 

--- a/src/test-apps/happy/lib/WeaveState.py
+++ b/src/test-apps/happy/lib/WeaveState.py
@@ -238,17 +238,32 @@ class WeaveState(State):
 
         return global_prefix
 
-    def typeToWeaveSubnet(self, type):
-        if type == "wifi":
+    def typeToWeaveSubnet(self, interface_type):
+        """This function attempts to match node interface type to a matching weave subnet.
+
+        Args:
+           interface_type (str): A string containing a node interface type, example: "wifi" or "wan".
+
+        Returns:
+           integer. The return code:
+
+              1  -- weave subnet is 1 which matches a wifi interface.
+              5  -- weave subnet is 5 which matches a wan interface.
+              4  -- weave subnet is 4 which matches a mobile interface.
+              6  -- weave subnet is 6 which matches a thread interface.
+              0  -- weave subnet is 0 which matches all other interfaces.
+        """
+
+        if interface_type == "wifi":
             return 1
 
-        if type == "service":
+        if interface_type == "wan":
             return 5
 
-        if type == "mobile":
+        if interface_type == "mobile":
             return 4
 
-        if type == "thread":
+        if interface_type == "thread":
             return 6
 
         return 0

--- a/src/test-apps/happy/topologies/standalone/thread_wifi_on_tap_ap_service.sh
+++ b/src/test-apps/happy/topologies/standalone/thread_wifi_on_tap_ap_service.sh
@@ -55,7 +55,9 @@ happy-network-route --prefix 10.0.1.0 HomeWiFi onhub
 happy-network-route --prefix 192.168.100.0 Internet onhub
 
 weave-fabric-add fab1
-weave-node-configure
+weave-node-configure -w 18b4300000000001 BorderRouter
+weave-node-configure -w 18b430000000000a ThreadNode
+weave-node-configure -w 18B4300200000011 cloud
 weave-network-gateway HomeThread BorderRouter
 
 # happy-state -s thread_wifi_on_tap_ap_service.json


### PR DESCRIPTION
In lwip service tunnel test 02, we do weave-ping test between thread node and service(cloud) node, which will require both thread node and service node to have weave address.

This PR is to fix 2 minor issues that:
1. weave test infra does not add weave address if it is a service node.
2. node interface type for service node should be "wan", without correct interface type, service node is not getting correct weave address subnet.

