### PR TITLE
Clang 9 warning fix.

### DIFF
--- a/src/lib/profiles/data-management/Current/UpdateClient.h
+++ b/src/lib/profiles/data-management/Current/UpdateClient.h
@@ -122,9 +122,16 @@ struct UpdateClient::InEventParam
 struct UpdateClient::OutEventParam
 {
     bool DefaultHandlerCalled;
-    union
-    {
-    };
+
+    // additional parameters required by application shall be added via structs
+    // added to an anonymous union, following the pattern for InEventParam
+    // above.  As some compilers emit warnings for anonymous empty unions, we
+    // leave the union declaration commented out below.
+
+    // union
+    // {
+    //    // Parameters for specific purposes should be embedded here as structs
+    // };
     void Clear() { memset(this, 0, sizeof(*this)); }
 };
 }; // namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNamespaceDesignation_Current)


### PR DESCRIPTION
Clang 9 emits a warning on an anonymous empty union.  In UpdateClient,
the OutEventParams declared no specific parameters which resulted in
the above construction.  Replace the problematic construct with a note
to the future developer on how to extend the parameters.