### PR TITLE
Ensure WeaveTunnelConnectionManager is in correct state before trying to reconnect when timer fires.

### DIFF
--- a/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.cpp
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.cpp
@@ -422,11 +422,13 @@ void WeaveTunnelConnectionMgr::ServiceConnectTimeout(System::Layer* aSystemLayer
         ExitNow();
     }
 
-    /* Check if the WeaveConnectionManager is in the correct state to effect a
+    /* Ensure that the WeaveConnectionManager is in the correct state to effect a
      * reconnect.
      */
-    VerifyOrExit(tConnMgr->mConnectionState == kState_NotConnected,
-                 /* NO_OP */);
+    if (tConnMgr->mConnectionState != kState_NotConnected)
+    {
+        tConnMgr->StopServiceTunnelConn(WEAVE_ERROR_TUNNEL_FORCE_ABORT);
+    }
 
     // Reconnect to Service.
 

--- a/src/test-apps/TestWeaveTunnelBR.cpp
+++ b/src/test-apps/TestWeaveTunnelBR.cpp
@@ -1107,7 +1107,7 @@ static void TestTunnelNoStatusReportResetReconnectBackoff(nlTestSuite *inSuite, 
     gTestSucceeded = false;
     /* Set the test timeout to be a little longer than the Tunnel Control ExchangeContext
      * timeout */
-    gMaxTestDurationMillisecs = (WEAVE_CONFIG_TUNNELING_CTRL_RESPONSE_TIMEOUT_SECS + 1 ) * System::kTimerFactor_milli_per_unit;
+    gMaxTestDurationMillisecs = (WEAVE_CONFIG_TUNNELING_CTRL_RESPONSE_TIMEOUT_SECS + 5 ) * System::kTimerFactor_milli_per_unit;
     gCurrTestNum = kTestNum_TestTunnelNoStatusReportResetReconnectBackoff;
     gTestStartTime = Now();
 


### PR DESCRIPTION
When the reconnect timer fires, ensure that the WeaveConnectionManager is in the correct 'NotConnected' state before attempting the reconnect.

Previously, there was only a check and exit if the state was wrong.