### PR TITLE
Fix format specifier for vendor Id

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.ipp
@@ -881,7 +881,7 @@ void GenericConfigurationManagerImpl<ImplClass>::LogDeviceConfig()
         {
             vendorId = 0;
         }
-        WeaveLogProgress(DeviceLayer, "  Vendor Id: %" PRId16 " (0x%" PRIX16 ")%s",
+        WeaveLogProgress(DeviceLayer, "  Vendor Id: %" PRIu16 " (0x%" PRIX16 ")%s",
                 vendorId, vendorId, (vendorId == kWeaveVendor_NestLabs) ? " (Nest)" : "");
     }
 


### PR DESCRIPTION
-- Instead of signed decimal integer format, use unsigned decimal
   integer format specifier when printing the Vendor Id