### PR TITLE
Complete Material Icon support for docs

### DIFF
--- a/doc/STYLE_GUIDE.md
+++ b/doc/STYLE_GUIDE.md
@@ -190,15 +190,15 @@ process, in order to visually tie concepts together across the documentation sit
 Example: https://openweave.io/guides/tools#weave-heartbeat
 
 To use these icons in your content, so that they render on the openweave.io documentation site,
-surround one of the supported keywords with an underscore+asterisk combo.
+put one of the supported keywords inside an HTML comment.
 
 For example:
 
-<div>_*Echo*_</div>
-<div>_*heartbeat*_</div>
+`<!-- echo -->`
 
-The keyword can be upper or lowercase. Use of this format with unsupported keywords merely
-renders the text in italics.
+`<!-- heartbeat -->`
+
+The keyword must be lowercase.
 
 See the **OpenWeave Tools** page for an example of this:
 
@@ -207,5 +207,49 @@ See the **OpenWeave Tools** page for an example of this:
 
 Supported keywords:
 
-*	Echo
-*	Heartbeat
+Keyword | Weave Element
+----|----
+alarm | Alarm
+bdx | Bulk Data Exchange
+certificate | Certificate
+common | Common
+controller | Controller
+custom | Custom Command
+description | Device Description
+devicecontrol | Device Control
+directory | Service Directory
+echo | Echo
+event | Events
+fabric | Fabric
+fabric | Fabric Provisioning
+general | General
+heartbeat | Heartbeat
+interface | Interfaces
+locale | Locale
+messaging | Messaging
+nestservice | Nest Service
+network | Network Provisioning
+notify | Notify
+pairing | Pairing
+profile | Profiles
+property | Properties
+publisher | Publisher
+request | Requests
+resource | Resources
+schema | Schema
+security | Security
+service | Service Provisioning
+status | Status Report
+subscribe | Subscribe
+swu | Software Update
+timeservice | Time Service
+timezone | Time Zone
+tlv | TLV
+trait | Traits
+tunnel | Tunnel
+ula | ULA (Unique Local Address)
+update | Update
+view | View
+wdl | WDL (Weave Schema Description Language)
+wdm | Data Management
+wrm | WRM

--- a/doc/guides/tools/index.md
+++ b/doc/guides/tools/index.md
@@ -15,9 +15,9 @@ Tool | Description | [Standalone build](https://openweave.io/guides/build#standa
 `weave` | Generate and manage Weave certificates | `/src/tools/weave`
 `weave-device-descriptor` | Encode and decode Weave device descriptor strings for pairing QR codes | `/src/test-apps`
 [`weave-device-mgr`](/guides/tools/device-manager) | Manage the device pairing process | `/src/device-manager/python`
-`weave-heartbeat` | Send and receive <a href="https://openweave.io/guides/weave-primer/profiles#heartbeat">_*Heartbeat*_</a> profile messages | `/src/test-apps`
+`weave-heartbeat` | Send and receive <a href="https://openweave.io/guides/weave-primer/profiles#heartbeat">Heartbeat <!-- heartbeat --></a> profile messages | `/src/test-apps`
 `weave-key-export` | Send key export requests | `/src/test-apps`
-`weave-ping`| Send and receive <a href="https://openweave.io/guides/weave-primer/profiles#echo">_*Echo*_</a> profile messages | `/src/test-apps`
+`weave-ping`| Send and receive <a href="https://openweave.io/guides/weave-primer/profiles#echo">Echo <!-- echo --></a> profile messages | `/src/test-apps`
 
 To build the target:
 
@@ -167,7 +167,7 @@ Primary WiFi MAC: 5C:F3:70:80:0E:77
 ## weave-heartbeat
 
 Use `weave-heartbeat` to send and receive
-<a href="https://openweave.io/guides/weave-primer/profiles#heartbeat">_*Heartbeat*_</a> profile messages between
+<a href="https://openweave.io/guides/weave-primer/profiles#heartbeat">Heartbeat <!-- heartbeat --></a> profile messages between
 two Weave nodes. Heartbeat provides a means to indicate liveness of one node to
 the other nodes in the network, or to check if a node remains connected to the
 fabric.
@@ -260,7 +260,7 @@ $ ./mock-device -a fd00:0:1:1::1
 ## weave-ping
 
 Use `weave-ping` to send and receive
-<a href="https://openweave.io/guides/weave-primer/profiles#echo">_*Echo*_</a> profile messages
+<a href="https://openweave.io/guides/weave-primer/profiles#echo">Echo <!-- echo --></a> profile messages
 between two Weave nodes. An Echo payload consists of arbitrary data supplied by
 the requesting node and is expected to be echoed back verbatim in the response.
 Echo provides a means to test network connectivity and latency.


### PR DESCRIPTION
- Changes method of designating Material Icons in docs to use HTML comments
- Adds complete Material Icon support for docs mirrored on openweave.io, in preparation for migrating the Weave Primer to GitHub
- Updates current usage of Material Icons in the Tools index to the new format