### PR TITLE
Yet more fixes to simnet

### DIFF
--- a/src/tools/simnet/lib/simnet/layouts/two-devices.py
+++ b/src/tools/simnet/lib/simnet/layouts/two-devices.py
@@ -39,10 +39,6 @@ ThreadNetwork(
     meshLocalPrefix = 'fd42:4242:4242::/64'
 )
 
-LegacyThreadNetwork(
-    name = 'legacy'
-)
-
 #===============================================================================
 # Devices
 #===============================================================================
@@ -56,21 +52,21 @@ Gateway(
     isIP4DefaultGateway = True
 )
 
-# Weave device with WiFi, Thread and Legacy Thread networks
+# Weave device with WiFi and Thread networks
 WeaveDevice(
     name = 'dev1',
     weaveNodeId = 1,
     weaveFabricId = 1,
     wifiNetwork = 'wifi',
     threadNetwork = 'thread',
-    legacyNetwork = 'legacy',
+    useLwIP = False
 )
 
-# Weave device with Thread and Legacy Thread networks only
+# Weave device with Thread network only
 WeaveDevice(
     name = 'dev2',
     weaveFabricId = 1,
     weaveNodeId = 2,
     threadNetwork = 'thread',
-    legacyNetwork = 'legacy'
+    useLwIP = False
 )


### PR DESCRIPTION
-- Fixed support for tap interfaces within virtual nodes.  Unlike a veth-pair, the two ends of a linux tap device cannot be in different namespaces.  To make it possible for a tap interface in a node namespace to be connected to bridge in a “network” namespace, simnet now constructs a “trunk line” veth-pair that spans the two namespaces, and a “tap bridge” in the node namespace.  The tap interface is connected to the tap bridge, along with one of the trunk interfaces.  The other trunk interface is connected to the bridge in the “network” namespace.  This allows packets to flow between the process holding the tap fd and the virtual network.

-- Eliminated the use of special short interface names when creating tap interfaces.  These interfaces now use the names “wifi”, “thread”, etc., just like normal interfaces.

-- Disabled automatic assignment of IPv6 link-local addresses on interfaces that don’t need them (e.g. the bridge interfaces in “network” namespaces, and the ends of a veth-pair that are plugged into bridges).

-- Simplified the two-device simnet layout.