### PR TITLE
Update openweave python package versioning

### DIFF
--- a/src/device-manager/python/build-openweave-wheel.py
+++ b/src/device-manager/python/build-openweave-wheel.py
@@ -117,7 +117,7 @@ try:
     if 'TRAVIS_BUILD_NUMBER' in os.environ:
         owPackageVer = os.environ['TRAVIS_BUILD_NUMBER']
     else:
-        owPackageVer = '0.0'
+        owPackageVer = os.environ.get('OPENWEAVE_PYTHON_VERSION', '0.0')
     
     # Generate a description string with information on how/when the package
     # was built. 


### PR DESCRIPTION
Allow the openweave python package version to be set from OPENWEAVE_PYTHON_VERSION when the package is built outside of Travis CI