### PR TITLE
[toble] Fix ble pairing conflicts with thread

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -1005,13 +1005,13 @@ WEAVE_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstan
     otIp6SetSlaacEnabled(otInst, false);
 #endif
 
-    // Enable the Thread IPv6 interface.
-    otErr = otIp6SetEnabled(otInst, true);
-    VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
-
     // If the Thread stack has been provisioned, but is not currently enabled, enable it now.
     if (otThreadGetDeviceRole(mOTInst) == OT_DEVICE_ROLE_DISABLED && otDatasetIsCommissioned(otInst))
     {
+        // Enable the Thread IPv6 interface.
+        otErr = otIp6SetEnabled(otInst, true);
+        VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
+
         otErr = otThreadSetEnabled(otInst, true);
         VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
     }

--- a/src/adaptations/device-layer/nRF5/BLEManagerImpl.cpp
+++ b/src/adaptations/device-layer/nRF5/BLEManagerImpl.cpp
@@ -614,7 +614,7 @@ void BLEManagerImpl::HandleSoftDeviceBLEEvent(const WeaveDeviceEvent * event)
         WeaveLogProgress(DeviceLayer, "BLE GATT Server timeout (con %" PRIu16 ")", bleEvent->evt.gatts_evt.conn_handle);
         err = sd_ble_gap_disconnect(bleEvent->evt.gatts_evt.conn_handle,
                                     BLE_HCI_REMOTE_USER_TERMINATED_CONNECTION);
-        APP_ERROR_CHECK(err);
+        SuccessOrExit(err);
         break;
 
     case BLE_GATTS_EVT_WRITE:


### PR DESCRIPTION
Don't start Thread radio until Weave pairing has set the Thread credentials.

Also fixes an assert in WoBLE peripheral timeout when connection has already been closed.