### PR TITLE
Fix for bug in Python TLVWriter

### DIFF
--- a/src/tools/factory-prov-tool/WeaveTLV.py
+++ b/src/tools/factory-prov-tool/WeaveTLV.py
@@ -69,8 +69,8 @@ UINT64_MAX                              = 18446744073709551615
 
 class TLVWriter(object):
     
-    def __init__(self, encoding=bytearray(), implicitProfile=None):
-        self._encoding = encoding
+    def __init__(self, encoding=None, implicitProfile=None):
+        self._encoding = encoding if encoding is not None else bytearray()
         self._implicitProfile = implicitProfile
         self._containerStack = []
 


### PR DESCRIPTION
-- Fixed a bug in the Python TLVWriter implementation caused all instances of the class to use the same output buffer.