### PR TITLE
Fix compile failure in lock example

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -38,6 +38,7 @@
 #include <InetLayer/IPPrefix.h>
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
+#include <lwip/tcpip.h>
 #include <lwip/sys.h>
 #include <lwip/netif.h>
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP


### PR DESCRIPTION
-- Added missing LwIP header to InetInterface.cpp.  Apparently this header gets included via some other path in the standalone LwIP build.