### PR TITLE
NoMorePendingEventCbHelper needs to be called when flush empty updates

### DIFF
--- a/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
@@ -3249,6 +3249,11 @@ WEAVE_ERROR SubscriptionClient::FlushUpdate(bool aForce)
 exit:
     UnlockUpdateMutex();
 
+    if (mPendingSetState == kPendingSetEmpty)
+    {
+        NoMorePendingEventCbHelper();
+    }
+
     return err;
 }
 


### PR DESCRIPTION
--When application calls FlushUpdate, if no updated item is set,
mPendingSetState is kPendingSetEmpty, NoMorePendingEventCbHelper()
needs to be called, and notify application there is no more pending
updates.