### PR TITLE
Fix for Issue#369 : Add support for WPA3 in Network Provisioning Profile

### DIFF
--- a/src/adaptations/device-layer/ESP32/NetworkProvisioningServerImpl.cpp
+++ b/src/adaptations/device-layer/ESP32/NetworkProvisioningServerImpl.cpp
@@ -355,6 +355,16 @@ void NetworkProvisioningServerImpl::HandleScanTimeOut(::nl::Weave::System::Layer
 
 #endif // WEAVE_DEVICE_CONFIG_WIFI_SCAN_COMPLETION_TIMEOUT
 
+bool NetworkProvisioningServerImpl::IsSupportedWiFiSecurityType(WiFiSecurityType_t wifiSecType)
+{
+    return (wifiSecType == kWiFiSecurityType_None ||
+            wifiSecType == kWiFiSecurityType_WEP ||
+            wifiSecType == kWiFiSecurityType_WPAPersonal ||
+            wifiSecType == kWiFiSecurityType_WPA2Personal ||
+            wifiSecType == kWiFiSecurityType_WPA2Enterprise);
+}
+
+
 } // namespace Internal
 } // namespace DeviceLayer
 } // namespace Weave

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ESP32/NetworkProvisioningServerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ESP32/NetworkProvisioningServerImpl.h
@@ -63,6 +63,7 @@ private:
     void HandleScanDone(void);
     static NetworkProvisioningServerImpl & Instance(void);
     static void HandleScanTimeOut(::nl::Weave::System::Layer * aLayer, void * aAppState, ::nl::Weave::System::Error aError);
+    static bool IsSupportedWiFiSecurityType(WiFiSecurityType_t wifiSecType);
 
     // ===== Members for internal use by the following friends.
 

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericNetworkProvisioningServerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericNetworkProvisioningServerImpl.h
@@ -41,6 +41,7 @@ protected:
     using NetworkInfo = ::nl::Weave::DeviceLayer::Internal::DeviceNetworkInfo;
     using NetworkType_t = ::nl::Weave::Profiles::NetworkProvisioning::NetworkType;
     using PacketBuffer = ::nl::Weave::System::PacketBuffer;
+    using WiFiSecurityType_t = ::nl::Weave::Profiles::NetworkProvisioning::WiFiSecurityType;
 
     // ===== Members that implement the NetworkProvisioningServer abstract interface
 

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericNetworkProvisioningServerImpl.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericNetworkProvisioningServerImpl.ipp
@@ -862,11 +862,8 @@ WEAVE_ERROR GenericNetworkProvisioningServerImpl<ImplClass>::ValidateWiFiStation
         ExitNow(err = WEAVE_ERROR_INVALID_ARGUMENT);
     }
 
-    if (netInfo.WiFiSecurityType != kWiFiSecurityType_None &&
-        netInfo.WiFiSecurityType != kWiFiSecurityType_WEP &&
-        netInfo.WiFiSecurityType != kWiFiSecurityType_WPAPersonal &&
-        netInfo.WiFiSecurityType != kWiFiSecurityType_WPA2Personal &&
-        netInfo.WiFiSecurityType != kWiFiSecurityType_WPA2Enterprise)
+    // Defer to the implementation class to determine if the proposed security type is supported.
+    if (!ImplClass::IsSupportedWiFiSecurityType(netInfo.WiFiSecurityType))
     {
         WeaveLogProgress(DeviceLayer, "%sUnsupported WiFi station security type: %d", sLogPrefix, netInfo.WiFiSecurityType);
         statusProfileId = kWeaveProfile_NetworkProvisioning;

--- a/src/device-manager/cocoa/NLNetworkInfo.mm
+++ b/src/device-manager/cocoa/NLNetworkInfo.mm
@@ -243,6 +243,14 @@ const int NLThreadChannel_NotSpecified = -1;
         return nl::Weave::Profiles::NetworkProvisioning::kWiFiSecurityType_WPA2Enterprise;
     case kNLWiFiSecurityType_WPA2MixedEnterprise:
         return nl::Weave::Profiles::NetworkProvisioning::kWiFiSecurityType_WPA2MixedEnterprise;
+    case kNLWiFiSecurityType_WPA3Personal:
+        return nl::Weave::Profiles::NetworkProvisioning::kWiFiSecurityType_WPA3Personal;
+    case kNLWiFiSecurityType_WPA3MixedPersonal:
+        return nl::Weave::Profiles::NetworkProvisioning::kWiFiSecurityType_WPA3MixedPersonal;
+    case kNLWiFiSecurityType_WPA3Enterprise:
+        return nl::Weave::Profiles::NetworkProvisioning::kWiFiSecurityType_WPA3Enterprise;
+    case kNLWiFiSecurityType_WPA3MixedEnterprise:
+        return nl::Weave::Profiles::NetworkProvisioning::kWiFiSecurityType_WPA3MixedEnterprise;
     default:
         return nl::Weave::Profiles::NetworkProvisioning::kWiFiSecurityType_NotSpecified;
     }

--- a/src/device-manager/cocoa/NLWeaveDeviceManagerTypes.h
+++ b/src/device-manager/cocoa/NLWeaveDeviceManagerTypes.h
@@ -82,7 +82,11 @@ typedef NS_ENUM(NSInteger, NLWiFiSecurityType) {
     kNLWiFiSecurityType_WPA2MixedPersonal = 5,
     kNLWiFiSecurityType_WPAEnterprise = 6,
     kNLWiFiSecurityType_WPA2Enterprise = 7,
-    kNLWiFiSecurityType_WPA2MixedEnterprise = 8
+    kNLWiFiSecurityType_WPA2MixedEnterprise = 8,
+    kNLWiFiSecurityType_WPA3Personal = 9,
+    kNLWiFiSecurityType_WPA3MixedPersonal = 10,
+    kNLWiFiSecurityType_WPA3Enterprise = 11,
+    kNLWiFiSecurityType_WPA3MixedEnterprise = 12
 };
 
 // Device Descriptor

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/WiFiSecurityType.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/WiFiSecurityType.java
@@ -27,7 +27,11 @@ public enum WiFiSecurityType
     WPA2MixedPersonal(5),
     WPAEnterprise(6),
     WPA2Enterprise(7),
-    WPA2MixedEnterprise(8);
+    WPA2MixedEnterprise(8),
+    WPA3Personal(9),
+    WPA3MixedPersonal(10),
+    WPA3Enterprise(11),
+    WPA3MixedEnterprise(12);
 
     WiFiSecurityType(int v)
     {

--- a/src/lib/profiles/network-provisioning/NetworkProvisioning.h
+++ b/src/lib/profiles/network-provisioning/NetworkProvisioning.h
@@ -166,7 +166,11 @@ enum WiFiSecurityType
     kWiFiSecurityType_WPA2MixedPersonal         = 5,
     kWiFiSecurityType_WPAEnterprise             = 6,
     kWiFiSecurityType_WPA2Enterprise            = 7,
-    kWiFiSecurityType_WPA2MixedEnterprise       = 8
+    kWiFiSecurityType_WPA2MixedEnterprise       = 8,
+    kWiFiSecurityType_WPA3Personal              = 9,
+    kWiFiSecurityType_WPA3MixedPersonal         = 10,
+    kWiFiSecurityType_WPA3Enterprise            = 11,
+    kWiFiSecurityType_WPA3MixedEnterprise       = 12,
 };
 
 /**


### PR DESCRIPTION
-- Added enumerated values to WiFiSecurityType to represent WPA3 security types (WPA3Personal, WPA3MixedPersonal, WPA3Enterprise and WPA3MixedEnterprise).

-- Revised GenericNetworkProvisioningServerImpl<> class to defer to the implementation subclass when determining whether a proposed WiFi security type is supported.  This allows individual Device Layer adaptations to control which security types they accept.

-- Added IsSupportedWiFiSecurityType() to the ESP32 NetworkProvisioningServerImpl class.