### PR TITLE
fix pending update state clean when discarding Update

### DIFF
--- a/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
@@ -2913,6 +2913,7 @@ void SubscriptionClient::AbortUpdates(WEAVE_ERROR aErr)
     {
         numPending = mPendingUpdateSet.GetNumItems();
         mPendingUpdateSet.Clear();
+        SetPendingSetState(kPendingSetEmpty);
 
         numInProgress = mInProgressUpdateList.GetNumItems();
         mInProgressUpdateList.Clear();


### PR DESCRIPTION
--When application trigger DiscardUpdate with WEAVE_NO_ERROR, pending
set state needs to be reset.