### PR TITLE
Use default-construct and assign for some variables

### DIFF
--- a/src/lib/core/WeaveExchangeMgr.cpp
+++ b/src/lib/core/WeaveExchangeMgr.cpp
@@ -557,7 +557,7 @@ ExchangeContext *WeaveExchangeManager::AllocContext()
     for (int i = 0; i < WEAVE_CONFIG_MAX_EXCHANGE_CONTEXTS; i++, ec++)
         if (ec->ExchangeMgr == NULL)
         {
-            memset(ec, 0, sizeof(ExchangeContext));
+            *ec = ExchangeContext();
             ec->ExchangeMgr = this;
             ec->mRefCount = 1;
             mContextsInUse++;

--- a/src/lib/profiles/data-management/Current/LoggingManagement.cpp
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.cpp
@@ -1586,7 +1586,7 @@ WEAVE_ERROR LoggingManagement::FetchEventParameters(const TLVReader & aReader, s
     if ((reader.GetTag() == nl::Weave::TLV::ContextTag(kTag_ExternalEventStructure)) && (envelope->mExternalEvents != NULL))
     {
         err = reader.GetBytes(static_cast<uint8_t *>(static_cast<void *>(envelope->mExternalEvents)), sizeof(ExternalEvents));
-        VerifyOrExit(err == WEAVE_NO_ERROR, memset(envelope->mExternalEvents, 0, sizeof(ExternalEvents)));
+        VerifyOrExit(err == WEAVE_NO_ERROR, *(envelope->mExternalEvents) = ExternalEvents());
         envelope->mNumFieldsToRead--;
     }
 

--- a/src/lib/profiles/device-description/DeviceDescription.cpp
+++ b/src/lib/profiles/device-description/DeviceDescription.cpp
@@ -1077,7 +1077,7 @@ WEAVE_ERROR IdentifyRequestMessage::Decode(PacketBuffer *msgBuf, uint64_t msgDes
 
     VerifyOrExit(msgBuf->DataLength() == 16, err = WEAVE_ERROR_INVALID_MESSAGE_LENGTH);
 
-    memset(&msg, 0, sizeof(msg));
+    msg = IdentifyRequestMessage();
     p = msgBuf->Start();
     msg.TargetFabricId = LittleEndian::Read64(p);
     msg.TargetModes = LittleEndian::Read32(p);

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.cpp
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.cpp
@@ -741,7 +741,7 @@ void WeaveTunnelConnectionMgr::HandleServiceConnectionComplete(WeaveConnection *
 
     // Create tunnel route for Service and send Tunnel control message.
 
-    memset(&tunRoute, 0, sizeof(tunRoute));
+    tunRoute = WeaveTunnelRoute();
     globalId = WeaveFabricIdToIPv6GlobalId(tConnMgr->mTunAgent->mExchangeMgr->FabricState->FabricId);
     if (tConnMgr->mTunAgent->mRole == kClientRole_BorderGateway)
     {

--- a/src/ra-daemon/RADaemon.cpp
+++ b/src/ra-daemon/RADaemon.cpp
@@ -629,7 +629,7 @@ void RADaemon::DelPrefixInfo(InterfaceId link, IPPrefix ipPrefix)
                 currIPPrefixInfo = &currLinkInfo->IPPrefixInfo[k];
                 if (currIPPrefixInfo->IPPrefx == ipPrefix)
                 {
-                    memset(&currIPPrefixInfo->IPPrefx, 0, sizeof(IPPrefix));
+                    currIPPrefixInfo->IPPrefx = IPPrefix();
                     prefix_removed = 1;
                     num_free_prefixes++;
                 }
@@ -672,7 +672,7 @@ void RADaemon::DelLinkInfo(InterfaceId link)
             currLinkInfo->RawEP = NULL;
             SystemLayer->CancelTimer(MulticastPeriodicRA, currLinkInfo);
             SystemLayer->CancelTimer(TrackRSes, currLinkInfo);
-            memset(currLinkInfo, 0, sizeof(RADaemon::LinkInformation));
+            *currLinkInfo = RADaemon::LinkInformation();
             currLinkInfo->Self = this;
             break;
         }


### PR DESCRIPTION
This fixes a compiler warning in gcc 8+. That compiler now warns when
calling memset writes to private variables in a struct. This appears
to mostly be the cause of the warnings here.