### PR TITLE
BLEManager changes

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ConnectivityManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ConnectivityManager.h
@@ -157,6 +157,7 @@ public:
     WEAVE_ERROR SetBLEAdvertisingEnabled(bool val);
     bool IsBLEFastAdvertisingEnabled(void);
     WEAVE_ERROR SetBLEFastAdvertisingEnabled(bool val);
+    bool IsBLEAdvertising(void);
     WEAVE_ERROR GetBLEDeviceName(char * buf, size_t bufSize);
     WEAVE_ERROR SetBLEDeviceName(const char * deviceName);
     uint16_t NumBLEConnections(void);
@@ -477,6 +478,11 @@ inline bool ConnectivityManager::IsBLEFastAdvertisingEnabled(void)
 inline WEAVE_ERROR ConnectivityManager::SetBLEFastAdvertisingEnabled(bool val)
 {
     return static_cast<ImplClass*>(this)->_SetBLEFastAdvertisingEnabled(val);
+}
+
+inline bool ConnectivityManager::IsBLEAdvertising(void)
+{
+    return static_cast<ImplClass*>(this)->_IsBLEAdvertising();
 }
 
 inline WEAVE_ERROR ConnectivityManager::GetBLEDeviceName(char * buf, size_t bufSize)

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ESP32/BLEManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ESP32/BLEManagerImpl.h
@@ -58,6 +58,7 @@ class BLEManagerImpl final
     WEAVE_ERROR _SetAdvertisingEnabled(bool val);
     bool _IsFastAdvertisingEnabled(void);
     WEAVE_ERROR _SetFastAdvertisingEnabled(bool val);
+    bool _IsAdvertising(void);
     WEAVE_ERROR _GetDeviceName(char * buf, size_t bufSize);
     WEAVE_ERROR _SetDeviceName(const char * deviceName);
     uint16_t _NumConnections(void);
@@ -90,18 +91,18 @@ class BLEManagerImpl final
 
     enum
     {
-        kFlag_AsyncInitCompleted        = 0x0001,
-        kFlag_ESPBLELayerInitialized    = 0x0002,
-        kFlag_AppRegistered             = 0x0004,
-        kFlag_AttrsRegistered           = 0x0008,
-        kFlag_GATTServiceStarted        = 0x0010,
-        kFlag_AdvertisingConfigured     = 0x0020,
-        kFlag_Advertising               = 0x0040,
-        kFlag_ControlOpInProgress       = 0x0080,
-
-        kFlag_AdvertisingEnabled        = 0x0100,
-        kFlag_FastAdvertisingEnabled    = 0x0200,
-        kFlag_UseCustomDeviceName       = 0x0400,
+        kFlag_AsyncInitCompleted        = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
+        kFlag_ESPBLELayerInitialized    = 0x0002, /**< The ESP BLE layer has been initialized. */
+        kFlag_AppRegistered             = 0x0004, /**< The WoBLE application has been registered with the ESP BLE layer. */
+        kFlag_AttrsRegistered           = 0x0008, /**< The WoBLE GATT attributes have been registered with the ESP BLE layer. */
+        kFlag_GATTServiceStarted        = 0x0010, /**< The WoBLE GATT service has been started. */
+        kFlag_AdvertisingConfigured     = 0x0020, /**< WoBLE advertising has been configured in the ESP BLE layer. */
+        kFlag_Advertising               = 0x0040, /**< The system is currently WoBLE advertising. */
+        kFlag_ControlOpInProgress       = 0x0080, /**< An async control operation has been issued to the ESP BLE layer. */
+        kFlag_AdvertisingEnabled        = 0x0100, /**< The application has enabled WoBLE advertising. */
+        kFlag_FastAdvertisingEnabled    = 0x0200, /**< The application has enabled fast advertising. */
+        kFlag_UseCustomDeviceName       = 0x0400, /**< The application has configured a custom BLE device name. */
+        kFlag_AdvertisingRefreshNeeded  = 0x0800, /**< The advertising state in ESP BLE layer needs to be updated. */
     };
 
     enum
@@ -190,6 +191,11 @@ inline bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
     return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
+}
+
+inline bool BLEManagerImpl::_IsAdvertising(void)
+{
+    return GetFlag(mFlags, kFlag_Advertising);
 }
 
 } // namespace Internal

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/WeaveDeviceEvent.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/WeaveDeviceEvent.h
@@ -189,6 +189,13 @@ enum PublicEventTypes
      * Signals that the state of the Thread network interface has changed.
      */
     kThreadInterfaceStateChange,
+
+    /**
+     * Weave-over-BLE (WoBLE) Advertising Change
+     *
+     * Signals that the state of WoBLE advertising has changed.
+     */
+    kWoBLEAdvertisingChange,
 };
 
 /**
@@ -224,6 +231,18 @@ enum ConnectivityChange
     kConnectivity_NoChange      = 0,
     kConnectivity_Established   = 1,
     kConnectivity_Lost          = -1
+};
+
+/**
+ * Activity Change
+ *
+ * Describes a change in some activity associated with a Weave device.
+ */
+enum ActivityChange
+{
+    kActivity_NoChange          = 0,
+    kActivity_Started           = 1,
+    kActivity_Stopped           = -1,
 };
 
 inline ConnectivityChange GetConnectivityChange(bool prevState, bool newState)
@@ -374,6 +393,10 @@ struct WeaveDeviceEvent final
                 uint32_t Flags;
             } OpenThread;
         } ThreadStateChange;
+        struct
+        {
+            ActivityChange Result;
+        } WoBLEAdvertisingChange;
     };
 
     void Clear() { memset(this, 0, sizeof(*this)); }

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/BLEManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/BLEManager.h
@@ -59,6 +59,7 @@ public:
     WEAVE_ERROR SetAdvertisingEnabled(bool val);
     bool IsFastAdvertisingEnabled(void);
     WEAVE_ERROR SetFastAdvertisingEnabled(bool val);
+    bool IsAdvertising(void);
     WEAVE_ERROR GetDeviceName(char * buf, size_t bufSize);
     WEAVE_ERROR SetDeviceName(const char * deviceName);
     uint16_t NumConnections(void);
@@ -146,6 +147,11 @@ inline bool BLEManager::IsFastAdvertisingEnabled(void)
 inline WEAVE_ERROR BLEManager::SetFastAdvertisingEnabled(bool val)
 {
     return static_cast<ImplClass*>(this)->_SetFastAdvertisingEnabled(val);
+}
+
+inline bool BLEManager::IsAdvertising(void)
+{
+    return static_cast<ImplClass*>(this)->_IsAdvertising();
 }
 
 inline WEAVE_ERROR BLEManager::GetDeviceName(char * buf, size_t bufSize)

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_BLE.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_BLE.h
@@ -61,6 +61,7 @@ public:
     WEAVE_ERROR _SetBLEAdvertisingEnabled(bool val);
     bool _IsBLEFastAdvertisingEnabled(void);
     WEAVE_ERROR _SetBLEFastAdvertisingEnabled(bool val);
+    bool _IsBLEAdvertising(void);
     WEAVE_ERROR _GetBLEDeviceName(char * buf, size_t bufSize);
     WEAVE_ERROR _SetBLEDeviceName(const char * deviceName);
     uint16_t _NumBLEConnections(void);
@@ -108,6 +109,12 @@ template<class ImplClass>
 inline WEAVE_ERROR GenericConnectivityManagerImpl_BLE<ImplClass>::_SetBLEFastAdvertisingEnabled(bool val)
 {
     return BLEMgr().SetFastAdvertisingEnabled(val);
+}
+
+template<class ImplClass>
+inline bool GenericConnectivityManagerImpl_BLE<ImplClass>::_IsBLEAdvertising(void)
+{
+    return BLEMgr().IsAdvertising();
 }
 
 template<class ImplClass>

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/nRF5/BLEManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/nRF5/BLEManagerImpl.h
@@ -57,6 +57,7 @@ class BLEManagerImpl final
     WEAVE_ERROR _SetAdvertisingEnabled(bool val);
     bool _IsFastAdvertisingEnabled(void);
     WEAVE_ERROR _SetFastAdvertisingEnabled(bool val);
+    bool _IsAdvertising(void);
     WEAVE_ERROR _GetDeviceName(char * buf, size_t bufSize);
     WEAVE_ERROR _SetDeviceName(const char * deviceName);
     uint16_t _NumConnections(void);
@@ -89,11 +90,11 @@ class BLEManagerImpl final
 
     enum
     {
-        kFlag_AsyncInitCompleted                = 0x0001,
-        kFlag_AdvertisingEnabled                = 0x0002,
-        kFlag_FastAdvertisingEnabled            = 0x0004,
-        kFlag_Advertising                       = 0x0008,
-        kFlag_AdvertisingConfigChangePending    = 0x0010,
+        kFlag_AsyncInitCompleted                = 0x0001, /**< One-time asynchronous initialization actions have been performed. */
+        kFlag_AdvertisingEnabled                = 0x0002, /**< The application has enabled WoBLE advertising. */
+        kFlag_FastAdvertisingEnabled            = 0x0004, /**< The application has enabled fast advertising. */
+        kFlag_Advertising                       = 0x0008, /**< The system is currently WoBLE advertising. */
+        kFlag_AdvertisingRefreshNeeded          = 0x0010, /**< The advertising state/configuration has changed, but the SoftDevice has yet to be updated. */
     };
 
     enum
@@ -172,6 +173,11 @@ inline bool BLEManagerImpl::_IsAdvertisingEnabled(void)
 inline bool BLEManagerImpl::_IsFastAdvertisingEnabled(void)
 {
     return GetFlag(mFlags, kFlag_FastAdvertisingEnabled);
+}
+
+inline bool BLEManagerImpl::_IsAdvertising(void)
+{
+    return GetFlag(mFlags, kFlag_Advertising);
 }
 
 } // namespace Internal


### PR DESCRIPTION
- Introduced a new WoBLEAdvertisingChange device event that gets generated whenever the BLEManager starts and stops WoBLE advertising.

- Added method to ConnectivityManager to determine whether WoBLE advertising is currently active.

- Fixed logic bugs in the transition between fast and slow WoBLE advertising.  The system will now properly transition between the two modes when the device’s provisioning state changes, or when expressly asked to by the application.

- Eliminated subtle race condition on Nordic platforms where WoBLE would be disabled entirely due to an unexpected error from the SoftDevice if a connection arrived just as the BLEManager was updating the advertising configuration.

- Renamed BLEManager internal flag values and added documentation to make their meaning clearer.