### PR TITLE
Fix a logic bug and perform minor cleanup

### DIFF
--- a/src/lib/profiles/time/WeaveTime.h
+++ b/src/lib/profiles/time/WeaveTime.h
@@ -1108,6 +1108,21 @@ protected:
 
     static void HandleAutoSyncTimeout(System::Layer* aSystemLayer, void* aAppState, System::Error aError);
 
+    /**
+     * @brief
+     *   Determine whether given state is operational
+     *
+     * Convenience method to determine whether the ClientState denotes
+     * operational state, i.e. the client has completed initialization and is
+     * not in the process of shutting down.
+     *
+     * @param[in] aState   state to be evaluated
+     *
+     * @return true if the state falls after the initialization has completed
+     *         and before the shutdown has started, false otherwise.
+     */
+    static inline bool IsOperationalState(ClientState aState) { return ((kClientState_BeginNormal < aState) && (aState < kClientState_EndNormal)); }
+
 #endif // WEAVE_CONFIG_TIME_ENABLE_CLIENT
 };
 

--- a/src/lib/profiles/time/WeaveTimeClient.cpp
+++ b/src/lib/profiles/time/WeaveTimeClient.cpp
@@ -557,14 +557,11 @@ WEAVE_ERROR TimeSyncNode::Abort(void)
 
         DestroyCommContext();
 
-        if ((kClientState_BeginNormal > state) || (kClientState_EndNormal < state))
-        {
-            // don't touch the state
-        }
-        else
+        if (IsOperationalState(state))
         {
             SetClientState(kClientState_Idle);
         }
+        // dont touch the state if its either initializing or shutting down
     }
 
 exit:
@@ -1940,8 +1937,7 @@ void TimeSyncNode::HandleTimeChangeNotification(ExchangeContext *ec, const IPPac
 
         // check internal state
         // only try to decode if we're in any of these normal states
-        if ((kClientState_BeginNormal >= ClientStateAtEntry)
-            && (kClientState_EndNormal <= ClientStateAtEntry))
+        if (!IsOperationalState(ClientStateAtEntry))
         {
             ExitNow(err = WEAVE_ERROR_INCORRECT_STATE);
         }


### PR DESCRIPTION
Based on the feedback from @lcniles, this patch cleans up a logic bug
in WeaveTimeClient.  WeaveTimeClient has a notion of "normal" state, I
ended up adopting "operational" state as the term.  The term denotes
all possible states that are not a part of initialization or shutdown
of the module.  This PR defines the canonical helper function,
replaces the faulty logic in `HandleTimeChangeNotification`, and
cleans up the correct but confusing logic in `Abort`.