### PR TITLE
Fixed logic bugs in ESP32 BLEManager

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ESP32/BLEManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ESP32/BLEManagerImpl.h
@@ -102,7 +102,7 @@ class BLEManagerImpl final
         kFlag_AdvertisingEnabled        = 0x0100, /**< The application has enabled WoBLE advertising. */
         kFlag_FastAdvertisingEnabled    = 0x0200, /**< The application has enabled fast advertising. */
         kFlag_UseCustomDeviceName       = 0x0400, /**< The application has configured a custom BLE device name. */
-        kFlag_AdvertisingRefreshNeeded  = 0x0800, /**< The advertising state in ESP BLE layer needs to be updated. */
+        kFlag_AdvertisingRefreshNeeded  = 0x0800, /**< The advertising configuration/state in ESP BLE layer needs to be updated. */
     };
 
     enum


### PR DESCRIPTION
- Fixed a set of logic bugs in the ESP32 version of the BLEManager having to do with refreshing the WoBLE advertising state as the state of the device changes.  These bugs were inadvertently introduced in the previous change to this code.