### PR TITLE
Accessor functions for SoftDevice advertising handle

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/nRF5/BLEManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/nRF5/BLEManagerImpl.h
@@ -48,6 +48,15 @@ class BLEManagerImpl final
     // the implementation methods provided by this class.
     friend BLEManager;
 
+public:
+
+    // ===== Platform-specific members available for use by the application.
+
+    uint8_t GetAdvertisingHandle(void);
+    void SetAdvertisingHandle(uint8_t handle);
+
+private:
+
     // ===== Members that implement the BLEManager internal interface.
 
     WEAVE_ERROR _Init(void);
@@ -153,6 +162,16 @@ inline BLEManager & BLEMgr(void)
 inline BLEManagerImpl & BLEMgrImpl(void)
 {
     return BLEManagerImpl::sInstance;
+}
+
+inline uint8_t BLEManagerImpl::GetAdvertisingHandle(void)
+{
+    return mAdvHandle;
+}
+
+inline void BLEManagerImpl::SetAdvertisingHandle(uint8_t handle)
+{
+    mAdvHandle = handle;
 }
 
 inline ::nl::Ble::BleLayer * BLEManagerImpl::_GetBleLayer() const


### PR DESCRIPTION
- Added accessor functions to the Nordic version of the BLEManagerImpl class that allow the application to get and set the SoftDevice BLE advertising handle.