### PR TITLE
Remove unused header <sys/sysctl.h>

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -51,7 +51,6 @@
 #ifdef HAVE_SYS_SOCKIO_H
 #include <sys/sockio.h>
 #endif /* HAVE_SYS_SOCKIO_H */
-#include <sys/sysctl.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
 #ifdef __ANDROID__


### PR DESCRIPTION
Included header is unused (provides, by contract, sysctl API, unused
in inet layer at this time (by inspection)).  sysctl is not
universally available, esp. on android-based systems.