### PR TITLE
Fixes to the device layer/nRF implementation

### DIFF
--- a/src/adaptations/device-layer/nRF5/BLEManagerImpl.cpp
+++ b/src/adaptations/device-layer/nRF5/BLEManagerImpl.cpp
@@ -802,7 +802,7 @@ void BLEManagerImpl::SoftDeviceBLEEventCallback(const ble_evt_t * bleEvent, void
     }
 
     // Post the event to the Weave queue.
-#if NRF_SDH_DISPATCH_MODEL_INTERRUPT
+#if (NRF_SDH_DISPATCH_MODEL == NRF_SDH_DISPATCH_MODEL_INTERRUPT)
     BaseType_t yieldRequired;
     PlatformMgrImpl().PostEventFromISR(&event, yieldRequired);
     portYIELD_FROM_ISR(yieldRequired);
@@ -1050,4 +1050,3 @@ bool BLEManagerImpl::IsSubscribed(uint16_t conId)
 } // namespace nl
 
 #endif // WEAVE_DEVICE_CONFIG_ENABLE_WOBLE
-

--- a/src/lwip/freertos/arch/sys_arch.h
+++ b/src/lwip/freertos/arch/sys_arch.h
@@ -33,7 +33,7 @@ typedef QueueHandle_t sys_mbox_t;
 typedef xSemaphoreHandle sys_mutex_t;
 typedef xSemaphoreHandle sys_sem_t;
 typedef TaskHandle_t sys_thread_t;
-typedef int sys_prot_t;
+typedef UBaseType_t sys_prot_t;
 
 #include "arch/sys_arch.h"
 #include "lwip/opt.h"

--- a/src/lwip/freertos/sys_arch.c
+++ b/src/lwip/freertos/sys_arch.c
@@ -274,12 +274,11 @@ u32_t sys_now(void)
 
 sys_prot_t sys_arch_protect(void)
 {
-    taskENTER_CRITICAL();
-    return 1;
+    return taskENTER_CRITICAL_FROM_ISR();
 }
 
 void sys_arch_unprotect(sys_prot_t pval)
 {
-    taskEXIT_CRITICAL();
+    taskEXIT_CRITICAL_FROM_ISR(pval);
 }
 


### PR DESCRIPTION
* Correctly dispatch at compile time on the NRF_SDH_DISPATCH_MODEL
  rather than on the enum that defines the model.  This change enables
  the softdevice to actually use the right queue posting primitives.

* When NRF_DEBUG is enabled, softdevice will dispatch log statements
  from interrupt context.  In order to support this, if appropriate,
  log timestamping needs to be available; in turn, this implies that
  TicksSinceBoot must be callable from interrupt context.  Since
  FreeRTOS does not provide generalized facility to determine whether
  a function is in an interrupt context, we make the symbol weak here,
  and leave it to more specific adaptations to provide a more robust
  implementation.