### PR TITLE
Typo: timeout vs. timeOut

### DIFF
--- a/src/adaptations/device-layer/FreeRTOS/SystemTimeSupport.cpp
+++ b/src/adaptations/device-layer/FreeRTOS/SystemTimeSupport.cpp
@@ -71,8 +71,8 @@ uint64_t FreeRTOSTicksSinceBoot(void)
     {
         // Note that sNumOverflows may be quite stale, and under those
         // circumstances, the function may violate monotonicity guarantees
-        timeout.xTimeOnEntering = xTaskGetTickCountFromISR();
-        timeout.xOverflowCount = sNumOfOverflows;
+        timeOut.xTimeOnEntering = xTaskGetTickCountFromISR();
+        timeOut.xOverflowCount = sNumOfOverflows;
     }
     else
     {


### PR DESCRIPTION
Last minute changes to the code in PR436.  CI did not catch the
issue. This time around, I was able to build and verify the code works
as expected.