### PR TITLE
Fixed spelling typo in CommunicationError

### DIFF
--- a/src/adaptations/device-layer/ServiceProvisioningServer.cpp
+++ b/src/adaptations/device-layer/ServiceProvisioningServer.cpp
@@ -358,7 +358,7 @@ exit:
             if (err == WEAVE_ERROR_TIMEOUT)
             {
                 statusReportProfileId = kWeaveProfile_ServiceProvisioning;
-                statusReportStatusCode = Profiles::ServiceProvisioning::kStatusCode_ServiceCommuncationError;
+                statusReportStatusCode = Profiles::ServiceProvisioning::kStatusCode_ServiceCommunicationError;
             }
             else
             {
@@ -404,7 +404,7 @@ void ServiceProvisioningServer::HandleProvServiceBindingEvent(void * appState, B
         else
         {
             statusReportProfileId = kWeaveProfile_ServiceProvisioning;
-            statusReportStatusCode = Profiles::ServiceProvisioning::kStatusCode_ServiceCommuncationError;
+            statusReportStatusCode = Profiles::ServiceProvisioning::kStatusCode_ServiceCommunicationError;
         }
         sInstance.HandlePairDeviceToAccountResult(inParam.PrepareFailed.Reason,
                 statusReportProfileId, statusReportStatusCode);

--- a/src/lib/profiles/echo/Next/WeaveEchoClient.cpp
+++ b/src/lib/profiles/echo/Next/WeaveEchoClient.cpp
@@ -400,7 +400,7 @@ exit:
         err = armTimerErr;
     }
 
-    // If needed, deliver a CommuncationError API event to the application.  Note that this may result
+    // If needed, deliver a CommunicationError API event to the application.  Note that this may result
     // in the state of the client object changing (e.g. as a result of the application calling Stop()).
     // So the code here shouldn't presume anything about the current state after the callback.
     if (err != WEAVE_NO_ERROR)
@@ -503,7 +503,7 @@ void WeaveEchoClient::CancelSendTimer()
 }
 
 /**
- * Deliver a CommuncationError API event to the application.
+ * Deliver a CommunicationError API event to the application.
  */
 void WeaveEchoClient::DeliverCommunicationError(WEAVE_ERROR err)
 {
@@ -512,11 +512,11 @@ void WeaveEchoClient::DeliverCommunicationError(WEAVE_ERROR err)
 
     inParam.Clear();
     inParam.Source = this;
-    inParam.CommuncationError.Reason = err;
+    inParam.CommunicationError.Reason = err;
 
     outParam.Clear();
 
-    mEventCallback(AppState, kEvent_CommuncationError, inParam, outParam);
+    mEventCallback(AppState, kEvent_CommunicationError, inParam, outParam);
 }
 
 /**
@@ -551,7 +551,7 @@ void WeaveEchoClient::HandleBindingEvent(void * const appState, const Binding::E
 
             // If SendRepeating mode is enabled arm the send timer.  When the timer fires another
             // attempt will be made to prepare the binding.
-            // Otherwise, if SendRepeating mode is NOT enabled, deliver a CommuncationError API
+            // Otherwise, if SendRepeating mode is NOT enabled, deliver a CommunicationError API
             // event to the application.
             if (client->GetFlag(kFlag_SendRepeating))
             {

--- a/src/lib/profiles/echo/Next/WeaveEchoClient.h
+++ b/src/lib/profiles/echo/Next/WeaveEchoClient.h
@@ -108,7 +108,7 @@ using namespace ::nl::Weave;
  * An EchoResponse message was received from the peer.  Arguments to the event contain the response
  * payload and meta-information about the response message.
  *
- * ### CommuncationError
+ * ### CommunicationError
  *
  * An error occurred while forming or sending an EchoRequest, or while waiting for a response.
  * Examples of errors that can occur while waiting for a response are key errors or unexpected close
@@ -153,7 +153,7 @@ public:
         kEvent_PreparePayload                       = 1,    /**< The application is requested to prepare the payload for the Echo request. */
         kEvent_RequestSent                          = 2,    /**< An EchoRequest message was sent to the peer. */
         kEvent_ResponseReceived                     = 3,    /**< An EchoResponse message was received from the peer. */
-        kEvent_CommuncationError                    = 4,    /**< A communication error occurred while sending an EchoRequest or waiting for a response. */
+        kEvent_CommunicationError                   = 4,    /**< A communication error occurred while sending an EchoRequest or waiting for a response. */
         kEvent_ResponseTimeout                      = 5,    /**< An EchoResponse was not received in the alloted time. */
         kEvent_RequestAborted                       = 6,    /**< An in-progress Echo exchange was aborted because a request was made to start another exchange. */
 
@@ -246,7 +246,7 @@ struct WeaveEchoClient::InEventParam
         struct
         {
             WEAVE_ERROR Reason;                             /**< The error code associated with the communication failure. */
-        } CommuncationError;
+        } CommunicationError;
 
         struct
         {

--- a/src/lib/profiles/service-provisioning/ServiceProvisioning.h
+++ b/src/lib/profiles/service-provisioning/ServiceProvisioning.h
@@ -62,7 +62,7 @@ enum
     kStatusCode_PairingServerError              = 5,    /**< The device could not complete service pairing because it failed to talk to the pairing server. */
     kStatusCode_InvalidPairingToken             = 6,    /**< The device could not complete service pairing because it passed an invalid pairing token. */
     kStatusCode_PairingTokenOld                 = 7,    /**< The device could not complete service pairing because the pairing token it passed has expired. */
-    kStatusCode_ServiceCommuncationError        = 8,    /**< The device could not complete service pairing because it encountered an error when communicating with the service. */
+    kStatusCode_ServiceCommunicationError       = 8,    /**< The device could not complete service pairing because it encountered an error when communicating with the service. */
     kStatusCode_ServiceConfigTooLarge           = 9,    /**< The specified service configuration is too large. */
     kStatusCode_WrongFabric                     = 10,   /**< Device paired with a different fabric. */
     kStatusCode_TooManyFabrics                  = 11    /**< Too many fabrics in the structure. */

--- a/src/lib/support/StatusReportStr.cpp
+++ b/src/lib/support/StatusReportStr.cpp
@@ -287,7 +287,7 @@ NL_DLL_EXPORT const char *StatusReportStr(uint32_t profileId, uint16_t statusCod
         case ServiceProvisioning::kStatusCode_PairingServerError                        : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Error talking to pairing server"; break;
         case ServiceProvisioning::kStatusCode_InvalidPairingToken                       : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Invalid pairing token"; break;
         case ServiceProvisioning::kStatusCode_PairingTokenOld                           : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Pairing token no longer valid"; break;
-        case ServiceProvisioning::kStatusCode_ServiceCommuncationError                  : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Service communication error"; break;
+        case ServiceProvisioning::kStatusCode_ServiceCommunicationError                 : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Service communication error"; break;
         case ServiceProvisioning::kStatusCode_ServiceConfigTooLarge                     : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Service configuration too large"; break;
         case ServiceProvisioning::kStatusCode_WrongFabric                               : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Wrong fabric"; break;
         case ServiceProvisioning::kStatusCode_TooManyFabrics                            : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Too many fabrics"; break;

--- a/src/test-apps/TestStatusReportStr.cpp
+++ b/src/test-apps/TestStatusReportStr.cpp
@@ -246,7 +246,7 @@ static struct Profile_Status sContext[] = {
             ServiceProvisioning::kStatusCode_PairingServerError,
             ServiceProvisioning::kStatusCode_InvalidPairingToken,
             ServiceProvisioning::kStatusCode_PairingTokenOld,
-            ServiceProvisioning::kStatusCode_ServiceCommuncationError,
+            ServiceProvisioning::kStatusCode_ServiceCommunicationError,
             ServiceProvisioning::kStatusCode_ServiceConfigTooLarge,
             ServiceProvisioning::kStatusCode_WrongFabric,
             ServiceProvisioning::kStatusCode_TooManyFabrics,


### PR DESCRIPTION
Fixed spelling typo in the event and status code name: CommuncationError --> CommunicationError