### PR TITLE
Strip from TAKE protocol the dependency on third_party/micro-ecc

### DIFF
--- a/src/lib/profiles/security/WeaveTAKE.h
+++ b/src/lib/profiles/security/WeaveTAKE.h
@@ -34,7 +34,6 @@
 #include <Weave/Core/WeaveError.h>
 #include <Weave/Core/WeaveCore.h>
 #include <SystemLayer/SystemPacketBuffer.h>
-#include <micro-ecc/uECC.h>
 
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
@robszewczyk I think you mentioned recently that this is a simple include oversight and should be removed?