### PR TITLE
Assume Apache 2.0 license for vendor/nestlabs modules

### DIFF
--- a/src/lib/profiles/vendor/nestlabs/device-description/NestProductIdentifiers.hpp
+++ b/src/lib/profiles/vendor/nestlabs/device-description/NestProductIdentifiers.hpp
@@ -1,15 +1,19 @@
 /*
- *
  *    Copyright (c) 2014-2018 Nest Labs, Inc.
+ *    Copyright (c) 2019 Google, LLC.
  *    All rights reserved.
  *
- *    This document is the property of Nest. It is considered
- *    confidential and proprietary information.
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
  *
- *    This document may not be reproduced or transmitted in any form,
- *    in whole or in part, without the express written permission of
- *    Nest.
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 
 /**

--- a/src/lib/profiles/vendor/nestlabs/dropcam-legacy-pairing/DropcamLegacyPairing.cpp
+++ b/src/lib/profiles/vendor/nestlabs/dropcam-legacy-pairing/DropcamLegacyPairing.cpp
@@ -1,15 +1,19 @@
 /*
- *
  *    Copyright (c) 2016 Nest Labs, Inc.
+ *    Copyright (c) 2019 Google, LLC.
  *    All rights reserved.
  *
- *    This document is the property of Nest. It is considered
- *    confidential and proprietary information.
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
  *
- *    This document may not be reproduced or transmitted in any form,
- *    in whole or in part, without the express written permission of
- *    Nest.
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 
 /**

--- a/src/lib/profiles/vendor/nestlabs/dropcam-legacy-pairing/DropcamLegacyPairing.h
+++ b/src/lib/profiles/vendor/nestlabs/dropcam-legacy-pairing/DropcamLegacyPairing.h
@@ -1,15 +1,19 @@
 /*
- *
  *    Copyright (c) 2016 Nest Labs, Inc.
+ *    Copyright (c) 2019 Google, LLC.
  *    All rights reserved.
  *
- *    This document is the property of Nest. It is considered
- *    confidential and proprietary information.
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
  *
- *    This document may not be reproduced or transmitted in any form,
- *    in whole or in part, without the express written permission of
- *    Nest.
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 
 /**

--- a/src/lib/profiles/vendor/nestlabs/thermostat/IfjStatusStr.cpp
+++ b/src/lib/profiles/vendor/nestlabs/thermostat/IfjStatusStr.cpp
@@ -1,15 +1,19 @@
 /*
- *
  *    Copyright (c) 2016 Nest Labs, Inc.
+ *    Copyright (c) 2019 Google, LLC.
  *    All rights reserved.
  *
- *    This document is the property of Nest. It is considered
- *    confidential and proprietary information.
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
  *
- *    This document may not be reproduced or transmitted in any form,
- *    in whole or in part, without the express written permission of
- *    Nest.
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 
 /**

--- a/src/lib/profiles/vendor/nestlabs/thermostat/NestThermostatWeaveConstants.h
+++ b/src/lib/profiles/vendor/nestlabs/thermostat/NestThermostatWeaveConstants.h
@@ -1,15 +1,19 @@
 /*
- *
  *    Copyright (c) 2013-2014 Nest Labs, Inc.
+ *    Copyright (c) 2019 Google, LLC.
  *    All rights reserved.
  *
- *    This document is the property of Nest. It is considered
- *    confidential and proprietary information.
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
  *
- *    This document may not be reproduced or transmitted in any form,
- *    in whole or in part, without the express written permission of
- *    Nest.
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 
 /**


### PR DESCRIPTION
This assumes the Apache 2.0 license for the as-opensourced modules found
in src/lib/profiles/vendor/nestlabs.