### PR TITLE
Device Layer: Generate Operational Device Credentials

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ConfigurationManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ConfigurationManager.h
@@ -154,6 +154,7 @@ private:
     WEAVE_ERROR ReadPersistedStorageValue(::nl::Weave::Platform::PersistedStorage::Key key, uint32_t & value);
     WEAVE_ERROR WritePersistedStorageValue(::nl::Weave::Platform::PersistedStorage::Key key, uint32_t value);
 #if WEAVE_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING
+    WEAVE_ERROR GenerateAndStoreOperationalDeviceCredentials(uint64_t deviceId = kNodeIdNotSpecified);
     WEAVE_ERROR ClearOperationalDeviceCredentials(void);
     void UseManufacturerCredentialsAsOperational(bool val);
 #endif
@@ -523,6 +524,11 @@ inline WEAVE_ERROR ConfigurationManager::SetFailSafeArmed(bool val)
 inline bool ConfigurationManager::OperationalDeviceCredentialsProvisioned()
 {
     return static_cast<ImplClass*>(this)->_OperationalDeviceCredentialsProvisioned();
+}
+
+inline WEAVE_ERROR ConfigurationManager::GenerateAndStoreOperationalDeviceCredentials(uint64_t deviceId)
+{
+    return static_cast<ImplClass*>(this)->_GenerateAndStoreOperationalDeviceCredentials(deviceId);
 }
 
 inline WEAVE_ERROR ConfigurationManager::ClearOperationalDeviceCredentials(void)

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConfigurationManagerImpl.h
@@ -110,6 +110,7 @@ public:
     bool _IsFullyProvisioned();
     WEAVE_ERROR _ComputeProvisioningHash(uint8_t * hashBuf, size_t hashBufSize);
 #if WEAVE_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING
+    WEAVE_ERROR _GenerateAndStoreOperationalDeviceCredentials(uint64_t deviceId);
     bool _OperationalDeviceCredentialsProvisioned();
     void _UseManufacturerCredentialsAsOperational(bool val);
 #endif

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericPlatformManagerImpl.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericPlatformManagerImpl.ipp
@@ -1,5 +1,6 @@
 /*
  *
+ *    Copyright (c) 2019-2020 Google LLC.
  *    Copyright (c) 2018 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -81,6 +82,27 @@ WEAVE_ERROR GenericPlatformManagerImpl<ImplClass>::_InitWeaveStack(void)
         WeaveLogError(DeviceLayer, "SystemLayer initialization failed: %s", ErrorStr(err));
     }
     SuccessOrExit(err);
+
+#if WEAVE_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING
+    if (!ConfigurationMgr().OperationalDeviceCredentialsProvisioned())
+    {
+        // If paired to account keep using manufacturer device credentials as operational.
+        if (ConfigurationMgr().IsServiceProvisioned() && ConfigurationMgr().IsPairedToAccount())
+        {
+	    ConfigurationMgr().UseManufacturerCredentialsAsOperational(true);
+        }
+        // Otherwise, generate and store operational device credentials.
+        else
+        {
+            err = ConfigurationMgr().GenerateAndStoreOperationalDeviceCredentials();
+            if (err != WEAVE_NO_ERROR)
+            {
+                WeaveLogError(DeviceLayer, "GenerateAndStoreOperationalDeviceCredentials() failed: %s", ErrorStr(err));
+            }
+            SuccessOrExit(err);
+        }
+    }
+#endif // WEAVE_DEVICE_CONFIG_ENABLE_JUST_IN_TIME_PROVISIONING
 
     // Initialize the Weave Inet layer.
     new (&InetLayer) Inet::InetLayer();


### PR DESCRIPTION
Added Operational Device Credentials Generation Function for the Weave Device Layer.

  -- If needed, this function should be called early during Weave stack initialization
     to provision device with initial set of operational credentials.
  -- In a special case, when device doesn't have operational credentials but it is already
     paired to account, a flag will be set that manufacturer-assigned credentials should
     be used as operational credentials.