### PR TITLE
Make the software update timer oblivious to service connectivity events

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/SoftwareUpdateManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/SoftwareUpdateManager.h
@@ -320,7 +320,6 @@ private:
     template<class> friend class Internal::GenericPlatformManagerImpl;
 
     WEAVE_ERROR Init(void);
-    void OnPlatformEvent(const WeaveDeviceEvent * event);
 
 protected:
 
@@ -480,11 +479,6 @@ inline WEAVE_ERROR SoftwareUpdateManager::ImageInstallComplete(WEAVE_ERROR aErro
 inline WEAVE_ERROR SoftwareUpdateManager::PrepareImageStorageComplete(WEAVE_ERROR aError)
 {
     return static_cast<ImplClass*>(this)->_PrepareImageStorageComplete(aError);
-}
-
-inline void SoftwareUpdateManager::OnPlatformEvent(const WeaveDeviceEvent * event)
-{
-    static_cast<ImplClass*>(this)->_OnPlatformEvent(event);
 }
 
 inline SoftwareUpdateManager::State SoftwareUpdateManager::GetState(void)

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericPlatformManagerImpl.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericPlatformManagerImpl.ipp
@@ -421,9 +421,6 @@ void GenericPlatformManagerImpl<ImplClass>::DispatchEventToDeviceLayer(const Wea
     NetworkProvisioningSvr().OnPlatformEvent(event);
     FabricProvisioningSvr().OnPlatformEvent(event);
     ServiceProvisioningSvr().OnPlatformEvent(event);
-#if WEAVE_DEVICE_CONFIG_ENABLE_SOFTWARE_UPDATE_MANAGER
-    SoftwareUpdateMgr().OnPlatformEvent(event);
-#endif
 #if WEAVE_DEVICE_CONFIG_ENABLE_TRAIT_MANAGER
     TraitMgr().OnPlatformEvent(event);
 #endif // WEAVE_DEVICE_CONFIG_ENABLE_TRAIT_MANAGER

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericSoftwareUpdateManagerImpl.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericSoftwareUpdateManagerImpl.h
@@ -53,7 +53,6 @@ protected:
     bool _IsInProgress(void);
     SoftwareUpdateManager::State _GetState(void);
 
-    void _OnPlatformEvent(const WeaveDeviceEvent * event);
     void _SetRetryPolicyCallback(const SoftwareUpdateManager::RetryPolicyCallback aRetryPolicyCallback);
 
     static void _DefaultEventHandler(void *apAppState, SoftwareUpdateManager::EventType aEvent,
@@ -131,7 +130,6 @@ private:
 
     PacketBuffer * mImageQueryPacketBuffer;
 
-    bool mHaveServiceConnectivity;
     bool mScheduledCheckEnabled;
     bool mShouldRetry;
     bool mIgnorePartialImage;
@@ -161,4 +159,3 @@ extern template class Internal::GenericSoftwareUpdateManagerImpl<SoftwareUpdateM
 
 // #endif // WEAVE_DEVICE_CONFIG_ENABLE_SOFTWARE_UPDATE_MANAGER
 #endif // GENERIC_SOFTWARE_UPDATE_MANAGER_IMPL_H
-


### PR DESCRIPTION
The existing behavior reset the software timers based on connectivity
to the service: when connectivity to the service was lost, the exiting
timer was cancelled, and when connectivity to the service was
restored, the idle timer was restored.  The intended effect was to
avoid software update checks when they were doomed to fail (service
unreachable) while preventing "thundering herd" behavior on service
outages.  However, the actual most common behavior was to reset the
long-running timer on any flapping in Thread network connectivity.

The solution is to just use the software update timer policy,
oblivious to the service connectivity.  The new code fails eagerly in
`PrepareBinding` when there is no service connectivity, which
generates no useless network activity.  The platform events are only
used to track whether we have a chance to succeed in contacting the
service.  Existing behavior already addresses the group behavior in
the event of mass service recovery -- the timer policy implements a
long, randomized background check, followed by randomized, exponential
backoff retry that ultimately reverts to the background rate.  In the
event of a synchronized start of a population of devices -- e.g. power
outage for line powered devices -- existing behavior also ensures
protection againts "thundering herds".