### PR TITLE
Fixup Python3 support in Device Manager /WoBLE code on Linux

### DIFF
--- a/src/device-manager/python/openweave/WeaveBleUtility.py
+++ b/src/device-manager/python/openweave/WeaveBleUtility.py
@@ -53,7 +53,7 @@ CBCharacteristicWriteWithoutResponse = 1
 def _VoidPtrToUUIDString(ptr, len):
     try:
         ptr = _VoidPtrToByteArray(ptr, len)
-        ptr = binascii.hexlify(ptr)
+        ptr = binascii.hexlify(ptr).decode()
         ptr = ptr[:8] + '-' + ptr[8:12] + '-' + ptr[12:16] + '-' + ptr[16:20] + '-' + ptr[20:]
         ptr = str(ptr)
     except:
@@ -100,11 +100,11 @@ class BleTxEvent:
 
         if self.SvcId:
             print("%sSvcId:" % (prefix))
-            print(binascii.hexlify(self.SvcId))
+            print(binascii.hexlify(self.SvcId).decode())
 
         if self.CharId:
             print("%sCharId:" % (prefix))
-            print(binascii.hexlify(self.CharId))
+            print(binascii.hexlify(self.CharId).decode())
 
     def SetField(self, name, val):
         name = name.lower()
@@ -150,15 +150,15 @@ class BleRxEvent:
         print("%sBleEvent Type: %s" % (prefix, ("RX" if self.EventType == BleEventType_Rx else "ERROR")))
         if self.Buffer:
             print("%sBuffer:" % (prefix))
-            print(binascii.hexlify(self.Buffer))
+            print(binascii.hexlify(self.Buffer).decode())
 
         if self.SvcId:
             print("%sSvcId:" % (prefix))
-            print(binascii.hexlify(self.SvcId))
+            print(binascii.hexlify(self.SvcId).decode())
 
         if self.CharId:
             print("%sCharId:" % (prefix))
-            print(binascii.hexlify(self.CharId))
+            print(binascii.hexlify(self.CharId).decode())
 
     def SetField(self, name, val):
         name = name.lower()
@@ -189,11 +189,11 @@ class BleSubscribeEvent:
 
         if self.SvcId:
             print("%sSvcId:" % (prefix))
-            print(binascii.hexlify(self.SvcId))
+            print(binascii.hexlify(self.SvcId).decode())
 
         if self.CharId:
             print("%sCharId:" % (prefix))
-            print(binascii.hexlify(self.CharId))
+            print(binascii.hexlify(self.CharId).decode())
 
     def SetField(self, name, val):
         name = name.lower()

--- a/src/device-manager/python/openweave/WeaveBluezMgr.py
+++ b/src/device-manager/python/openweave/WeaveBluezMgr.py
@@ -279,7 +279,10 @@ class BluezDbusDevice():
         self.path = self.device.object_path
         self.device_event = threading.Event()
         if self.Name:
-            self.device_id = uuid.uuid3(uuid.NAMESPACE_DNS, self.Name.encode('utf-8'))
+            try:
+                self.device_id = uuid.uuid3(uuid.NAMESPACE_DNS, self.Name)
+            except UnicodeDecodeError:
+                self.device_id = uuid.uuid3(uuid.NAMESPACE_DNS, self.Name.encode('utf-8'))
         else:
             self.device_id = uuid.uuid4()
         self.bluez = bluez
@@ -987,10 +990,10 @@ class BluezManager(WeaveBleBase):
         self.logger.debug("write start")
         result = False
         if self.target and self.target.Connected:
-            converted_data = str(_VoidPtrToByteArray(buffer, length))
+            converted_data = _VoidPtrToByteArray(buffer, length)
             self.charId_tx = bytearray(uuid.UUID(str(_VoidPtrToUUIDString(charId, 16))).bytes)
             self.svcId_tx = bytearray(uuid.UUID(str(_VoidPtrToUUIDString(svcId, 16))).bytes)
-            self.tx.WriteValue(dbus.Array([dbus.Byte(ord(i)) for i in converted_data], 'y'),
+            self.tx.WriteValue(dbus.Array([dbus.Byte(i) for i in converted_data], 'y'),
                                options="",
                                reply_handler=self.WriteCharactertisticSuccessCB,
                                error_handler=self.WriteCharactertisticErrorCB,

--- a/src/device-manager/python/openweave/WeaveCoreBluetoothMgr.py
+++ b/src/device-manager/python/openweave/WeaveCoreBluetoothMgr.py
@@ -58,7 +58,7 @@ chromecast_setup_service_short = CBUUID.UUIDWithString_(u'FEA0')
 def _VoidPtrToCBUUID(ptr, len):
     try:
         ptr = _VoidPtrToByteArray(ptr, len)
-        ptr = binascii.hexlify(ptr)
+        ptr = binascii.hexlify(ptr).decode()
         ptr = ptr[:8] + '-' + ptr[8:12] + '-' + ptr[12:16] + '-' + ptr[16:20] + '-' + ptr[20:]
         ptr = CBUUID.UUIDWithString_(ptr)
     except:


### PR DESCRIPTION
Bluez code contained a number of issues that were not caught earlier:

* `dbus.String` is essentially a string in Python3 but must be encoded
  in Python 2 if we want to use it with any modules that expect a
  string

* binascii.hexlify() returns a binary string. As such, it should
  always be decoded

* Better handling bytearrays -- avoid unnecessary conversions to
  string.