### PR TITLE
Weave time stray const

### DIFF
--- a/src/lib/profiles/time/WeaveTime.h
+++ b/src/lib/profiles/time/WeaveTime.h
@@ -1245,7 +1245,7 @@ protected:
     WEAVE_ERROR SendSyncRequest(void);
 
     void SetClientState(const ClientState state);
-    const char * const GetClientStateName(void) const;
+    const char * GetClientStateName(void) const;
 
     static void HandleTimeChangeNotification(ExchangeContext *aEC, const IPPacketInfo *aPktInfo,
         const WeaveMessageInfo *aMsgInfo, uint32_t aProfileId, uint8_t aMsgType, PacketBuffer *aPayload);

--- a/src/lib/profiles/time/WeaveTimeClient.cpp
+++ b/src/lib/profiles/time/WeaveTimeClient.cpp
@@ -2669,7 +2669,7 @@ void SingleSourceTimeSyncClient::HandleTimeChangeNotification(ExchangeContext *a
     }
 }
 
-const char * const SingleSourceTimeSyncClient::GetClientStateName(void) const
+const char * SingleSourceTimeSyncClient::GetClientStateName(void) const
 {
     const char * stateName = NULL;
 


### PR DESCRIPTION
The `{ NULL } -> { }` is a bit of a RFC.  It resolves -Wmissing-field-initializers warnings, and I think it results in default-0 values in most C and C++ compilers.  RFC?