### PR TITLE
Python3 compatibility for DeviceManager

### DIFF
--- a/src/device-manager/python/build-openweave-wheel.py
+++ b/src/device-manager/python/build-openweave-wheel.py
@@ -162,8 +162,9 @@ try:
             'License :: OSI Approved :: Apache Software License',
             'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
         ],
-        python_requires='>=2.7, <3',
+        python_requires='>=2.7',
         packages=[
             'openweave'                     # Arrange to install a package named "openweave"
         ],

--- a/src/device-manager/python/openweave/WeaveDeviceMgr.py
+++ b/src/device-manager/python/openweave/WeaveDeviceMgr.py
@@ -100,7 +100,7 @@ def _VoidPtrToByteArray(ptr, len):
 
 def _ByteArrayToVoidPtr(array):
     if array != None:
-        if not (isinstance(array, str) or isinstance(array, bytearray)):
+        if not (isinstance(array, bytes) or isinstance(array, bytearray)):
             raise TypeError("Array must be an str or a bytearray")
         return cast( (c_byte * len(array)) .from_buffer_copy(array), c_void_p)
     else:
@@ -853,6 +853,9 @@ class WeaveDeviceManager(object):
 
         cbHandlePairTokenComplete = _PairTokenCompleteFunct(HandlePairTokenComplete)
 
+        if pairingToken is not None and isinstance(pairingToken, str):
+            pairingToken = _StringToCString(pairingToken)
+
         return self._CallDevMgrAsync(
             lambda: _dmLib.nl_Weave_DeviceManager_PairToken(self.devMgr, _ByteArrayToVoidPtr(pairingToken), len(pairingToken), cbHandlePairTokenComplete, self.cbHandleError)
         )
@@ -1016,6 +1019,12 @@ class WeaveDeviceManager(object):
     def RegisterServicePairAccount(self, serviceId, accountId, serviceConfig, pairingToken, pairingInitData):
         if accountId is not None and '\x00' in accountId:
             raise ValueError("Unexpected NUL character in accountId")
+
+        if pairingToken is not None and isinstance(pairingToken, str):
+            pairingToken = _StringToCString(pairingToken)
+
+        if pairingInitData is not None and isinstance(pairingInitData, str):
+            pairingInitData = _StringToCString(pairingInitData)
 
         self._CallDevMgrAsync(
             lambda: _dmLib.nl_Weave_DeviceManager_RegisterServicePairAccount(self.devMgr, serviceId, _StringToCString(accountId),


### PR DESCRIPTION
A few missing bits that made it past the previous changes:
* _BytesArrayToVoidPtr operates on `bytes` class rather than on `str`
class.  In Python 2, `bytes` is merely an alias for `str` so no
changes required, in Python3, `bytes` is the binary string returned by
various utilities such as `base64.b64decode()`
* Wheel packaging changed to reflect that the package is expected to
work on Python3.