### PR TITLE
add kStatus_InvalidValueInUpdate

### DIFF
--- a/src/lib/profiles/data-management/Current/MessageDef.h
+++ b/src/lib/profiles/data-management/Current/MessageDef.h
@@ -131,6 +131,7 @@ enum
     kStatus_IncompatibleDataSchemaVersion = 0x2B,
     kStatus_MultipleFailures              = 0x2C,
     kStatus_UpdateOutOfSequence           = 0x2D,
+    kStatus_InvalidValueInUpdate          = 0x2E,
 };
 
 // TODO: The type is only used in a few places. We should use it everywhere.

--- a/src/lib/profiles/data-management/Current/SubscriptionEngine.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionEngine.cpp
@@ -1655,6 +1655,12 @@ void SubscriptionEngine::BuildStatusDataHandleElement(PacketBuffer * pBuf, Trait
         statusCode = kStatus_VersionMismatch;
         err        = WEAVE_NO_ERROR;
     }
+    else if (WEAVE_ERROR_WRONG_TLV_TYPE == err)
+    {
+        profileId  = Weave::Profiles::kWeaveProfile_WDM;
+        statusCode = kStatus_InvalidValueInUpdate;
+        err        = WEAVE_NO_ERROR;
+    }
     else if (WEAVE_NO_ERROR == err)
     {
         profileId  = Weave::Profiles::kWeaveProfile_Common;


### PR DESCRIPTION
-- add kStatus_InvalidValueInUpdate to represent data element value error in wdm
profie.
-- when processing update request, we need to skip this DE when DE generates
WEAVE_ERROR_WRONG_TLV_TYPE.