### PR TITLE
Network Provisioning: Support for wireless regulatory provisioning

### DIFF
--- a/src/device-manager/WeaveDeviceManager.h
+++ b/src/device-manager/WeaveDeviceManager.h
@@ -35,6 +35,7 @@
 #include <Weave/Profiles/device-description/DeviceDescription.h>
 #include <Weave/Profiles/network-provisioning/NetworkProvisioning.h>
 #include <Weave/Profiles/network-provisioning/NetworkInfo.h>
+#include <Weave/Profiles/network-provisioning/WirelessRegConfig.h>
 #include <Weave/Profiles/security/WeaveSecurity.h>
 #include <Weave/Profiles/security/WeaveCASE.h>
 #include <Weave/Profiles/security/WeaveSig.h>
@@ -89,6 +90,7 @@ typedef void (*ConnectionClosedFunc)(WeaveDeviceManager *deviceMgr, void *appReq
 typedef void (*PairTokenCompleteFunct)(WeaveDeviceManager *deviceMgr, void *appReqState, const uint8_t *tokenPairingBundle, uint32_t tokenPairingBunldeLen);
 typedef void (*UnpairTokenCompleteFunct)(WeaveDeviceManager *deviceMgr, void *appReqState);
 typedef void (*GetCameraAuthDataCompleteFunct)(WeaveDeviceManager *deviceMgr, void *appReqState, const char *macAddress, const char *authData);
+typedef void (*GetWirelessRegulatoryConfigCompleteFunct)(WeaveDeviceManager *deviceMgr, void *appReqState, const WirelessRegConfig *regConfig);
 };
 
 class NL_DLL_EXPORT WeaveDeviceManager : private Security::CASE::WeaveCASEAuthDelegate
@@ -209,6 +211,8 @@ public:
             ErrorFunct onError);
     WEAVE_ERROR GetRendezvousMode(void* appReqState, GetRendezvousModeCompleteFunct onComplete, ErrorFunct onError);
     WEAVE_ERROR SetRendezvousMode(uint16_t modeFlags, void* appReqState, CompleteFunct onComplete, ErrorFunct onError);
+    WEAVE_ERROR GetWirelessRegulatoryConfig(void* appReqState, GetWirelessRegulatoryConfigCompleteFunct onComplete, ErrorFunct onError);
+    WEAVE_ERROR SetWirelessRegulatoryConfig(const WirelessRegConfig *regConfig, void* appReqState, CompleteFunct onComplete, ErrorFunct onError);
     WEAVE_ERROR GetLastNetworkProvisioningResult(void* appReqState, CompleteFunct onComplete, ErrorFunct onError);
 
     // ----- Fabric Provisioning -----
@@ -300,36 +304,38 @@ private:
         kOpState_UnpairToken                            = 41,
         kOpState_GetCameraAuthData                      = 42,
         kOpState_EnumerateDevices                       = 43,
-        kOpState_RemotePassiveRendezvousTimedOut        = 44
+        kOpState_RemotePassiveRendezvousTimedOut        = 44,
+        kOpState_GetWirelessRegulatoryConfig            = 45,
+        kOpState_SetWirelessRegulatoryConfig            = 46,
     };
 
     enum ConnectionState
     {
-        kConnectionState_NotConnected                             = 0,
-        kConnectionState_WaitDeviceConnect                        = 1,
-        kConnectionState_IdentifyDevice                           = 2,
-        kConnectionState_ConnectDevice                            = 3,
-        kConnectionState_StartSession                             = 4,
-        kConnectionState_ReenableConnectionMonitor                = 5,
-        kConnectionState_Connected                                = 6,
-        kConnectionState_IdentifyRemoteDevice                     = 7
+        kConnectionState_NotConnected                    = 0,
+        kConnectionState_WaitDeviceConnect               = 1,
+        kConnectionState_IdentifyDevice                  = 2,
+        kConnectionState_ConnectDevice                   = 3,
+        kConnectionState_StartSession                    = 4,
+        kConnectionState_ReenableConnectionMonitor       = 5,
+        kConnectionState_Connected                       = 6,
+        kConnectionState_IdentifyRemoteDevice            = 7
     };
 
     enum
     {
-        kMaxPairingCodeLength                   = 16,
+        kMaxPairingCodeLength                            = 16,
 
-        kConRetryInterval                       = 500,  // ms
-        kEnumerateDevicesRetryInterval          = 500, // ms
-        kSessionRetryInterval                   = 1000, // ms
-        kMaxSessionRetryCount                   = 20,
+        kConRetryInterval                                = 500,  // ms
+        kEnumerateDevicesRetryInterval                   = 500, // ms
+        kSessionRetryInterval                            = 1000, // ms
+        kMaxSessionRetryCount                            = 20,
     };
 
     enum
     {
-        kAuthType_None                          = 0,
-        kAuthType_PASEWithPairingCode           = 1,
-        kAuthType_CASEWithAccessToken           = 2
+        kAuthType_None                                   = 0,
+        kAuthType_PASEWithPairingCode                    = 1,
+        kAuthType_CASEWithAccessToken                    = 2
     };
 
     enum
@@ -370,6 +376,7 @@ private:
         UnpairTokenCompleteFunct UnpairToken;
         GetCameraAuthDataCompleteFunct GetCameraAuthData;
         DeviceEnumerationResponseFunct DeviceEnumeration;
+        GetWirelessRegulatoryConfigCompleteFunct GetWirelessRegulatoryConfig;
     } mOnComplete;
     CompleteFunct mOnRemotePassiveRendezvousComplete;
     ErrorFunct mOnError;

--- a/src/device-manager/java/WeaveDeviceManager-JNI.cpp
+++ b/src/device-manager/java/WeaveDeviceManager-JNI.cpp
@@ -3519,7 +3519,7 @@ WEAVE_ERROR J2N_WirelessRegulatoryConfig(JNIEnv *env, jobject inRegConfig, Wirel
         memcpy(outRegConfig.RegDomain.Code, strVal, sizeof(outRegConfig.RegDomain.Code));
     }
 
-    err = J2N_EnumFieldVal(env, inRegConfig, "OpLocation", "Lnl/Weave/DeviceManager/OperatingLocation;", enumVal);
+    err = J2N_EnumFieldVal(env, inRegConfig, "OpLocation", "Lnl/Weave/DeviceManager/WirelessOperatingLocation;", enumVal);
     SuccessOrExit(err);
     outRegConfig.OpLocation = (uint8_t)enumVal;
 
@@ -3536,7 +3536,7 @@ exit:
 WEAVE_ERROR N2J_WirelessRegulatoryConfig(JNIEnv *env, const WirelessRegConfig& inRegConfig, jobject& outRegConfig)
 {
     WEAVE_ERROR err = WEAVE_NO_ERROR;
-    jmethodID makeMethod;
+    jmethodID constructor;
     jstring regDomain = NULL;
     jobjectArray supportedRegDomains = NULL;
     jclass java_lang_String = NULL;
@@ -3560,11 +3560,11 @@ WEAVE_ERROR N2J_WirelessRegulatoryConfig(JNIEnv *env, const WirelessRegConfig& i
         });
     SuccessOrExit(err);
 
-    makeMethod = env->GetStaticMethodID(sWirelessRegulatoryConfigCls, "Make", "(Ljava/lang/String;I[Ljava/lang/String;)Lnl/Weave/DeviceManager/WirelessRegulatoryConfig;");
-    VerifyOrExit(makeMethod != NULL, err = WDM_JNI_ERROR_METHOD_NOT_FOUND);
+    constructor = env->GetMethodID(sWirelessRegulatoryConfigCls, "<init>", "(Ljava/lang/String;I[Ljava/lang/String;)V");
+    VerifyOrExit(constructor != NULL, err = WDM_JNI_ERROR_METHOD_NOT_FOUND);
 
     env->ExceptionClear();
-    outRegConfig = env->CallStaticObjectMethod(sWirelessRegulatoryConfigCls, makeMethod,
+    outRegConfig = (jthrowable)env->NewObject(sWirelessRegulatoryConfigCls, constructor,
             regDomain, (jint)inRegConfig.OpLocation, supportedRegDomains);
     VerifyOrExit(!env->ExceptionCheck(), err = WDM_JNI_ERROR_EXCEPTION_THROWN);
 

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/TestMain.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/TestMain.java
@@ -834,7 +834,7 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
         TestResult = null;
         System.out.println("SetWirelessRegulatoryConfig Test");
         System.out.println("    Setting wireless regulatory configuration...");
-        WirelessRegulatoryConfig regConfig = WirelessRegulatoryConfig.Make("CA", WirelessOperatingLocation.Indoors.val, null);
+        WirelessRegulatoryConfig regConfig = new WirelessRegulatoryConfig("CA", WirelessOperatingLocation.Indoors);
         DeviceMgr.beginSetWirelessRegulatoryConfig(regConfig);
         ExpectSuccess("SetWirelessRegulatoryConfig");
         System.out.println("SetWirelessRegulatoryConfig Test Succeeded");

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/TestMain.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/TestMain.java
@@ -794,7 +794,7 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
         System.out.println("    Adding new Thread network...");
         networkInfo = NetworkInfo.MakeThread("Thread-Test",
                                         parseHexBinary("0102030405060708"),
-                                        "akey".getBytes(),
+                                        parseHexBinary("0102030405060708090A0B0C0D0E0F10"),
                                         0x1234,
                                         (byte)21);
         DeviceMgr.beginAddNetwork(networkInfo);
@@ -823,6 +823,21 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
         DeviceMgr.beginGetNetworks(GetNetworkFlags.None);
         ExpectSuccess("GetNetworks");
         System.out.println("GetNetworks Test Succeeded");
+
+        TestResult = null;
+        System.out.println("GetWirelessRegulatoryConfig Test");
+        System.out.println("    Getting wireless regulatory configuration...");
+        DeviceMgr.beginGetWirelessRegulatoryConfig();
+        ExpectSuccess("GetWirelessRegulatoryConfig");
+        System.out.println("GetWirelessRegulatoryConfig Test Succeeded");
+
+        TestResult = null;
+        System.out.println("SetWirelessRegulatoryConfig Test");
+        System.out.println("    Setting wireless regulatory configuration...");
+        WirelessRegulatoryConfig regConfig = WirelessRegulatoryConfig.Make("CA", WirelessOperatingLocation.Indoors.val, null);
+        DeviceMgr.beginSetWirelessRegulatoryConfig(regConfig);
+        ExpectSuccess("SetWirelessRegulatoryConfig");
+        System.out.println("SetWirelessRegulatoryConfig Test Succeeded");
 
         TestResult = null;
         System.out.println("GetCameraAuthData Test");
@@ -914,8 +929,8 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
             try { Thread.sleep(100); }
             catch (Exception ex) { }
 
-        if (TestResult != expectedResult) {
-            if (expectedResult != "Success")
+        if (!TestResult.equals(expectedResult)) {
+            if (!expectedResult.equals("Success"))
                 System.out.format("%s test failed:%n    Expected: %s%n    Got: %s%n", testName, expectedResult, TestResult);
             else
                 System.out.format("%s test failed: %s%n", testName, TestResult);
@@ -1090,6 +1105,27 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
     public void onUnpairTokenComplete()
     {
         System.out.println("    Unpair token complete");
+        TestResult = "Success";
+    }
+
+    public void onGetWirelessRegulatoryConfigComplete(WirelessRegulatoryConfig regConfig)
+    {
+        System.out.println("    Get wireless regulatory config complete");
+        System.out.format("        RegDomain = %s%n", regConfig.RegDomain);
+        System.out.format("        OpLocation = %d%n", regConfig.OpLocation.val);
+        System.out.format("        SupportedRegDomains = ");
+        for (String regDomain : regConfig.SupportedRegDomains)
+            System.out.format("%s ", regDomain);
+        System.out.format("%n");
+        if (regConfig.RegDomain.equals("US"))
+            TestResult = "Success";
+        else
+            TestResult = "Incorrect regulatory domain";
+    }
+    
+    public void onSetWirelessRegulatoryConfigComplete()
+    {
+        System.out.format("    Set wireless regulatory config complete:%n");
         TestResult = "Success";
     }
 

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/WeaveDeviceManager.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/WeaveDeviceManager.java
@@ -412,6 +412,16 @@ public class WeaveDeviceManager
         beginUnpairToken(mDeviceMgrPtr);
     }
 
+    public void beginGetWirelessRegulatoryConfig()
+    {
+        beginGetWirelessRegulatoryConfig(mDeviceMgrPtr);
+    }
+
+    public void beginSetWirelessRegulatoryConfig(WirelessRegulatoryConfig regConfig)
+    {
+        beginSetWirelessRegulatoryConfig(mDeviceMgrPtr, regConfig);
+    }
+
     public void setRendezvousAddress(String rendezvousAddr)
     {
         setRendezvousAddress(mDeviceMgrPtr, rendezvousAddr);
@@ -628,6 +638,16 @@ public class WeaveDeviceManager
         }
     }
 
+    public void onGetWirelessRegulatoryConfigComplete(WirelessRegulatoryConfig regConfig)
+    {
+        mCompHandler.onGetWirelessRegulatoryConfigComplete(regConfig);
+    }
+    
+    public void onSetWirelessRegulatoryConfigComplete()
+    {
+        mCompHandler.onSetWirelessRegulatoryConfigComplete();
+    }
+
     public void onError(Throwable err)
     {
         mCompHandler.onError(err);
@@ -683,6 +703,8 @@ public class WeaveDeviceManager
         void onStopSystemTestComplete();
         void onError(Throwable err);
         void onDeviceEnumerationResponse(WeaveDeviceDescriptor deviceDesc, String deviceAddr);
+        void onGetWirelessRegulatoryConfigComplete(WirelessRegulatoryConfig regConfig);
+        void onSetWirelessRegulatoryConfigComplete();
     }
 
     public static native boolean isValidPairingCode(String pairingCode);
@@ -782,6 +804,8 @@ public class WeaveDeviceManager
     private native void beginDisableConnectionMonitor(long deviceMgrPtr);
     private native void beginPairToken(long deviceMgrPtr, byte[] pairingToken);
     private native void beginUnpairToken(long deviceMgrPtr);
+    private native void beginGetWirelessRegulatoryConfig(long deviceMgrPtr);
+    private native void beginSetWirelessRegulatoryConfig(long deviceMgrPtr, WirelessRegulatoryConfig regConfig);
     private native void close(long deviceMgrPtr);
     private native boolean isConnected(long deviceMgrPtr);
     private native long deviceId(long deviceMgrPtr);

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/WirelessOperatingLocation.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/WirelessOperatingLocation.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package nl.Weave.DeviceManager;
+
+/** 
+ * Device operating location, as relevant to wireless regulatory rules.
+ */
+public enum WirelessOperatingLocation
+{
+    NotSpecified(0),
+    Unknown(1),
+    Indoors(2),
+    Outdoors(3);
+
+    WirelessOperatingLocation(int v)
+    {
+        val = v;
+    }
+
+    public final int val;
+
+    public static WirelessOperatingLocation fromVal(int val)
+    {
+        for (WirelessOperatingLocation enumVal : WirelessOperatingLocation.values())
+            if (enumVal.val == val)
+                return enumVal;
+        return NotSpecified;
+    }
+}

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/WirelessRegulatoryConfig.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/WirelessRegulatoryConfig.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *    Copyright (c) 2019 Google LLC
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package nl.Weave.DeviceManager;
+
+/**
+ * Container for wireless regulatory configuration information.
+ */
+public class WirelessRegulatoryConfig
+{
+    /** Active wireless regulatory domain.
+     */
+    public String RegDomain;
+
+    /** Active operating location.
+     */
+    public WirelessOperatingLocation OpLocation;
+    
+    /** Supported regulatory domains
+     */
+    public String[] SupportedRegDomains;
+    
+    public WirelessRegulatoryConfig()
+    {
+        RegDomain = null;
+        OpLocation = WirelessOperatingLocation.NotSpecified;
+        SupportedRegDomains = null;
+    }
+    
+    public static WirelessRegulatoryConfig Make(String regDomain, int opLocation, String[] supportedRegDomains)
+    {
+        WirelessRegulatoryConfig regConfig = new WirelessRegulatoryConfig();
+        regConfig.RegDomain = regDomain;
+        regConfig.OpLocation = WirelessOperatingLocation.fromVal(opLocation);
+        regConfig.SupportedRegDomains = supportedRegDomains;
+        return regConfig;
+    }
+};

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/WirelessRegulatoryConfig.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/WirelessRegulatoryConfig.java
@@ -21,33 +21,39 @@ package nl.Weave.DeviceManager;
 /**
  * Container for wireless regulatory configuration information.
  */
-public class WirelessRegulatoryConfig
+public final class WirelessRegulatoryConfig
 {
     /** Active wireless regulatory domain.
      */
-    public String RegDomain;
+    public final String RegDomain;
 
     /** Active operating location.
      */
-    public WirelessOperatingLocation OpLocation;
+    public final WirelessOperatingLocation OpLocation;
     
     /** Supported regulatory domains
      */
-    public String[] SupportedRegDomains;
+    public final String[] SupportedRegDomains;
     
-    public WirelessRegulatoryConfig()
+    public WirelessRegulatoryConfig(String regDomain, WirelessOperatingLocation opLocation)
     {
-        RegDomain = null;
-        OpLocation = WirelessOperatingLocation.NotSpecified;
-        SupportedRegDomains = null;
+		this.RegDomain = regDomain;
+		this.OpLocation = opLocation;
+		this.SupportedRegDomains = new String[0];
+    }
+
+    public WirelessRegulatoryConfig(String regDomain, WirelessOperatingLocation opLocation, String[] supportedRegDomains)
+    {
+        this.RegDomain = regDomain;
+        this.OpLocation = opLocation;
+        this.SupportedRegDomains = supportedRegDomains.clone();
     }
     
-    public static WirelessRegulatoryConfig Make(String regDomain, int opLocation, String[] supportedRegDomains)
+    // Convenience constructor for JNI code
+    WirelessRegulatoryConfig(String regDomain, int opLocation, String[] supportedRegDomains)
     {
-        WirelessRegulatoryConfig regConfig = new WirelessRegulatoryConfig();
-        regConfig.RegDomain = regDomain;
-        regConfig.OpLocation = WirelessOperatingLocation.fromVal(opLocation);
-        regConfig.SupportedRegDomains = supportedRegDomains;
-        return regConfig;
+        this.RegDomain = regDomain;
+        this.OpLocation = WirelessOperatingLocation.fromVal(opLocation);
+        this.SupportedRegDomains = supportedRegDomains;
     }
 };

--- a/src/device-manager/python/WeaveDeviceManager-ScriptBinding.cpp
+++ b/src/device-manager/python/WeaveDeviceManager-ScriptBinding.cpp
@@ -219,6 +219,8 @@ extern "C" {
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_TestNetworkConnectivity(WeaveDeviceManager *devMgr, uint32_t networkId, CompleteFunct onComplete, ErrorFunct onError);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_GetRendezvousMode(WeaveDeviceManager *devMgr, GetRendezvousModeCompleteFunct onComplete, ErrorFunct onError);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetRendezvousMode(WeaveDeviceManager *devMgr, uint16_t modeFlags, CompleteFunct onComplete, ErrorFunct onError);
+    NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_GetWirelessRegulatoryConfig(WeaveDeviceManager *devMgr, GetWirelessRegulatoryConfigCompleteFunct onComplete, ErrorFunct onError);
+    NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_SetWirelessRegulatoryConfig(WeaveDeviceManager *devMgr, const WirelessRegConfig *regConfig, CompleteFunct onComplete, ErrorFunct onError);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_GetLastNetworkProvisioningResult(WeaveDeviceManager *devMgr, CompleteFunct onComplete, ErrorFunct onError);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_CreateFabric(WeaveDeviceManager *devMgr, CompleteFunct onComplete, ErrorFunct onError);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_DeviceManager_LeaveFabric(WeaveDeviceManager *devMgr, CompleteFunct onComplete, ErrorFunct onError);
@@ -898,6 +900,16 @@ WEAVE_ERROR nl_Weave_DeviceManager_GetRendezvousMode(WeaveDeviceManager *devMgr,
 WEAVE_ERROR nl_Weave_DeviceManager_SetRendezvousMode(WeaveDeviceManager *devMgr, uint16_t modeFlags, CompleteFunct onComplete, ErrorFunct onError)
 {
     return devMgr->SetRendezvousMode(modeFlags, NULL, onComplete, onError);
+}
+
+WEAVE_ERROR nl_Weave_DeviceManager_GetWirelessRegulatoryConfig(WeaveDeviceManager *devMgr, GetWirelessRegulatoryConfigCompleteFunct onComplete, ErrorFunct onError)
+{
+    return devMgr->GetWirelessRegulatoryConfig(NULL, onComplete, onError);
+}
+
+WEAVE_ERROR nl_Weave_DeviceManager_SetWirelessRegulatoryConfig(WeaveDeviceManager *devMgr, const WirelessRegConfig *regConfig, CompleteFunct onComplete, ErrorFunct onError)
+{
+    return devMgr->SetWirelessRegulatoryConfig(regConfig, NULL, onComplete, onError);
 }
 
 WEAVE_ERROR nl_Weave_DeviceManager_GetLastNetworkProvisioningResult(WeaveDeviceManager *devMgr, CompleteFunct onComplete, ErrorFunct onError)

--- a/src/device-manager/python/weave-device-mgr.py
+++ b/src/device-manager/python/weave-device-mgr.py
@@ -249,6 +249,8 @@ class DeviceMgrCmd(Cmd):
         'disable-network',
         'test-network',
         'set-rendezvous-mode',
+        'get-wireless-reg-config',
+        'set-wireless-reg-config',
         'ping',
         'identify',
         'create-fabric',
@@ -1678,6 +1680,78 @@ class DeviceMgrCmd(Cmd):
             return
 
         print("Set rendezvous mode complete")
+
+    def do_getwirelessregconfig(self, line):
+        """
+          get-wireless-reg-config
+
+          Get the wireless regulatory configuration for the device.
+        """
+
+        args = shlex.split(line)
+
+        if (len(args) > 0):
+            print("Unexpected argument: " + args[0])
+            return
+
+        try:
+            getResult = self.devMgr.GetWirelessRegulatoryConfig()
+        except WeaveStack.WeaveStackException as ex:
+            print(str(ex))
+            return
+
+        print("Get wireless regulatory configuration complete:")
+        getResult.Print(prefix='  ')
+
+    def do_setwirelessregconfig(self, line):
+        """
+          set-wireless-reg-config <reg-domain> [ <op-mode> ]
+
+          Set the wireless regulatory configuration for the device.
+          
+            <reg-domain> : 2-character wireless regulatory domain code
+            
+            <op-mode> : Device operating location
+            
+              unknown -- The operating location of the device is unknown or varies.
+              indoors -- The device will be operated indoors.
+              outdoors -- The device will be operated outdoors.
+        """
+
+        args = shlex.split(line)
+
+        if (len(args) < 1):
+            print("Please specify the wireless regulatory domain code")
+            return
+        
+        if (len(args) > 2):
+            print("Unexpected argument: " + args[0])
+            return
+        
+        regDomain = args[0].upper()
+        opLocation = args[1] if (len(args) > 1) else None
+
+        if len(regDomain) != 2:
+            print('Invalid wireless regulatory domain code: %s' % regDomain)
+            print('Regulatory domain codes must be exactly 2 characters')
+            return
+        
+        if opLocation != None:
+            try:
+                opLocation = WeaveDeviceMgr.ParseOperatingLocation(opLocation)
+            except Exception as ex:
+                print(str(ex))
+                return
+            
+        regConfig = WeaveDeviceMgr.WirelessRegConfig(regDomain=regDomain, opLocation=opLocation)
+        
+        try:
+            self.devMgr.SetWirelessRegulatoryConfig(regConfig)
+        except WeaveStack.WeaveStackException as ex:
+            print(str(ex))
+            return
+
+        print("Set wireless regulatory configuration complete")
 
     def do_getlastnetworkprovisioningresult(self, line):
         """

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -704,6 +704,7 @@ $(NULL)
 nl_public_WeaveProfiles_network_provisioning_header_sources = \
 $(nl_public_WeaveProfiles_source_dirstem)/network-provisioning/NetworkInfo.h         \
 $(nl_public_WeaveProfiles_source_dirstem)/network-provisioning/NetworkProvisioning.h \
+$(nl_public_WeaveProfiles_source_dirstem)/network-provisioning/WirelessRegConfig.h \
 $(NULL)
 
 nl_public_WeaveProfiles_security_header_sources = \

--- a/src/lib/profiles/WeaveProfiles.am
+++ b/src/lib/profiles/WeaveProfiles.am
@@ -65,6 +65,7 @@ nl_WeaveProfiles_sources                                                        
     @top_builddir@/src/lib/profiles/heartbeat/WeaveHeartbeatReceiver.cpp                \
     @top_builddir@/src/lib/profiles/heartbeat/WeaveHeartbeatSender.cpp                  \
     @top_builddir@/src/lib/profiles/network-provisioning/NetworkProvisioning.cpp        \
+    @top_builddir@/src/lib/profiles/network-provisioning/WirelessRegConfig.cpp          \
     @top_builddir@/src/lib/profiles/security/ApplicationKeysTrait.cpp                   \
     @top_builddir@/src/lib/profiles/security/ApplicationKeysTraitDataSink.cpp           \
     @top_builddir@/src/lib/profiles/security/WeaveAccessToken.cpp                       \

--- a/src/lib/profiles/network-provisioning/WirelessRegConfig.cpp
+++ b/src/lib/profiles/network-provisioning/WirelessRegConfig.cpp
@@ -1,0 +1,240 @@
+/*
+ *
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <Weave/Core/WeaveCore.h>
+#include <Weave/Support/CodeUtils.h>
+#include <Weave/Core/WeaveEncoding.h>
+#include <Weave/Profiles/WeaveProfiles.h>
+#include <Weave/Profiles/network-provisioning/NetworkProvisioning.h>
+#include <Weave/Profiles/network-provisioning/WirelessRegConfig.h>
+
+namespace nl {
+namespace Weave {
+namespace Profiles {
+namespace NetworkProvisioning {
+
+using namespace nl::Weave::Encoding;
+using namespace nl::Weave::TLV;
+
+/**
+ * A null wireless regulatory domain value.
+ *
+ * Note that this value cannot be sent over the wire.
+ */
+const WirelessRegDomain WirelessRegDomain::Null = { '\0', '\0' };
+
+/**
+ * Represents the special 'world-wide' wireless regulatory domain.
+ */
+const WirelessRegDomain WirelessRegDomain::WorldWide = { '0', '0' };
+
+/**
+ * Encode the object in Weave TLV format.
+ *
+ * @param[in]   writer                  A \c TLVWriter object to which the encoded data should
+ *                                      be written.
+ *
+ * @retval #WEAVE_NO_ERROR              On success.
+ * @retval other                        Other Weave or platform-specific error codes indicating
+ *                                      that an error occurred while encoding the data.
+ */
+WEAVE_ERROR WirelessRegConfig::Encode(TLVWriter & writer) const
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    TLVType outerContainer;
+
+    err = writer.StartContainer(AnonymousTag, kTLVType_Structure, outerContainer);
+    SuccessOrExit(err);
+
+    if (IsRegDomainPresent())
+    {
+        err = writer.PutString(ContextTag(kTag_WirelessRegConfig_RegulatoryDomain), RegDomain.Code, sizeof(RegDomain.Code));
+        SuccessOrExit(err);
+    }
+
+    if (IsOpLocationPresent())
+    {
+        err = writer.Put(ContextTag(kTag_WirelessRegConfig_OperatingLocation), OpLocation);
+        SuccessOrExit(err);
+    }
+
+    if (NumSupportedRegDomains > 0)
+    {
+        TLVType outerContainer2;
+
+        err = writer.StartContainer(ContextTag(kTag_WirelessRegConfig_SupportedRegulatoryDomains), kTLVType_Array, outerContainer2);
+        SuccessOrExit(err);
+
+        for (uint8_t i = 0; i < NumSupportedRegDomains; i++)
+        {
+            err = writer.PutString(AnonymousTag, SupportedRegDomains[i].Code, sizeof(SupportedRegDomains[i].Code));
+            SuccessOrExit(err);
+        }
+
+        err = writer.EndContainer(outerContainer2);
+        SuccessOrExit(err);
+    }
+
+    err = writer.EndContainer(outerContainer);
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+/**
+ * Populate the object from information encoded in Weave TLV format.
+ *
+ * The supplied \c TVLReader object must be position on or immediately before
+ * the TLV structure containing the information to be decoded.
+ *
+ * Prior to calling the method, the caller must initialize the \c SupportedRegDomains
+ * member to an array big enough to hold the decoded values, and set the
+ * \c NumSupportedRegDomains member to size of that array, in elements.
+ *
+ * @param[in]   reader                  A \c TVLReader object to which should be used to decode
+ *                                      the object information.
+ *
+ * @retval #WEAVE_NO_ERROR              On success.
+ * @retval other                        Other Weave or platform-specific error codes indicating
+ *                                      that an error occurred while decoding the encoded data.
+ */
+WEAVE_ERROR WirelessRegConfig::Decode(TLVReader & reader)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    TLVType outerContainer, outerContainer2;
+    uint16_t maxSupportedRegDomains;
+
+    maxSupportedRegDomains = NumSupportedRegDomains;
+    NumSupportedRegDomains = 0;
+
+    // If not already in position, advance the reader to the first element.
+    if (reader.GetType() == kTLVType_NotSpecified)
+    {
+        err = reader.Next();
+        SuccessOrExit(err);
+    }
+
+    VerifyOrExit(reader.GetType() == kTLVType_Structure, err = WEAVE_ERROR_WRONG_TLV_TYPE);
+
+    err = reader.EnterContainer(outerContainer);
+    SuccessOrExit(err);
+
+    while ((err = reader.Next()) == WEAVE_NO_ERROR)
+    {
+        uint64_t elemTag = reader.GetTag();
+
+        if (!IsContextTag(elemTag))
+            continue;
+
+        switch (TagNumFromTag(elemTag))
+        {
+        case kTag_WirelessRegConfig_RegulatoryDomain:
+            VerifyOrExit(reader.GetType() == kTLVType_UTF8String, err = WEAVE_ERROR_INVALID_TLV_ELEMENT);
+            VerifyOrExit(!IsRegDomainPresent(), err = WEAVE_ERROR_INVALID_TLV_ELEMENT);
+            VerifyOrExit(reader.GetLength() == sizeof(RegDomain.Code), err = WEAVE_ERROR_INVALID_ARGUMENT);
+            err = reader.GetBytes((uint8_t *)RegDomain.Code, sizeof(WirelessRegDomain::Code));
+            SuccessOrExit(err);
+            break;
+
+        case kTag_WirelessRegConfig_OperatingLocation:
+            VerifyOrExit(!IsOpLocationPresent(), err = WEAVE_ERROR_INVALID_TLV_ELEMENT);
+            err = reader.Get(OpLocation);
+            SuccessOrExit(err);
+            VerifyOrExit(OpLocation != kWirelessOperatingLocation_NotSpecified, err = WEAVE_ERROR_INVALID_ARGUMENT);
+            break;
+
+        case kTag_WirelessRegConfig_SupportedRegulatoryDomains:
+            VerifyOrExit(reader.GetType() == kTLVType_Array, err = WEAVE_ERROR_INVALID_TLV_ELEMENT);
+            VerifyOrExit(NumSupportedRegDomains == 0, err = WEAVE_ERROR_INVALID_TLV_ELEMENT);
+
+            err = reader.EnterContainer(outerContainer2);
+            SuccessOrExit(err);
+
+            while ((err = reader.Next()) == WEAVE_NO_ERROR)
+            {
+                VerifyOrExit(NumSupportedRegDomains < maxSupportedRegDomains, err = WEAVE_ERROR_BUFFER_TOO_SMALL);
+                VerifyOrExit(reader.GetType() == kTLVType_UTF8String, err = WEAVE_ERROR_INVALID_TLV_ELEMENT);
+                VerifyOrExit(reader.GetLength() == sizeof(RegDomain.Code), err = WEAVE_ERROR_INVALID_ARGUMENT);
+                err = reader.GetBytes((uint8_t *)SupportedRegDomains[NumSupportedRegDomains].Code, sizeof(WirelessRegDomain::Code));
+                SuccessOrExit(err);
+                VerifyOrExit(!SupportedRegDomains[NumSupportedRegDomains].IsNull(), err = WEAVE_ERROR_INVALID_ARGUMENT);
+                NumSupportedRegDomains++;
+            }
+
+            err = reader.ExitContainer(outerContainer2);
+            SuccessOrExit(err);
+
+            break;
+
+        default:
+            // Ignore unknown fields.
+            break;
+        }
+    }
+
+    err = reader.ExitContainer(outerContainer);
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+/**
+ * Populate the object from information encoded PacketBuffer, reusing
+ *
+ * Upon completion of the method, the contents of the supplied \c PacketBuffer
+ * will be overwritten with an array containing the supported regulatory domains.
+ * The \c SupportedRegDomains member will be set to point at the start of this
+ * array, and the \c NumSupportedRegDomains member will contain the number of
+ * items in the array.
+ *
+ * @param[in]   buf                     A \c PacketBuffer object containing the information to
+ *                                      be decoded.
+ *
+ * @retval #WEAVE_NO_ERROR              On success.
+ * @retval other                        Other Weave or platform-specific error codes indicating
+ *                                      that an error occurred while decoding the encoded data.
+ */
+WEAVE_ERROR WirelessRegConfig::DecodeInPlace(PacketBuffer * buf)
+{
+    TLVReader reader;
+
+    // Arrange to store the array of supported regulatory domains at the beginning of
+    // the packet buffer, overwriting the encoded config data.  Because the encoded size
+    // of the array is always larger than the decoded size, writing the array will never
+    // disrupt the reading of the encoded config data.
+    SupportedRegDomains = reinterpret_cast<WirelessRegDomain *>(buf->Start());
+    NumSupportedRegDomains = static_cast<uint16_t>(buf->MaxDataLength() / sizeof(WirelessRegDomain));
+
+    reader.Init(buf);
+
+    return Decode(reader);
+}
+
+
+} // namespace NetworkProvisioning
+} // namespace Profiles
+} // namespace Weave
+} // namespace nl

--- a/src/lib/profiles/network-provisioning/WirelessRegConfig.h
+++ b/src/lib/profiles/network-provisioning/WirelessRegConfig.h
@@ -1,0 +1,150 @@
+/*
+ *
+ *    Copyright (c) 2019 Google LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef WIRELESS_REG_CONFIG_H
+#define WIRELESS_REG_CONFIG_H
+
+#include <Weave/Core/WeaveCore.h>
+#include <Weave/Support/FlagUtils.hpp>
+
+namespace nl {
+namespace Weave {
+namespace Profiles {
+namespace NetworkProvisioning {
+
+/**
+ * 2-character code identifying a wireless regulatory domain.
+ */
+struct WirelessRegDomain
+{
+    char Code[2];
+
+    bool operator ==(const struct WirelessRegDomain & other) const;
+    bool operator !=(const struct WirelessRegDomain & other) const;
+    bool IsNull(void) const;
+    bool IsWorldWide(void) const;
+
+    static const WirelessRegDomain Null;
+    static const WirelessRegDomain WorldWide;
+};
+
+/**
+ * Device operating location, as relevant to wireless regulatory rules.
+ */
+enum WirelessOperatingLocation
+{
+    kWirelessOperatingLocation_NotSpecified = 0x00, /**< Reserved value.
+                                                         May not be sent over-the-wire. */
+
+    kWirelessOperatingLocation_Unknown      = 0x01, /**< Operating location unknown.
+                                                         Signifies that the device's expected operating location
+                                                         is not known, or may change over time. */
+
+    kWirelessOperatingLocation_Indoors      = 0x02, /**< Operating indoors.
+                                                         Signifies that the device's expected operating location
+                                                         is indoors. */
+
+    kWirelessOperatingLocation_Outdoors     = 0x03, /**< Operating outdoors.
+                                                         Signifies that the device's expected operating location
+                                                         is outdoors. */
+};
+
+/**
+ * Container for wireless regulatory configuration information.
+ */
+class WirelessRegConfig
+{
+public:
+    WirelessRegDomain * SupportedRegDomains;                /**< Array of supported regulatory domain structures */
+    uint16_t NumSupportedRegDomains;                        /**< Length of SupportedRegDomains array */
+    WirelessRegDomain RegDomain;                            /**< Active wireless regulatory domain
+                                                                 Value of '\0' indicates not present. */
+    uint8_t OpLocation;                                     /**< Active operating location
+                                                                 Value of 0 indicates not present. */
+
+    void Init(void);
+    bool IsRegDomainPresent(void) const;
+    bool IsOpLocationPresent(void) const;
+
+    WEAVE_ERROR Encode(nl::Weave::TLV::TLVWriter & writer) const;
+    WEAVE_ERROR Decode(nl::Weave::TLV::TLVReader & reader);
+    WEAVE_ERROR DecodeInPlace(PacketBuffer * buf);
+};
+
+/**
+ * Test WirelessRegDomain structure for equality
+ */
+inline bool WirelessRegDomain::operator ==(const struct WirelessRegDomain & other) const
+{
+    return memcmp(Code, other.Code, sizeof(Code)) == 0;
+}
+
+/**
+ * Test WirelessRegDomain structure for inequality
+ */
+inline bool WirelessRegDomain::operator !=(const struct WirelessRegDomain & other) const
+{
+    return memcmp(Code, other.Code, sizeof(Code)) != 0;
+}
+
+/**
+ * Test if the value is null.
+ */
+inline bool WirelessRegDomain::IsNull(void) const
+{
+    return Code[0] == '\0' && Code[1] == '\0';
+}
+
+/**
+ * Test if the value represents the special 'world-wide' regulatory code.
+ */
+inline bool WirelessRegDomain::IsWorldWide(void) const
+{
+    return Code[0] == '0' && Code[1] == '0';
+}
+
+/**
+ * Reset the WirelessRegConfig object to an empty state.
+ */
+inline void WirelessRegConfig::Init(void)
+{
+    memset(this, 0, sizeof(*this));
+}
+
+/**
+ * Is RegDomain field present in WirelessRegConfig object.
+ */
+inline bool WirelessRegConfig::IsRegDomainPresent(void) const
+{
+    return !RegDomain.IsNull();
+}
+
+/**
+ * Is OpLocation field present in WirelessRegConfig object.
+ */
+inline bool WirelessRegConfig::IsOpLocationPresent(void) const
+{
+    return OpLocation != kWirelessOperatingLocation_NotSpecified;
+}
+
+} // namespace NetworkProvisioning
+} // namespace Profiles
+} // namespace Weave
+} // namespace nl
+
+#endif // WIRELESS_REG_CONFIG_H

--- a/src/lib/support/StatusReportStr.cpp
+++ b/src/lib/support/StatusReportStr.cpp
@@ -242,6 +242,8 @@ NL_DLL_EXPORT const char *StatusReportStr(uint32_t profileId, uint16_t statusCod
         case NetworkProvisioning::kStatusCode_TestNetworkFailed                         : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Test network failed"; break;
         case NetworkProvisioning::kStatusCode_NetworkConnectFailed                      : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Network connect failed"; break;
         case NetworkProvisioning::kStatusCode_NoRouterAvailable                         : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] No router available"; break;
+        case NetworkProvisioning::kStatusCode_UnsupportedRegulatoryDomain               : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Unsupported wireless regulatory domain"; break;
+        case NetworkProvisioning::kStatusCode_UnsupportedOperatingLocation              : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Unsupported wireless operating location"; break;
         default                                                                         : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ]"; break;
         }
         break;

--- a/src/test-apps/MockNPServer.h
+++ b/src/test-apps/MockNPServer.h
@@ -31,10 +31,12 @@
 #include <Weave/Core/WeaveCore.h>
 #include <Weave/Profiles/network-provisioning/NetworkProvisioning.h>
 #include <Weave/Profiles/network-provisioning/NetworkInfo.h>
+#include <Weave/Profiles/network-provisioning/WirelessRegConfig.h>
 
 using nl::Weave::System::PacketBuffer;
 using nl::Weave::WeaveExchangeManager;
 using nl::Weave::Profiles::NetworkProvisioning::NetworkInfo;
+using nl::Weave::Profiles::NetworkProvisioning::WirelessRegConfig;
 using nl::Weave::Profiles::NetworkProvisioning::NetworkProvisioningServer;
 using nl::Weave::Profiles::NetworkProvisioning::NetworkProvisioningDelegate;
 
@@ -52,6 +54,7 @@ public:
     NetworkInfo ScanResults[kMaxScanResults];
     NetworkInfo ProvisionedNetworks[kMaxProvisionedNetworks];
     uint32_t NextNetworkId;
+    WirelessRegConfig RegConfig;
 
     WEAVE_ERROR Init(WeaveExchangeManager *exchangeMgr);
     WEAVE_ERROR Shutdown();
@@ -68,6 +71,7 @@ protected:
         uint32_t networkId;
         uint8_t flags;
         uint16_t rendezvousMode;
+        PacketBuffer *regConfigTLV;
     } mOpArgs;
 
     virtual WEAVE_ERROR HandleScanNetworks(uint8_t networkType);
@@ -79,6 +83,8 @@ protected:
     virtual WEAVE_ERROR HandleDisableNetwork(uint32_t networkId);
     virtual WEAVE_ERROR HandleTestConnectivity(uint32_t networkId);
     virtual WEAVE_ERROR HandleSetRendezvousMode(uint16_t rendezvousMode);
+    virtual WEAVE_ERROR HandleGetWirelessRegulatoryConfig(void);
+    virtual WEAVE_ERROR HandleSetWirelessRegulatoryConfig(PacketBuffer* regConfigTLV);
     virtual void EnforceAccessControl(nl::Weave::ExchangeContext *ec, uint32_t msgProfileId, uint8_t msgType,
                 const nl::Weave::WeaveMessageInfo *msgInfo, AccessControlResult& result);
     virtual bool IsPairedToAccount() const;
@@ -95,11 +101,14 @@ protected:
     WEAVE_ERROR CompleteDisableNetwork(uint32_t networkId);
     WEAVE_ERROR CompleteTestConnectivity(uint32_t networkId);
     WEAVE_ERROR CompleteSetRendezvousMode(uint16_t rendezvousMode);
+    WEAVE_ERROR CompleteGetWirelessRegulatoryConfig(void);
+    WEAVE_ERROR CompleteSetWirelessRegulatoryConfig(PacketBuffer* regConfigTLV);
 
     virtual WEAVE_ERROR SendStatusReport(uint32_t statusProfileId, uint16_t statusCode, WEAVE_ERROR sysError = WEAVE_NO_ERROR);
 
     WEAVE_ERROR ValidateNetworkConfig(NetworkInfo& netConfig);
     static void PrintNetworkInfo(NetworkInfo& netInfo, const char *prefix);
+    static void PrintWirelessRegConfig(WirelessRegConfig& regConfig, const char *prefix);
     static void HandleOpDelayComplete(nl::Weave::System::Layer* lSystemLayer, void* aAppState, nl::Weave::System::Error aError);
 };
 

--- a/src/test-apps/TestWeaveDeviceMangerJNI
+++ b/src/test-apps/TestWeaveDeviceMangerJNI
@@ -50,5 +50,5 @@ fi
 
 export WEAVE_IPV4_LISTEN_ADDR=127.0.0.2
 
-java --add-modules java.xml.bind -verbose:jni -Xcheck:jni -Djava.library.path=${LIB_DIR} -jar ${JAR_FILE} nl.Weave.DeviceManager.TestMain
+java -verbose:jni -Xcheck:jni -Djava.library.path=${LIB_DIR} -jar ${JAR_FILE} nl.Weave.DeviceManager.TestMain
 

--- a/src/test-apps/happy/lib/WeaveDeviceManager.py
+++ b/src/test-apps/happy/lib/WeaveDeviceManager.py
@@ -1059,13 +1059,36 @@ if __name__ == '__main__':
     deviceDesc.Print("  ")
 
     print ''
-    print '#################################get-last-network-grovisioning-result#################################'
+    print '#################################get-last-network-provisioning-result#################################'
 
     try:
         devMgr.GetLastNetworkProvisioningResult()
     except WeaveStack.WeaveStackException, ex:
         print str(ex)
         exit()
+
+    print ''
+    print  '#################################get-wireless-reg-config#################################'
+
+    try:
+        getResult = devMgr.GetWirelessRegulatoryConfig()
+    except WeaveDeviceMgr.DeviceManagerException, ex:
+        print str(ex)
+        exit()
+
+    print "GetWirelessRegulatoryConfig complete"
+    getResult.Print("  ")
+
+    print ''
+    print  '#################################set-wireless-reg-config#################################'
+
+    try:
+        devMgr.SetWirelessRegulatoryConfig(WeaveDeviceMgr.WirelessRegConfig(regDomain="US"))
+    except WeaveDeviceMgr.DeviceManagerException, ex:
+        print str(ex)
+        exit()
+
+    print "SetWirelessRegulatoryConfig complete"
 
     print ''
     print '#################################ping#################################'


### PR DESCRIPTION
This change implements the feature described in https://github.com/openweave/openweave-core/issues/399.

- Added three new message types to the Network Provisioning profile:
GetWirelessRegulatoryConfig, GetWirelessRegulatoryConfigComplete and SetWirelessRegulatoryConfig.

- Extended the NetworkProvisioningServer and NetworkProvisioningDelegate classes to support the new provisioning protocol.

- Created WirelessRegConfig class and associated types to represent wireless regulatory config in memory and provide functions for encoding/decoding to Weave TLV.

- Added APIs to C++ WeaveDeviceManager class for getting and setting wireless regulatory configuration information. Extended the Java and Python (but not Objective-C++) wrappers for the Device Manager to support the APIs.

- Added support for wireless regulatory provisioning to the mock device and extended the WeaveDeviceManager happy test to exercise it.

- Extended the WeaveDeviceManager JNI tests to exercise the new Java APIs.