### PR TITLE
Fix warning from TraitSchemaEngine::ParseTagString

### DIFF
--- a/src/lib/profiles/data-management/Current/TraitData.cpp
+++ b/src/lib/profiles/data-management/Current/TraitData.cpp
@@ -99,7 +99,6 @@ WEAVE_ERROR TraitSchemaEngine::ParseTagString(const char * apTagString, char ** 
 
     aParseRes = strtoul(apTagString, apEndptr, 0);
     VerifyOrExit(!(*apEndptr == apTagString || (**apEndptr != '\0' && **apEndptr != '/')), err = WEAVE_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(aParseRes < kContextTagMaxNum, err = WEAVE_ERROR_INVALID_TLV_TAG);
 
 exit:
     return err;


### PR DESCRIPTION
-- Seeing the warning, TraitData.cpp:102:43: error: comparison is always true due to
limited range of data type [-Werror=type-limits],
VerifyOrExit(aParseRes < kContextTagMaxNum, err = WEAVE_ERROR_INVALID_TLV_TAG);
-- Removing this extra check.