### PR TITLE
Bug/misc fixes

### DIFF
--- a/src/lib/profiles/data-management/Current/GenericTraitCatalogImpl.cpp
+++ b/src/lib/profiles/data-management/Current/GenericTraitCatalogImpl.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#if WEAVE_CONFIG_DATA_MANAGEMENT_CLIENT_EXPERIMENTAL
 #include <map>
 #include <limits>
 #include <Weave/Profiles/data-management/Current/WdmManagedNamespace.h>
@@ -32,3 +33,4 @@ template class GenericTraitCatalogImpl<TraitDataSource>;
 }; // namespace Profiles
 }; // namespace Weave
 }; // namespace nl
+#endif

--- a/src/lib/profiles/data-management/Current/SubscriptionEngine.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionEngine.cpp
@@ -1879,7 +1879,7 @@ WEAVE_ERROR SubscriptionEngine::ProcessUpdateRequestDataElement(Weave::TLV::TLVR
     if (err == WEAVE_ERROR_TLV_TAG_NOT_FOUND)
     {
         WeaveLogDetail(DataManagement, "Ignoring un-mappable path!");
-        err = WEAVE_NO_ERROR;
+        // no need to reset the value of err, it is set unconditionally below
     }
 #endif
 

--- a/src/lib/profiles/data-management/Current/TraitData.cpp
+++ b/src/lib/profiles/data-management/Current/TraitData.cpp
@@ -91,16 +91,15 @@ WEAVE_ERROR UpdateDictionaryDirtyPathCut::CutPath(PropertyPathHandle aPathhandle
 WEAVE_ERROR TraitSchemaEngine::ParseTagString(const char * apTagString, char ** apEndptr, uint8_t & aParseRes) const
 {
     WEAVE_ERROR err = WEAVE_NO_ERROR;
-
+    unsigned long int tag;
     VerifyOrExit(apTagString != NULL, err = WEAVE_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(*apTagString == '/', err = WEAVE_ERROR_INVALID_ARGUMENT);
 
     apTagString++;
-
-    aParseRes = strtoul(apTagString, apEndptr, 0);
+    tag = strtoul(apTagString, apEndptr, 0);
     VerifyOrExit(!(*apEndptr == apTagString || (**apEndptr != '\0' && **apEndptr != '/')), err = WEAVE_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(aParseRes < kContextTagMaxNum, err = WEAVE_ERROR_INVALID_TLV_TAG);
-
+    VerifyOrExit(tag < kContextTagMaxNum, err = WEAVE_ERROR_INVALID_TLV_TAG);
+    aParseRes = tag;
 exit:
     return err;
 }

--- a/src/lib/profiles/security/WeaveCertProvisioning.cpp
+++ b/src/lib/profiles/security/WeaveCertProvisioning.cpp
@@ -336,6 +336,7 @@ WEAVE_ERROR WeaveCertProvEngine::ProcessGetCertificateResponse(PacketBuffer * ms
         relatedCertsLen = writer.GetLengthWritten() - certLen;
 
         err = reader.Next();
+        VerifyOrExit(err == WEAVE_END_OF_TLV, err = WEAVE_ERROR_UNEXPECTED_TLV_ELEMENT);
     }
 
     err = reader.VerifyEndOfContainer();


### PR DESCRIPTION
Please excuse the co-mingling of multiple fixes in a single pull request, each of the changes otherwise has absolutely minimal content which in total does not clearly merrit a full build. 
Changes in this pull request: 

* in `TraitSchemaEngine::ParseTagString` static analysis returned a warning that the comparison was always true because of limited range of the operands.  The change correctly checks the parsed result prior to narrowing
* `GenericTraitCatalogImpl.cpp` contains an explicit instantiation of the template classes.  These classes rely on richer C++ library than what's available on many of our targets.  The change guards the template instantiation with a compile time instantiation; the developer is free to either enable the flag or pull in the templates and instantiate them directly, but the build system continues to compile without `<map>` support
* Fixes for dead stores flagged by static analysis