### PR TITLE
several changes on update server

### DIFF
--- a/src/lib/profiles/data-management/Current/MessageDef.h
+++ b/src/lib/profiles/data-management/Current/MessageDef.h
@@ -131,6 +131,7 @@ enum
     kStatus_IncompatibleDataSchemaVersion = 0x2B,
     kStatus_MultipleFailures              = 0x2C,
     kStatus_UpdateOutOfSequence           = 0x2D,
+    kStatus_InvalidTLVInUpdate            = 0x2E,
 };
 
 // TODO: The type is only used in a few places. We should use it everywhere.

--- a/src/lib/profiles/data-management/Current/SubscriptionEngine.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionEngine.h
@@ -447,13 +447,16 @@ private:
 
     static WEAVE_ERROR AllocateRightSizedBuffer(PacketBuffer *& buf, const uint32_t desiredSize, const uint32_t minSize,
                                                 uint32_t & outMaxPayloadSize);
+    static WEAVE_ERROR InitializeStatusDataHandleList(Weave::TLV::TLVReader & aReader,
+                                                      StatusDataHandleElement * apStatusDataHandleList, uint32_t & aNumDataElements,
+                                                      uint8_t * apBufEndAddr);
     static void ConstructStatusListVersionList(Weave::TLV::TLVWriter & aWriter, void * apContext);
-    static void BuildStatusDataHandleElement(PacketBuffer * pBuf, TraitDataHandle aTraitDataHandle, WEAVE_ERROR & err,
-                                             uint32_t aCurrentIndex);
+    static void UpdateStatusDataHandleElement(StatusDataHandleElement * apStatusDataHandleList, TraitDataHandle aTraitDataHandle,
+                                              WEAVE_ERROR & err, uint32_t aCurrentIndex);
     static bool IsStartingPath(StatusDataHandleElement * apStatusDataHandleList, TraitDataHandle aTraitDataHandle,
                                uint32_t aCurrentIndex);
-    static WEAVE_ERROR UpdateTraitVersions(PacketBuffer * apBuf, const TraitCatalogBase<TraitDataSource> * apCatalog,
-                                           uint32_t aNumDataElements);
+    static WEAVE_ERROR UpdateTraitVersions(StatusDataHandleElement * apStatusDataHandleList,
+                                           const TraitCatalogBase<TraitDataSource> * apCatalog, uint32_t aNumDataElements);
     static WEAVE_ERROR SendFaultyUpdateResponse(Weave::ExchangeContext * apEC);
     static WEAVE_ERROR SendUpdateResponse(Weave::ExchangeContext * apEC, uint32_t aNumDataElements,
                                           const TraitCatalogBase<TraitDataSource> * apCatalog, PacketBuffer * apBuf,
@@ -463,12 +466,17 @@ private:
                                                        const TraitCatalogBase<TraitDataSource> * apCatalog,
                                                        IUpdateRequestDataElementAccessControlDelegate & acDelegate,
                                                        bool aConditionalLoop, uint32_t aCurrentIndex, bool & aExistFailure,
-                                                       PacketBuffer * apBuf);
-    static WEAVE_ERROR ProcessUpdateRequestDataList(Weave::TLV::TLVReader & aReader, PacketBuffer * apBuf,
+                                                       StatusDataHandleElement * apStatusDataHandleList);
+    static WEAVE_ERROR ProcessUpdateRequestDataListWithConditionality(Weave::TLV::TLVReader & aReader,
+                                                                      StatusDataHandleElement * apStatusDataHandleList,
+                                                                      const TraitCatalogBase<TraitDataSource> * apCatalog,
+                                                                      IUpdateRequestDataElementAccessControlDelegate & acDelegate,
+                                                                      bool & aExistFailure, bool aConditionalLoop);
+    static WEAVE_ERROR ProcessUpdateRequestDataList(Weave::TLV::TLVReader & aReader,
+                                                    StatusDataHandleElement * apStatusDataHandleList,
                                                     const TraitCatalogBase<TraitDataSource> * apCatalog,
                                                     IUpdateRequestDataElementAccessControlDelegate & acDelegate,
-                                                    bool & aExistFailure, uint32_t & aNumDataElements, bool aConditionalLoop);
-
+                                                    bool & aExistFailure, uint32_t aNumDataElements);
     static WEAVE_ERROR ProcessUpdateRequest(Weave::ExchangeContext * apEC, Weave::TLV::TLVReader & aReader,
                                             const TraitCatalogBase<TraitDataSource> * apCatalog,
                                             IUpdateRequestDataElementAccessControlDelegate & acDelegate);

--- a/src/lib/profiles/data-management/Current/TraitData.h
+++ b/src/lib/profiles/data-management/Current/TraitData.h
@@ -897,7 +897,7 @@ public:
 
     enum EventType
     {
-        kEvent_DataSourceMax
+        kEventDataSourceMax
     };
     /*
      * Invoked either by the base class or by an external agent (like the subscription engine) to signal the occurrence of an event
@@ -985,21 +985,14 @@ public:
 
     enum EventType
     {
-        kEventChangeFirst = kEvent_DataSourceMax,
-
-        /* Signals the beginning of a change record which in certain scenarios can span multiple data elements over multiple
-         * update requests (the latter only a possibility if the data being transmitted is unable to fit within a single packet)
-         */
-        kEventChangeBegin,
-
         /* Start of a data element */
-        kEventDataElementBegin,
+        kEventDataElementBegin = kEventDataSourceMax + 1,
 
         /* End of a data element */
         kEventDataElementEnd,
 
-        /* End of a change record */
-        kEventChangeEnd,
+        /* Signal complete of update processing */
+        kEventUpdateProcessingComplete,
 
         /* Start of replacement of an entire dictionary */
         kEventDictionaryReplaceBegin,
@@ -1027,7 +1020,7 @@ public:
         /* Signals the termination of a subscription either due to an error, or the subscription was cancelled */
         kEventSubscriptionTerminated,
 
-        kEvent_UpdatableDataSourceMax
+        kEventUpdatableDataSourceMax
     };
 
     union InEventParam


### PR DESCRIPTION
-- Remove unsupported kEventChangeBegin and kEventChangeEnd
-- Add kEventUpdateProcessingComplete, trigger it when updating trait version.
-- Update status report using kStatus_BadRequest when update request is malformed.
-- Add kStatus_InvalidValueInUpdate to represent data element value error in wdm
profie.
-- When processing update request, we need to skip this DE when DE generates
WEAVE_ERROR_WRONG_TLV_TYPE and WEAVE_ERROR_TLV_TAG_NOT_FOUND.
-- Rename BuildStatusDataHandleElement to UpdateStatusDataHandleElement
-- Add InitializeStatusDataHandleList to initialize StatusDataHandleList
with defaut incorrect state, whenenever the data element in list has
been processed successfully, update StatusDataHandleList with sucess
status. Once it hit fatal error, we end up the conditional and
unconditional data list loop, and update trait version for successful
DEs.
-- note: when starting to process update request,
update.CheckSchemaValidity() is triggered so that malformed update request
should be checked, which needs feature flags, WEAVE_CONFIG_DATA_MANAGEMENT_ENABLE_SCHEMA_CHECK
and WEAVE_DETAIL_LOGGING, and they are defaulted enabled.