### PR TITLE
Updated WeaveProductId Used In the mock-weave-bg.

### DIFF
--- a/src/test-apps/mock-weave-bg.cpp
+++ b/src/test-apps/mock-weave-bg.cpp
@@ -1,5 +1,6 @@
 /*
  *
+ *    Copyright (c) 2020 Google LLC.
  *    Copyright (c) 2014-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -295,7 +296,7 @@ int main(int argc, char *argv[])
     SetSignalHandler(DoneOnHandleSIGUSR1);
 
     // Configure some alternate defaults for the device descriptor values.
-    gDeviceDescOptions.BaseDeviceDesc.ProductId = nl::Weave::Profiles::Vendor::Nestlabs::DeviceDescription::kNestWeaveProduct_Topaz2;
+    gDeviceDescOptions.BaseDeviceDesc.ProductId = nl::Weave::Profiles::Vendor::Nestlabs::DeviceDescription::kNestWeaveProduct_Onyx;
     strcpy(gDeviceDescOptions.BaseDeviceDesc.SerialNumber, "mock-weave-bg");
     strcpy(gDeviceDescOptions.BaseDeviceDesc.SoftwareVersion, "mock-weave-bg/1.0");
     gDeviceDescOptions.BaseDeviceDesc.DeviceFeatures = WeaveDeviceDescriptor::kFeature_LinePowered;


### PR DESCRIPTION
Needed to update that as in some test cases Topaz2 device
may have limited capabilities.