### PR TITLE
Support for suspending and restoring Weave security sessions

### DIFF
--- a/src/lib/core/WeaveError.cpp
+++ b/src/lib/core/WeaveError.cpp
@@ -228,6 +228,8 @@ bool FormatWeaveError(char * buf, uint16_t bufSize, int32_t err)
     case WEAVE_ERROR_WDM_INCONSISTENT_CONDITIONALITY            : desc = "The Trait Instance is already being updated with a different conditionality"; break;
     case WEAVE_ERROR_WDM_LOCAL_DATA_INCONSISTENT                : desc = "The local data does not match any known version of the Trait Instance"; break;
     case WEAVE_ERROR_WDM_PATH_STORE_FULL                        : desc = "A WDM TraitPath store is full"; break;
+    case WEAVE_EVENT_ID_FOUND                                   : desc = "Event id found"; break;
+    case WEAVE_ERROR_SESSION_KEY_SUSPENDED                      : desc = "Session key suspended"; break;
     }
 #endif // !WEAVE_CONFIG_SHORT_ERROR_STR
 

--- a/src/lib/core/WeaveError.h
+++ b/src/lib/core/WeaveError.h
@@ -1721,6 +1721,7 @@ typedef WEAVE_CONFIG_ERROR_TYPE WEAVE_ERROR;
  *
  */
 #define WEAVE_ERROR_WDM_PATH_STORE_FULL                          _WEAVE_ERROR(181)
+
 /**
  * @def WEAVE_EVENT_ID_FOUND
  *
@@ -1728,6 +1729,16 @@ typedef WEAVE_CONFIG_ERROR_TYPE WEAVE_ERROR;
  *   Event ID matching the criteria was found
  */
 #define WEAVE_EVENT_ID_FOUND                                     _WEAVE_ERROR(182)
+
+/**
+ *  @def WEAVE_ERROR_SESSION_KEY_SUSPENDED
+ *
+ *  @brief
+ *    Use of the identified session key is suspended.
+ *
+ */
+#define WEAVE_ERROR_SESSION_KEY_SUSPENDED                        _WEAVE_ERROR(183)
+
 
 /**
  *  @}

--- a/src/lib/core/WeaveFabricState.cpp
+++ b/src/lib/core/WeaveFabricState.cpp
@@ -62,6 +62,7 @@ using namespace nl::Weave::Encoding;
 using namespace nl::Weave::Crypto;
 using namespace nl::Weave::Profiles;
 using namespace nl::Weave::Profiles::FabricProvisioning;
+using namespace nl::Weave::Profiles::Security;
 using namespace nl::Weave::Profiles::Security::AppKeys;
 
 #if WEAVE_CONFIG_SECURITY_TEST_MODE
@@ -390,20 +391,7 @@ void WeaveFabricState::RemoveSessionKey(WeaveSessionKey *sessionKey, bool wasIdl
     WeaveLogDetail(MessageLayer, "Removing %ssession key: Id=%04" PRIX16 " Peer=%016" PRIX64,
             (wasIdle) ? "idle " : "", sessionKey->MsgEncKey.KeyId, sessionKey->NodeId);
 
-    if (sessionKey->IsSharedSession())
-    {
-        SharedSessionEndNode *endNode = SharedSessionsNodes;
-
-        // Clear all information about shared session end nodes.
-        for (int i = 0; i < WEAVE_CONFIG_MAX_SHARED_SESSIONS_END_NODES; i++, endNode++)
-        {
-            if (endNode->SessionKey == sessionKey)
-            {
-                memset((uint8_t *)endNode, 0, sizeof(SharedSessionEndNode));
-            }
-        }
-    }
-
+    RemoveSharedSessionEndNodes(sessionKey);
     sessionKey->Clear();
 }
 
@@ -602,6 +590,300 @@ exit:
     return err;
 }
 
+void WeaveFabricState::RemoveSharedSessionEndNodes(const WeaveSessionKey *sessionKey)
+{
+    if (sessionKey->IsSharedSession())
+    {
+        SharedSessionEndNode *endNode = SharedSessionsNodes;
+
+        // Clear all information about shared session end nodes.
+        for (int i = 0; i < WEAVE_CONFIG_MAX_SHARED_SESSIONS_END_NODES; i++, endNode++)
+        {
+            if (endNode->SessionKey == sessionKey)
+            {
+                memset((uint8_t *)endNode, 0, sizeof(SharedSessionEndNode));
+            }
+        }
+    }
+}
+
+/**
+ * Suspend and serialize the state of an active Weave security session.
+ *
+ * Serializes the state of an identified Weave security session into the supplied buffer
+ * and suspends the session such that no further messages can be sent or received.
+ *
+ * This method is intended to be used by devices that do not retain RAM while sleeping,
+ * allowing them to persist the state of an active session and thereby avoid the need to
+ * re-establish the session when they wake.
+ */
+WEAVE_ERROR WeaveFabricState::SuspendSession(uint16_t keyId, uint64_t peerNodeId, uint8_t * buf, uint16_t bufSize, uint16_t & serializedSessionLen)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    WeaveSessionKey * sessionKey;
+
+    // Lookup the specified session.
+    err = GetSessionKey(keyId, peerNodeId, sessionKey);
+    SuccessOrExit(err);
+
+    // Assert various requirements about the session.
+    VerifyOrExit(sessionKey->IsKeySet(), err = WEAVE_ERROR_KEY_NOT_FOUND);
+    VerifyOrExit(!sessionKey->IsSuspended(), err = WEAVE_ERROR_SESSION_KEY_SUSPENDED);
+    VerifyOrExit(sessionKey->BoundCon == NULL, err = WEAVE_ERROR_INVALID_USE_OF_SESSION_KEY);
+    VerifyOrExit(IsCertAuthMode(sessionKey->AuthMode), err = WEAVE_ERROR_INVALID_USE_OF_SESSION_KEY);
+
+    {
+        TLVWriter writer;
+        TLVType container;
+
+        writer.Init(buf, bufSize);
+
+        // Begin encoding a Security:SerializedSession TLV structure.
+        err = writer.StartContainer(ProfileTag(kWeaveProfile_Security, kTag_SerializedSession), kTLVType_Structure, container);
+        SuccessOrExit(err);
+
+        // Encode various information about the session, in tag order.
+        err = writer.Put(ContextTag(kTag_SerializedSession_KeyId), sessionKey->MsgEncKey.KeyId);
+        SuccessOrExit(err);
+        err = writer.Put(ContextTag(kTag_SerializedSession_PeerNodeId), sessionKey->NodeId);
+        SuccessOrExit(err);
+        err = writer.Put(ContextTag(kTag_SerializedSession_NextMessageId), sessionKey->NextMsgId.GetValue());
+        SuccessOrExit(err);
+        err = writer.Put(ContextTag(kTag_SerializedSession_MaxRcvdMessageId), sessionKey->MaxRcvdMsgId);
+        SuccessOrExit(err);
+        err = writer.Put(ContextTag(kTag_SerializedSession_MessageRcvdFlags), sessionKey->RcvFlags);
+        SuccessOrExit(err);
+        err = writer.PutBoolean(ContextTag(kTag_SerializedSession_IsLocallyInitiated), sessionKey->IsLocallyInitiated());
+        SuccessOrExit(err);
+        err = writer.PutBoolean(ContextTag(kTag_SerializedSession_IsShared), sessionKey->IsSharedSession());
+        SuccessOrExit(err);
+
+        // If the session is shared...
+        if (sessionKey->IsSharedSession())
+        {
+            SharedSessionEndNode *endNode = SharedSessionsNodes;
+            TLVType container2;
+
+            // Begin encoding an array containing the alternate node ids for the peer.
+            err = writer.StartContainer(ContextTag(kTag_SerializedSession_SharedSessionAltNodeIds), kTLVType_Array, container2);
+            SuccessOrExit(err);
+
+            for (int i = 0; i < WEAVE_CONFIG_MAX_SHARED_SESSIONS_END_NODES; i++, endNode++)
+            {
+                if (endNode->SessionKey == sessionKey)
+                {
+                    err = writer.Put(AnonymousTag, endNode->EndNodeId);
+                    SuccessOrExit(err);
+                }
+            }
+
+            // End the array.
+            err = writer.EndContainer(container2);
+            SuccessOrExit(err);
+        }
+
+        // For a CASE-based session, encode the certificate type presented by the peer.
+        err = writer.Put(ContextTag(kTag_SerializedSession_CASE_PeerCertType), CertTypeFromAuthMode(sessionKey->AuthMode));
+        SuccessOrExit(err);
+
+        // Encode the encryption type used to encrypt messages via this session.
+        err = writer.Put(ContextTag(kTag_SerializedSession_EncryptionType), sessionKey->MsgEncKey.EncType);
+        SuccessOrExit(err);
+
+        // Encode the encryption key(s) associated with the session.
+        switch (sessionKey->MsgEncKey.EncType)
+        {
+        case kWeaveEncryptionType_AES128CTRSHA1:
+            err = writer.PutBytes(ContextTag(kTag_SerializedSession_AES128CTRSHA1_DataKey),
+                    sessionKey->MsgEncKey.EncKey.AES128CTRSHA1.DataKey, WeaveEncryptionKey_AES128CTRSHA1::DataKeySize);
+            SuccessOrExit(err);
+            err = writer.PutBytes(ContextTag(kTag_SerializedSession_AES128CTRSHA1_IntegrityKey),
+                    sessionKey->MsgEncKey.EncKey.AES128CTRSHA1.IntegrityKey, WeaveEncryptionKey_AES128CTRSHA1::IntegrityKeySize);
+            SuccessOrExit(err);
+            break;
+        default:
+            ExitNow(err = WEAVE_ERROR_UNSUPPORTED_ENCRYPTION_TYPE);
+        }
+
+        // End the Security:SerializedSession TLV structure and finalize the encoding.
+        err = writer.EndContainer(container);
+        SuccessOrExit(err);
+        err = writer.Finalize();
+        SuccessOrExit(err);
+
+        serializedSessionLen = (uint16_t)writer.GetLengthWritten();
+    }
+
+    // Mark the session key as suspended.
+    sessionKey->MarkSuspended();
+
+    // Wipe the key.
+    sessionKey->MsgEncKey.EncType = kWeaveEncryptionType_None;
+    ClearSecretData((uint8_t *)&sessionKey->MsgEncKey.EncKey, sizeof(sessionKey->MsgEncKey.EncKey));
+
+exit:
+    // If something goes wrong, make sure we don't leave any key material behind.
+    if (err != WEAVE_NO_ERROR)
+    {
+        ClearSecretData(buf, bufSize);
+    }
+    return err;
+}
+
+/**
+ * Restore a previously suspended Weave Security Session from a serialized state.
+ *
+ */
+WEAVE_ERROR WeaveFabricState::RestoreSession(uint8_t * serializedSession, uint16_t serializedSessionLen)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    TLVReader reader;
+    TLVType container;
+    uint16_t keyId;
+    uint64_t peerNodeId;
+    WeaveSessionKey * sessionKey = NULL;
+    bool removeSessionOnError = false;
+
+    reader.Init(serializedSession, serializedSessionLen);
+
+    // Look for and enter the Security:SerializedSession TLV structure.
+    err = reader.Next(kTLVType_Structure, ProfileTag(kWeaveProfile_Security, kTag_SerializedSession));
+    SuccessOrExit(err);
+    err = reader.EnterContainer(container);
+    SuccessOrExit(err);
+
+    // Read the key id and peer node id.
+    err = reader.Next(kTLVType_UnsignedInteger, ContextTag(kTag_SerializedSession_KeyId));
+    SuccessOrExit(err);
+    err = reader.Get(keyId);
+    SuccessOrExit(err);
+    err = reader.Next(kTLVType_UnsignedInteger, ContextTag(kTag_SerializedSession_PeerNodeId));
+    SuccessOrExit(err);
+    err = reader.Get(peerNodeId);
+    SuccessOrExit(err);
+
+    // Look for or create a session key entry for the given key id and peer node.
+    err = FindSessionKey(keyId, peerNodeId, true, sessionKey);
+    SuccessOrExit(err);
+
+    // If the key id / peer node matched an existing session key, fail with an error.
+    VerifyOrExit(!sessionKey->IsKeySet(), err = WEAVE_ERROR_DUPLICATE_KEY_ID);
+
+    // After this point, if an error occurs, remove the session key.
+    removeSessionOnError = true;
+
+    // If the key id / peer node matched a suspended session key, clear the suspended flag.
+    sessionKey->ClearSuspended();
+
+    // Clear any alternate end node ids associated with the session key.
+    RemoveSharedSessionEndNodes(sessionKey);
+
+    // Read the encoded session information in tag order and restore it into the session key entry.
+    {
+        uint32_t nextMsgId;
+        err = reader.Next(kTLVType_UnsignedInteger, ContextTag(kTag_SerializedSession_NextMessageId));
+        SuccessOrExit(err);
+        err = reader.Get(nextMsgId);
+        SuccessOrExit(err);
+        err = sessionKey->NextMsgId.Init(nextMsgId);
+        SuccessOrExit(err);
+    }
+    err = reader.Next(kTLVType_UnsignedInteger, ContextTag(kTag_SerializedSession_MaxRcvdMessageId));
+    SuccessOrExit(err);
+    err = reader.Get(sessionKey->MaxRcvdMsgId);
+    SuccessOrExit(err);
+    err = reader.Next(kTLVType_UnsignedInteger, ContextTag(kTag_SerializedSession_MessageRcvdFlags));
+    SuccessOrExit(err);
+    err = reader.Get(sessionKey->RcvFlags);
+    SuccessOrExit(err);
+    {
+        bool b;
+        err = reader.Next(kTLVType_Boolean, ContextTag(kTag_SerializedSession_IsLocallyInitiated));
+        SuccessOrExit(err);
+        err = reader.Get(b);
+        SuccessOrExit(err);
+        sessionKey->SetLocallyInitiated(b);
+        err = reader.Next(kTLVType_Boolean, ContextTag(kTag_SerializedSession_IsShared));
+        SuccessOrExit(err);
+        err = reader.Get(b);
+        SuccessOrExit(err);
+        sessionKey->SetSharedSession(b);
+    }
+
+    // If the session is a shared session, restore the list of alternate end node ids.
+    if (sessionKey->IsSharedSession())
+    {
+        TLVType container2;
+
+        err = reader.Next(kTLVType_Array, ContextTag(kTag_SerializedSession_SharedSessionAltNodeIds));
+        SuccessOrExit(err);
+        err = reader.EnterContainer(container2);
+        SuccessOrExit(err);
+
+        while ((err = reader.Next(kTLVType_UnsignedInteger, kTLVTagControl_Anonymous)) == WEAVE_NO_ERROR)
+        {
+            uint64_t altNodeId;
+
+            err = reader.Get(altNodeId);
+            SuccessOrExit(err);
+
+            err = AddSharedSessionEndNode(sessionKey, altNodeId);
+            SuccessOrExit(err);
+        }
+
+        err = reader.ExitContainer(container2);
+        SuccessOrExit(err);
+    }
+
+    // Read and restore the session AuthMode.
+    {
+        uint8_t certType;
+        err = reader.Next(kTLVType_UnsignedInteger, ContextTag(kTag_SerializedSession_CASE_PeerCertType));
+        SuccessOrExit(err);
+        err = reader.Get(certType);
+        SuccessOrExit(err);
+        sessionKey->AuthMode = CASEAuthMode(certType);
+    }
+
+    // Restore the session message encryption type.
+    err = reader.Next(kTLVType_UnsignedInteger, ContextTag(kTag_SerializedSession_EncryptionType));
+    SuccessOrExit(err);
+    err = reader.Get(sessionKey->MsgEncKey.EncType);
+    SuccessOrExit(err);
+
+    // Based on the encryption type, restore the associated keys.
+    switch (sessionKey->MsgEncKey.EncType)
+    {
+    case kWeaveEncryptionType_AES128CTRSHA1:
+        err = reader.Next(kTLVType_ByteString, ContextTag(kTag_SerializedSession_AES128CTRSHA1_DataKey));
+        SuccessOrExit(err);
+        VerifyOrExit(reader.GetLength() == WeaveEncryptionKey_AES128CTRSHA1::DataKeySize, err = WEAVE_ERROR_INVALID_ARGUMENT);
+        err = reader.GetBytes(sessionKey->MsgEncKey.EncKey.AES128CTRSHA1.DataKey, WeaveEncryptionKey_AES128CTRSHA1::DataKeySize);
+        SuccessOrExit(err);
+        err = reader.Next(kTLVType_ByteString, ContextTag(kTag_SerializedSession_AES128CTRSHA1_IntegrityKey));
+        SuccessOrExit(err);
+        VerifyOrExit(reader.GetLength() == WeaveEncryptionKey_AES128CTRSHA1::IntegrityKeySize, err = WEAVE_ERROR_INVALID_ARGUMENT);
+        err = reader.GetBytes(sessionKey->MsgEncKey.EncKey.AES128CTRSHA1.IntegrityKey, WeaveEncryptionKey_AES128CTRSHA1::IntegrityKeySize);
+        SuccessOrExit(err);
+        break;
+    default:
+        ExitNow(err = WEAVE_ERROR_UNSUPPORTED_ENCRYPTION_TYPE);
+    }
+
+    // Verify no other data in the serialized session structure.
+    err = reader.VerifyEndOfContainer();
+    SuccessOrExit(err);
+    err = reader.ExitContainer(container);
+    SuccessOrExit(err);
+
+exit:
+    if (removeSessionOnError && err != WEAVE_NO_ERROR)
+    {
+        RemoveSessionKey(sessionKey, false);
+    }
+    return err;
+}
+
 WEAVE_ERROR WeaveFabricState::GetSessionState(uint64_t remoteNodeId,
                                               uint16_t keyId,
                                               uint8_t encType,
@@ -635,6 +917,8 @@ WEAVE_ERROR WeaveFabricState::GetSessionState(uint64_t remoteNodeId,
         err = FindSessionKey(keyId, remoteNodeId, false, sessionKey);
         if (err != WEAVE_NO_ERROR)
             return err;
+        if (sessionKey->IsSuspended())
+            return WEAVE_ERROR_SESSION_KEY_SUSPENDED;
         if (sessionKey->MsgEncKey.EncType != encType)
             return (sessionKey->MsgEncKey.EncType == kWeaveEncryptionType_None) ? WEAVE_ERROR_KEY_NOT_FOUND : WEAVE_ERROR_WRONG_ENCRYPTION_TYPE;
         if (sessionKey->BoundCon != NULL && sessionKey->BoundCon != con)
@@ -1677,6 +1961,8 @@ bool WeaveFabricState::RemoveIdleSessionKeys()
 
     return potentialIdleSessionsExist;
 }
+
+
 
 // ============================================================
 // Weave Message Encryption Application Key Cache.

--- a/src/lib/core/WeaveFabricState.h
+++ b/src/lib/core/WeaveFabricState.h
@@ -361,6 +361,7 @@ public:
         kFlag_IsRemoveOnIdle         = 0x04,            /**< The session should be removed when idle (only applies to sessions
                                                              that are not bound to a connection). */
         kFlag_RecentlyActive         = 0x08,            /**< The session was recently active. */
+        kFlag_Suspended              = 0x10,            /**< The session has been suspended. */
     };
 
     uint64_t NodeId;                                    /**< The id of the node with which the session key is shared. */
@@ -387,6 +388,9 @@ public:
     bool IsRecentlyActive() const       { return GetFlag(Flags, kFlag_RecentlyActive); }
     void MarkRecentlyActive()           { SetFlag(Flags, kFlag_RecentlyActive); }
     void ClearRecentlyActive()          { ClearFlag(Flags, kFlag_RecentlyActive); }
+    bool IsSuspended() const            { return GetFlag(Flags, kFlag_Suspended); }
+    void MarkSuspended()                { SetFlag(Flags, kFlag_Suspended); }
+    void ClearSuspended()               { ClearFlag(Flags, kFlag_Suspended); }
 };
 
 /**
@@ -522,6 +526,10 @@ public:
     WEAVE_ERROR AddSharedSessionEndNode(WeaveSessionKey *sessionKey, uint64_t endNodeId);
     WEAVE_ERROR GetSharedSessionEndNodeIds(const WeaveSessionKey *sessionKey, uint64_t *endNodeIds,
                                            uint8_t endNodeIdsBufSize, uint8_t& endNodeIdsCount);
+    void RemoveSharedSessionEndNodes(const WeaveSessionKey *sessionKey);
+
+    WEAVE_ERROR SuspendSession(uint16_t keyId, uint64_t peerNodeId, uint8_t * buf, uint16_t bufSize, uint16_t & serializedSessionLen);
+    WEAVE_ERROR RestoreSession(uint8_t * serializedSession, uint16_t serializedSessionLen);
 
     WEAVE_ERROR GetSessionState(uint64_t remoteNodeId, uint16_t keyId, uint8_t encType, WeaveConnection *con, WeaveSessionState& outSessionState);
 

--- a/src/lib/core/WeaveSecurityMgr.cpp
+++ b/src/lib/core/WeaveSecurityMgr.cpp
@@ -2472,6 +2472,12 @@ bool WeaveSecurityManager::IsKeyError(WEAVE_ERROR err)
             err == WEAVE_ERROR_UNKNOWN_KEY_TYPE ||
             err == WEAVE_ERROR_INVALID_USE_OF_SESSION_KEY ||
             err == WEAVE_ERROR_UNSUPPORTED_ENCRYPTION_TYPE);
+
+    // NOTE: This method should NOT return true for WEAVE_ERROR_SESSION_KEY_SUSPENDED.
+    // A suspended session is one that has been serialized for persistence.  Once this
+    // has happened, subsequent inbound messages referencing the session should not
+    // provoke a Key Error back to the sender, lest they cause the other end of the
+    // session to abort.
 }
 
 /**

--- a/src/lib/profiles/security/WeaveSecurity.h
+++ b/src/lib/profiles/security/WeaveSecurity.h
@@ -145,6 +145,8 @@ enum
                                                         //    Presently this has the same internal structure as an ECDSASignature.
     kTag_WeaveAccessToken                       = 9,    // [ structure ] A Weave Access Token object
     kTag_GroupKeySignature                      = 10,   // [ structure ] A Weave group Key signature object
+    kTag_SerializedSession                      = 11,   // [ structure ] A serialized representation of Weave session
+                                                        //    suitable for persisting.
 
     // ---- Context-specific Tags for WeaveCertificate Structure ----
     kTag_SerialNumber                           = 1,    // [ byte string ] Certificate serial number, in BER integer encoding.
@@ -322,7 +324,25 @@ enum
     kTag_DNAttrType_WeaveDeviceId               = 17,   // [ unsigned int ]
     kTag_DNAttrType_WeaveServiceEndpointId      = 18,   // [ unsigned int ]
     kTag_DNAttrType_WeaveCAId                   = 19,   // [ unsigned int ]
-    kTag_DNAttrType_WeaveSoftwarePublisherId    = 20    // [ unsigned int ]
+    kTag_DNAttrType_WeaveSoftwarePublisherId    = 20,   // [ unsigned int ]
+
+    // ---- Context-specific Tags for Serialized Session structure ----
+    kTag_SerializedSession_KeyId                        = 1,  // [ UNSIGNED INT, range 16bits ] Assigned session key id
+    kTag_SerializedSession_PeerNodeId                   = 2,  // [ UNSIGNED INT, range 64bits ] Node id of session peer
+    kTag_SerializedSession_NextMessageId                = 3,  // [ UNSIGNED INT, range 32bits ] Next message id
+    kTag_SerializedSession_MaxRcvdMessageId             = 4,  // [ UNSIGNED INT, range 32bits ] Max received message id
+    kTag_SerializedSession_MessageRcvdFlags             = 5,  // [ UNSIGNED INT, range 64bits ] Message received flags
+    kTag_SerializedSession_IsLocallyInitiated           = 6,  // [ BOOLEAN ] Is session locally initiated
+    kTag_SerializedSession_IsShared                     = 7,  // [ BOOLEAN ] Is session shared
+    kTag_SerializedSession_SharedSessionAltNodeIds      = 8,  // [ ARRAY OF UNSIGNED INT, range 64bits ] For a shared session,
+                                                              //    list of alternate peer node ids.
+    kTag_SerializedSession_CASE_PeerCertType            = 9,  // [ UNSIGNED INT, range 8bits ] For CASE sessions, the type
+                                                              //    of certificate presented by the peer.
+    kTag_SerializedSession_EncryptionType               = 10, // [ UNSIGNED INT, range 8bits ] Message encryption type
+    kTag_SerializedSession_AES128CTRSHA1_DataKey        = 11, // [ BYTE STRING, len 16 ] For sessions supporting AES128CTRSHA1
+                                                              //    message encryption, the data encryption key.
+    kTag_SerializedSession_AES128CTRSHA1_IntegrityKey   = 12, // [ BYTE STRING, len 20 ] For sessions supporting AES128CTRSHA1
+                                                              //    message encryption, the data integrity key.
 };
 
 // Weave-defined elliptic curve ids

--- a/src/test-apps/weave-ping.cpp
+++ b/src/test-apps/weave-ping.cpp
@@ -113,6 +113,8 @@ uint8_t ServiceDirCache[300];
 bool UseWRMP = false;
 #endif // WEAVE_CONFIG_ENABLE_RELIABLE_MESSAGING
 
+bool TestSessionSuspend = false;
+
 enum NameResolutionStateEnum
 {
     kNameResolutionState_NotStarted,
@@ -123,6 +125,7 @@ enum NameResolutionStateEnum
 enum
 {
     kToolOpt_UseServiceDir                          = 1000,
+    kToolOpt_TestSessionSuspend                     = 1001,
 };
 
 static OptionDef gToolOptionDefs[] =
@@ -140,6 +143,7 @@ static OptionDef gToolOptionDefs[] =
 #if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
     { "service-dir",  kNoArgument,       kToolOpt_UseServiceDir },
 #endif // WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+    { "test-session-suspend", kNoArgument, kToolOpt_TestSessionSuspend },
     { }
 };
 
@@ -183,6 +187,9 @@ static const char *const gToolOptionHelp =
     "       Use service directory to lookup the destination node address.\n"
     "\n"
 #endif // WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+    "  --test-session-suspend\n"
+    "       Test the ability to suspend and restore a CASE session.\n"
+    "\n"
     ;
 
 static OptionSet gToolOptions =
@@ -489,6 +496,9 @@ bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *n
     case 'D':
         DestAddr = arg;
         break;
+    case kToolOpt_TestSessionSuspend:
+        TestSessionSuspend = true;
+        break;
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", progName, name);
         return false;
@@ -658,6 +668,35 @@ void DriveSending()
         {
             EchoClient.EncryptionType = kWeaveEncryptionType_AES128CTRSHA1;
             EchoClient.KeyId = gGroupKeyEncOptions.GetEncKeyId();
+        }
+
+        // If the --test-session-suspend option has been enabled, suspend and restore
+        // the CASE session every 4 echo requests.
+        if (TestSessionSuspend && gWeaveSecurityMode.SecurityMode == WeaveSecurityMode::kCASE)
+        {
+            if (EchoCount > 0 && (EchoCount % 4) == 0)
+            {
+                uint8_t buf[256];
+                uint16_t serializedKeyLen;
+
+                printf("Suspending CASE session\n");
+
+                err = FabricState.SuspendSession(EchoClient.KeyId, DestNodeId, buf, sizeof(buf), serializedKeyLen);
+                if (err != WEAVE_NO_ERROR)
+                {
+                    printf("FabricState.SuspendSession() failed: %s\n", ErrorStr(err));
+                }
+                else
+                {
+                    printf("Restoring CASE session\n");
+
+                    err = FabricState.RestoreSession(buf, serializedKeyLen);
+                    if (err != WEAVE_NO_ERROR)
+                    {
+                        printf("FabricState.RestoreSession() failed: %s\n", ErrorStr(err));
+                    }
+                }
+            }
         }
 
         err = EchoClient.SendEchoRequest(DestNodeId, DestIPAddr, DestPort, DestIntf, payloadBuf);


### PR DESCRIPTION
- Added methods to WeaveFabricState to suspend and restore an active Weave security session in a serialized form.  This feature can be used by devices that do not retain RAM when sleeping to avoid the need to re-establish sessions on wake.

- Added option to weave-ping tool to exercise the session suspend/restore APIs.