### PR TITLE
Initialize Network Telemetry Manager during weave stack initialization

### DIFF
--- a/src/adaptations/device-layer/NetworkTelemetryManager.cpp
+++ b/src/adaptations/device-layer/NetworkTelemetryManager.cpp
@@ -42,6 +42,8 @@
 using namespace nl::Weave::DeviceLayer;
 using namespace nl::Weave::DeviceLayer::Internal;
 
+NetworkTelemetryManager NetworkTelemetryManager::sInstance;
+
 WeaveTelemetryBase::WeaveTelemetryBase()
 {
 }

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/NetworkTelemetryManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/NetworkTelemetryManager.h
@@ -138,7 +138,20 @@ public:
 #if WEAVE_DEVICE_CONFIG_ENABLE_TUNNEL_TELEMETRY
     TunnelTelemetry mTunnelTelemetry;
 #endif
+
+private:
+    friend NetworkTelemetryManager & NetworkTelemetryMgr(void);
+
+    static NetworkTelemetryManager sInstance;
 };
+
+/**
+ * Returns a reference to the NetworkTelemetryManager singleton object.
+ */
+inline NetworkTelemetryManager & NetworkTelemetryMgr(void)
+{
+    return NetworkTelemetryManager::sInstance;
+}
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericPlatformManagerImpl.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericPlatformManagerImpl.ipp
@@ -27,12 +27,13 @@
 #define GENERIC_PLATFORM_MANAGER_IMPL_IPP
 
 #include <Weave/DeviceLayer/internal/WeaveDeviceLayerInternal.h>
+#include <Weave/DeviceLayer/NetworkTelemetryManager.h>
 #include <Weave/DeviceLayer/PlatformManager.h>
 #include <Weave/DeviceLayer/internal/GenericPlatformManagerImpl.h>
 #include <Weave/DeviceLayer/internal/DeviceControlServer.h>
 #include <Weave/DeviceLayer/internal/DeviceDescriptionServer.h>
-#include <Weave/DeviceLayer/internal/NetworkProvisioningServer.h>
 #include <Weave/DeviceLayer/internal/FabricProvisioningServer.h>
+#include <Weave/DeviceLayer/internal/NetworkProvisioningServer.h>
 #include <Weave/DeviceLayer/internal/ServiceProvisioningServer.h>
 #include <Weave/DeviceLayer/internal/ServiceDirectoryManager.h>
 #include <Weave/DeviceLayer/internal/EchoServer.h>
@@ -277,6 +278,15 @@ WEAVE_ERROR GenericPlatformManagerImpl<ImplClass>::_InitWeaveStack(void)
     }
     SuccessOrExit(err);
 #endif // WEAVE_DEVICE_CONFIG_ENABLE_SOFTWARE_UPDATE_MANAGER
+
+#if WEAVE_DEVICE_CONFIG_ENABLE_NETWORK_TELEMETRY
+    err = NetworkTelemetryMgr().Init();
+    if (err != WEAVE_NO_ERROR)
+    {
+        WeaveLogError(DeviceLayer, "Network Telemetry Manager initialization failed: %s", ErrorStr(err));
+    }
+    SuccessOrExit(err);
+#endif // WEAVE_DEVICE_CONFIG_ENABLE_NETWORK_TELEMETRY
 
 exit:
     return err;


### PR DESCRIPTION
-- This enables Network Telemetry Manager to upload Thread/Wifi/Tunnel
   telemetry data periodically.