### PR TITLE
Improved multi-process support in WeaveDeviceManager

### DIFF
--- a/build/config/android/WeaveProjectConfig.h
+++ b/build/config/android/WeaveProjectConfig.h
@@ -25,6 +25,12 @@
 #ifndef WEAVEPROJECTCONFIG_H
 #define WEAVEPROJECTCONFIG_H
 
+// Enable use of an ephemeral UDP source port for locally initiated Weave exchanges.
+#define WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT 1
+
+// Enable UDP listening on demand in the WeaveDeviceManager
+#define WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP 1
+
 // Enable passcode encryption configuration 1
 #define WEAVE_CONFIG_SUPPORT_PASSCODE_CONFIG1_TEST_ONLY     1
 

--- a/build/config/ios/WeaveProjectConfig.h
+++ b/build/config/ios/WeaveProjectConfig.h
@@ -25,6 +25,12 @@
 #ifndef WEAVEPROJECTCONFIG_H
 #define WEAVEPROJECTCONFIG_H
 
+// Enable use of an ephemeral UDP source port for locally initiated Weave exchanges.
+#define WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT 1
+
+// Enable UDP listening on demand in the WeaveDeviceManager
+#define WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP 1
+
 #define INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT 0
 
 // Enable passcode encryption configuration 1

--- a/build/config/standalone/WeaveProjectConfig.h
+++ b/build/config/standalone/WeaveProjectConfig.h
@@ -24,8 +24,11 @@
 #ifndef WEAVEPROJECTCONFIG_H
 #define WEAVEPROJECTCONFIG_H
 
-
+// Enable use of an ephemeral UDP source port for locally initiated Weave exchanges.
 #define WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT 1
+
+// Enable UDP listening on demand in the WeaveDeviceManager
+#define WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP 1
 
 // Configure WDM for event offload
 #define WEAVE_CONFIG_EVENT_LOGGING_WDM_OFFLOAD 1

--- a/src/device-manager/WeaveDeviceManager.h
+++ b/src/device-manager/WeaveDeviceManager.h
@@ -437,6 +437,14 @@ private:
     // Use by static HandleConnectionReceived callback.
     static WeaveDeviceManager *sListeningDeviceMgr;
 
+#if WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP
+    bool mUDPEnabled;
+    static uint32_t sUDPDemandEnableCount;
+
+    WEAVE_ERROR EnableUDP(void);
+    WEAVE_ERROR DisableUDP(void);
+#endif
+
     WEAVE_ERROR DoRemotePassiveRendezvous(const IPAddress rendezvousDeviceAddr, const uint16_t rendezvousTimeout,
             const uint16_t inactivityTimeout, void *appReqState, CompleteFunct onComplete, ErrorFunct onError);
 

--- a/src/device-manager/cocoa/NLWeaveStack.mm
+++ b/src/device-manager/cocoa/NLWeaveStack.mm
@@ -190,8 +190,12 @@ exit:
     err = _mFabricState.Init();
     SuccessOrExit(err);
 
-    // TODO: TEMPORARY HACK -- use a different default node id to avoid conflict with the mock device.
-    _mFabricState.LocalNodeId = 2;
+    // Not a member of a fabric.
+    _mFabricState.FabricId = 0;
+
+    // Generate a unique node id for local Weave stack.
+    err = GenerateWeaveNodeId(_mFabricState.LocalNodeId);
+    SuccessOrExit(err);
 
     // Configure the weave listening address, if one was provided
     {
@@ -234,7 +238,14 @@ exit:
     initContext.inet = &_mInetLayer;
     initContext.fabricState = &_mFabricState;
     initContext.listenTCP = false;
+#if WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP
+    initContext.listenUDP = false;
+#else
     initContext.listenUDP = true;
+#endif
+#if WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
+    initContext.enableEphemeralUDPPort = true;
+#endif
     err = _mMessageLayer.Init(&initContext);
     SuccessOrExit(err);
 

--- a/src/device-manager/java/WeaveDeviceManager-JNI.cpp
+++ b/src/device-manager/java/WeaveDeviceManager-JNI.cpp
@@ -341,21 +341,29 @@ jint JNI_OnLoad(JavaVM *jvm, void *reserved)
     err = sFabricState.Init();
     SuccessOrExit(err);
 
-    // TODO: TEMPORARY HACK -- use a different default node id to avoid conflict with the mock device.
-    sFabricState.LocalNodeId = 2;
-
-    // Set the fabric ID to unset
+    // Not a member of a fabric.
     sFabricState.FabricId = 0;
+
+    // Generate a unique node id for local Weave stack.
+    err = GenerateWeaveNodeId(sFabricState.LocalNodeId);
+    SuccessOrExit(err);
 
     // Initialize the WeaveMessageLayer object.
     initContext.systemLayer = &sSystemLayer;
     initContext.inet = &sInet;
     initContext.fabricState = &sFabricState;
     initContext.listenTCP = false;
+#if WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP
+    initContext.listenUDP = false;
+#else
     initContext.listenUDP = true;
+#endif
 #if CONFIG_NETWORK_LAYER_BLE
     initContext.ble = &sBle;
     initContext.listenBLE = true;
+#endif
+#if WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
+    initContext.enableEphemeralUDPPort = true;
 #endif
     err = sMessageLayer.Init(&initContext);
     SuccessOrExit(err);

--- a/src/device-manager/python/WeaveDeviceManager-ScriptBinding.cpp
+++ b/src/device-manager/python/WeaveDeviceManager-ScriptBinding.cpp
@@ -1162,14 +1162,24 @@ WEAVE_ERROR nl_Weave_Stack_Init()
     SuccessOrExit(err);
 
     FabricState.FabricId = 0; // Not a member of any fabric
-    FabricState.LocalNodeId = 1; // TODO: TEMPORARY HACK -- use a different default node id to avoid conflict with the mock device.
+
+    // Generate a unique node id for local Weave stack.
+    err = GenerateWeaveNodeId(FabricState.LocalNodeId);
+    SuccessOrExit(err);
 
     // Initialize the WeaveMessageLayer object.
     initContext.systemLayer = &sSystemLayer;
     initContext.inet = &Inet;
     initContext.fabricState = &FabricState;
     initContext.listenTCP = false;
+#if WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP
+    initContext.listenUDP = false;
+#else
     initContext.listenUDP = true;
+#endif
+#if WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
+    initContext.enableEphemeralUDPPort = true;
+#endif
 
     err = MessageLayer.Init(&initContext);
     SuccessOrExit(err);

--- a/src/device-manager/python/weave-device-mgr.py
+++ b/src/device-manager/python/weave-device-mgr.py
@@ -508,7 +508,8 @@ class DeviceMgrCmd(Cmd):
             print(str(ex))
             return
 
-        print("Connected to device.")
+        print("Connected to device %X at %s" % (self.devMgr.DeviceId(), self.devMgr.DeviceAddress()))
+
     def do_blediagtest(self, line):
         """
         ble-diag-test [ <options> ]

--- a/src/lib/core/WeaveConfig.h
+++ b/src/lib/core/WeaveConfig.h
@@ -2284,7 +2284,7 @@
  *  @def WEAVE_CONFIG_ALWAYS_USE_LEGACY_ADD_NETWORK_MESSAGE
  *
  *  @brief
- *    Enable (1) or disable (0) the exclusive use of the depricated
+ *    Enable (1) or disable (0) the exclusive use of the deprecated
  *    version of AddNetwork() message in the Network Provisioning
  *    profile.
  *    This option should be enabled when exclusively pairing with Nest
@@ -2307,6 +2307,24 @@
 #ifndef WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
 #define WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN         0
 #endif // WEAVE_CONFIG_ENABLE_IFJ_SERVICE_FABRIC_JOIN
+
+/**
+ *  @def WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP
+ *
+ *  @brief
+ *    Demand enable UDP as needed in the WeaveDeviceManager
+ *
+ *  When this option is enabled, the WeaveDeviceManager will automatically enable
+ *  listening for Weave messages over UDP whenever required to perform a device
+ *  management operation, and disable it when the operation completes.
+ *
+ *  This feature can be used to reduce competition for UDP listening ports the
+ *  WeaveDeviceManager is used in multiple processes on the same host.
+ *
+ */
+#ifndef WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP
+#define WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP     0
+#endif // WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP
 
 /**
  * @def WEAVE_NON_PRODUCTION_MARKER

--- a/src/lib/core/WeaveMessageLayer.cpp
+++ b/src/lib/core/WeaveMessageLayer.cpp
@@ -1725,7 +1725,7 @@ void WeaveMessageLayer::HandleUDPMessage(UDPEndPoint *endPoint, PacketBuffer *ms
 exit:
     if (err != WEAVE_NO_ERROR)
     {
-        WeaveLogError(MessageLayer, "HandleUDPMessage Error %d", err);
+        WeaveLogError(MessageLayer, "HandleUDPMessage Error %s", nl::ErrorStr(err));
 
         PacketBuffer::Free(msg);
 
@@ -1743,7 +1743,7 @@ exit:
 
 void WeaveMessageLayer::HandleUDPReceiveError(UDPEndPoint *endPoint, INET_ERROR err, const IPPacketInfo *pktInfo)
 {
-    WeaveLogError(MessageLayer, "HandleUDPReceiveError Error %d", err);
+    WeaveLogError(MessageLayer, "HandleUDPReceiveError Error %s", nl::ErrorStr(err));
 
     WeaveMessageLayer *msgLayer = (WeaveMessageLayer *) endPoint->AppState;
     if (msgLayer->OnReceiveError != NULL)


### PR DESCRIPTION
- Assign a random Weave node id to the local Weave stack when the WeaveDeviceManager is used on Android, iOS and from within Python.  This ensures that devices will treat separate WeaveDeviceManager instances running in different processes on the same host as distinct Weave nodes.

- Enabled use of an ephemeral UDP port for outgoing communication from the WeaveDeviceManager on the Android, iOS and Python.

- Added a build feature that enables listening on the Weave UDP port only when the Device Manager is attempting to identify or rendezvous with a device.  This reduces competition for the Weave port when the WeaveDeviceManager is used by multiple processes on the same host. This feature is enabled by default on Android, iOS and within Python.

- Minor adjustments to logging in WeaveDeviceManager, WeaveMessageLayer and Python wrapper code.