### PR TITLE
add TESTS=0|1 option in standalone compilation

### DIFF
--- a/Makefile-Standalone
+++ b/Makefile-Standalone
@@ -38,6 +38,7 @@ USE_LWIP                       ?= 0
 NO_OPENSSL                     ?= 0
 BLUEZ                          ?= 0
 USE_FUZZING                    ?= 0
+TESTS                          ?= 1
 
 HOSTOS                          = $(shell uname -s |tr [:upper:] [:lower:])
 ARCH                            = $(shell uname -m |tr [:upper:] [:lower:])
@@ -235,6 +236,13 @@ endif
 
 ifdef SCHEMA
 configure_OPTIONS              += --with-schema=$(SCHEMA)
+else
+configure_OPTIONS              +=
+endif
+
+# Disable tests generation
+ifeq ($(TESTS),0)
+configure_OPTIONS              += --disable-tests
 else
 configure_OPTIONS              +=
 endif
@@ -559,5 +567,7 @@ command line or in the environment:
                           default location to the Happy tool.  When set to any
                           other value, the value is treated as the location of
                           the Happy tool.
+
+  TESTS=[1|0]             Enable/disable tests (default: '$(TESTS)').
 
 endef


### PR DESCRIPTION
-- some traits, for example, localsetting and localecapability trait, are used not only in mobile client, but also in mock-device, for that case, when using weave data management client in mobile client or linux pairing tool, we need to disalbe these internal trait via TESTS=0 in standalone compilation.