### PR TITLE
Persistent service directory

### DIFF
--- a/src/lib/core/WeaveConfig.h
+++ b/src/lib/core/WeaveConfig.h
@@ -1905,6 +1905,23 @@
 #endif // WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
 
 /**
+ *  @def WEAVE_CONFIG_PERSIST_SERVICE_DIRECTORY
+ *
+ *  @brief
+ *    If set to (1), persistent service directory is enabled.
+ *    Default value is (0) or disabled.
+ *
+ *  @note
+ *    Enabling this feature flag persists the service directory
+ *    cache retrieved from the directory server and use it to
+ *    populate the in-memory cache at initialization time.
+ *
+ */
+#ifndef WEAVE_CONFIG_PERSIST_SERVICE_DIRECTORY
+#define WEAVE_CONFIG_PERSIST_SERVICE_DIRECTORY               0
+#endif // WEAVE_CONFIG_PERSIST_SERVICE_DIRECTORY
+
+/**
  *  @def WEAVE_CONFIG_SERVICE_DIR_CONNECT_TIMEOUT_MSECS
  *
  *  @brief

--- a/src/lib/profiles/service-directory/ServiceDirectory.h
+++ b/src/lib/profiles/service-directory/ServiceDirectory.h
@@ -133,6 +133,27 @@ enum
     kServiceMgrState_Resolved =             3
 };
 
+#if WEAVE_CONFIG_PERSIST_SERVICE_DIRECTORY
+enum
+{
+    /** Version number associated with persisted service directory data
+     *
+     * By convention, the version number of persisted service directory
+     * data is the same as the message type number of the SD response
+     * message.  This reflects the fact that the persisted data is an
+     * exact copy of the payload of that message.
+     */
+    kPersistedServiceDirVersion = kMsgType_ServiceEndpointResponse
+};
+
+namespace Platform {
+    extern WEAVE_ERROR LoadPersistentServiceDir(uint8_t *buf, uint16_t bufsize, uint16_t &len, uint8_t version);
+    extern WEAVE_ERROR StorePersistentServiceDir(uint8_t *buf, uint16_t len, uint8_t version);
+    extern WEAVE_ERROR ClearPersistentServiceDir();
+    extern bool IsPersistentServiceDirPresent(uint8_t version);
+}
+#endif // WEAVE_CONFIG_PERSIST_SERVICE_DIRECTORY
+
 #define kServiceEndpoint_Directory              (0x18B4300200000001ull)     ///< Directory profile endpoint
 #define kServiceEndpoint_SoftwareUpdate         (0x18B4300200000002ull)     ///< Software update profile endpoint
 #define kServiceEndpoint_Data_Management        (0x18B4300200000003ull)     ///< Core Weave data management protocol endpoint
@@ -411,6 +432,10 @@ private:
                                  const uint32_t aConnectTimeoutMsecs = 0,
                                  const InterfaceId aConnectIntf = INET_NULL_INTERFACEID);
 
+#if WEAVE_CONFIG_PERSIST_SERVICE_DIRECTORY
+    WEAVE_ERROR loadPersistentServiceDirIntoCache();
+#endif
+    WEAVE_ERROR unpackPacketBuffer(PacketBuffer *aMsg, bool useTimePresent, bool *redir = NULL);
     WEAVE_ERROR cacheDirectory(MessageIterator &, uint8_t, uint8_t *&);
     WEAVE_ERROR cacheSuffixes(MessageIterator &, uint8_t, uint8_t *&);
     WEAVE_ERROR calculateEntryLength(uint8_t *entryStart, uint8_t entryCtrlByte, uint16_t *entryLen);


### PR DESCRIPTION
-Add WEAVE_CONFIG_PERSIST_SERVICE_DIRECTORY for enabling and disabling this feature
-Save the byte stream received from directory server to persistent storage if ‘ServiceDirectory Redirect’ is not issued.
-Clear persisted storage whenever cache is cleared.