### PR TITLE
Add an option to allocate logging buffers on heap

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/WeaveDeviceConfig.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/WeaveDeviceConfig.h
@@ -744,6 +744,17 @@
 #endif
 
 // -------------------- Event Logging Configuration --------------------
+/**
+ * @def WEAVE_DEVICE_CONFIG_EVENT_LOGGING_BUFFER_STATIC
+ *
+ * @brief
+ *   Allocate logging buffer on data segment if defined, or allocate on
+ *   heap dynamically if not defined
+ */
+#ifndef WEAVE_DEVICE_CONFIG_EVENT_LOGGING_BUFFER_STATIC
+#define WEAVE_DEVICE_CONFIG_EVENT_LOGGING_BUFFER_STATIC 1
+#endif
+
 
 /**
  * @def WEAVE_DEVICE_CONFIG_EVENT_LOGGING_CRIT_BUFFER_SIZE


### PR DESCRIPTION
There is limit data segment on some FreeRTOS platform, because the
logging buffer is very large, we may want to move logging buffers
from static data segment to dynamic allocated heap.

The patch introduced an new define option:

WEAVE_DEVICE_CONFIG_EVENT_LOGGING_BUFFER_STATIC

When it is defined, the logging buffer will be allocated statically
on data segment; when it is not defined, the logging buffers will be
allocated dynamically on heap.

Signed-off-by: Zang MingJie <mingjiez@google.com>