### PR TITLE
Modify weave tool (gen-ca-cert command) to allow the -key argument

### DIFF
--- a/src/tools/weave/Cmd_GenCACert.cpp
+++ b/src/tools/weave/Cmd_GenCACert.cpp
@@ -65,8 +65,9 @@ static const char *const gCmdOptionHelp =
     "\n"
     "   -k, --key <file>\n"
     "\n"
-    "       File containing the public and private keys for the new CA certificate.\n"
-    "       (File must be in PEM format).\n"
+    "       File containing the public key for the new CA certificate. The file may\n"
+    "       contain only a public key, or a private key (from which the public key\n"
+    "       can be obtained). The file must be in PEM or DER format.\n"
     "\n"
     "   -C, --ca-cert <file>\n"
     "\n"
@@ -76,7 +77,7 @@ static const char *const gCmdOptionHelp =
     "   -K, --ca-key <file>\n"
     "\n"
     "       File containing CA private key to be used to sign the new CA certificate.\n"
-    "       This file must be in PEM format.\n"
+    "       This file may be in PEM or DER format.\n"
     "\n"
     "   -o, --out <file>\n"
     "\n"
@@ -245,7 +246,7 @@ bool Cmd_GenCACert(int argc, char *argv[])
     else
         newCertFile = stdout;
 
-    if (!ReadPrivateKey(gNewCertKeyFileName, "Enter password for private key:", newCertKey))
+    if (!ReadPublicKey(gNewCertKeyFileName, "Enter password for private key:", newCertKey))
         ExitNow(res = false);
 
     if (!gSelfSign)

--- a/src/tools/weave/weave-tool.h
+++ b/src/tools/weave/weave-tool.h
@@ -132,6 +132,9 @@ extern bool GenerateKeyPair(const char *curveName, EVP_PKEY *& key);
 extern bool EncodePrivateKey(EVP_PKEY *key, KeyFormat keyFormat, uint8_t *& encodedKey, uint32_t& encodedKeyLen);
 extern bool WeaveEncodePrivateKey(EVP_PKEY *key, uint8_t *& encodedKey, uint32_t& encodedKeyLen);
 extern bool WeaveEncodeECPrivateKey(EC_KEY *key, bool includePubKey, uint8_t *& encodedKey, uint32_t& encodedKeyLen);
+extern bool ReadPublicKey(const char *fileName, const char *prompt, EVP_PKEY *& key);
+extern bool DecodePublicKey(const uint8_t *keyData, uint32_t keyDataLen, KeyFormat keyFormat, const char *keySource, const char *prompt, EVP_PKEY *& key);
+extern KeyFormat DetectPublicKeyFormat(const uint8_t *key, uint32_t keyLen);
 
 extern bool InitOpenSSL();
 extern OID NIDToWeaveOID(int nid);


### PR DESCRIPTION
to be a public key (PEM or DER). Currently the tool requires a private key,
which is not available in some scenarios.