### PR TITLE
clear _mWeaveCppGenericTraitUpdatableDataSink when shutdown_Internal …

### DIFF
--- a/src/device-manager/cocoa/NLGenericTraitUpdatableDataSink.mm
+++ b/src/device-manager/cocoa/NLGenericTraitUpdatableDataSink.mm
@@ -291,6 +291,7 @@ static void handleGenericUpdatableDataSinkError(
 
     if (_mWeaveCppGenericTraitUpdatableDataSink != nil) {
         _mWeaveCppGenericTraitUpdatableDataSink->Clear();
+        _mWeaveCppGenericTraitUpdatableDataSink = nil;
     }
 }
 


### PR DESCRIPTION
…is triggered in NLGenericTraitUpdatableDataSink.mm

-[NLWdmClient close:] causes -[NLGenericTraitUpdatableDataSink
shutdown_Internal] to be called a first time, which calls
`_mWeaveCppGenericTraitUpdatableDataSink->Clear()`.

When an already-shutdown NLGenericTraitUpdatableDataSink gets
deallocated by ARC, -[NLGenericTraitUpdatableDataSink shutdown_Internal] is
called again, but `if (_mWeaveCppGenericTraitUpdatableDataSink != nil)`
is still true, so `_mWeaveCppGenericTraitUpdatableDataSink->Clear()`
gets called again and causes the crash.

This is fixed when adding in `_mWeaveCppGenericTraitUpdatableDataSink =
nil;` after calling `Clear()` (in -[NLGenericTraitUpdatableDataSink
shutdown_Internal]), so the second `shutdown_Internal` (upon dealloc) is
essentially a no-op instead.