### PR TITLE
Fix printf buffer overflow

### DIFF
--- a/src/adaptations/device-layer/ServiceProvisioningServer.cpp
+++ b/src/adaptations/device-layer/ServiceProvisioningServer.cpp
@@ -76,7 +76,7 @@ WEAVE_ERROR ServiceProvisioningServer::HandleRegisterServicePairAccount(Register
         ExitNow();
     }
 
-    WeaveLogProgress(DeviceLayer, "Registering new service: %" PRIx64 " (account id %*s)", msg.ServiceId, (int)msg.AccountIdLen, msg.AccountId);
+    WeaveLogProgress(DeviceLayer, "Registering new service: %" PRIx64 " (account id %.*s)", msg.ServiceId, (int)msg.AccountIdLen, msg.AccountId);
 
     // Store the service id and the service config in persistent storage.
     err = ConfigurationMgr().StoreServiceProvisioningData(msg.ServiceId, msg.ServiceConfig, msg.ServiceConfigLen, NULL, 0);


### PR DESCRIPTION
printf format %*s is not limiting the string size, here we should use
%.*s to limit the output length.

Change-Id: Iea875e06e0df786b9a0a7f03f1a7bcaba2a1b9b4