### PR TITLE
Workaround delayed subscribe request when doing InitiateSubscription

### DIFF
--- a/src/lib/profiles/data-management/Current/SubscriptionClient.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.h
@@ -539,6 +539,8 @@ private:
                                                               const nl::Weave::WeaveMessageInfo * aMsgInfo, uint32_t aProfileId,
                                                               uint8_t aMsgType, PacketBuffer * aPayload);
 
+    static void OnSubscribeScheduleWorkCallback(System::Layer * aSystemLayer, void * aAppState, System::Error);
+
 #if WEAVE_CONFIG_ENABLE_WDM_UPDATE
 
     IWeaveWDMMutex * mUpdateMutex;


### PR DESCRIPTION
In Java app, when mobile app calls InitiateSubscription with enabled
retry, there is around 10 seconds delay to activate OnTimerCallback
which start the subscription even though timeoutMsec is 0. In python
app, we don't see this issue. There is strong direction that points at
some bad interaction at Java scheduler level and weave exeuction
context.

In contrast, flushUpdate don't have this issue in both Jave and python
app. The key differience in scheduler is that flushUpdate do use SystemLayer->ScheduleWork
in the beginning to issue flush, which somehow make Java scheduler
happy. After applying the SchedulerWork pattern to InitiateSubscription,
the delayed subscribe issue goes away.