### PR TITLE
[Thread] Support Weave thread border routing

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_Thread.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_Thread.ipp
@@ -29,10 +29,6 @@
 #include <Weave/DeviceLayer/internal/GenericConnectivityManagerImpl_Thread.h>
 #include <Warm/Warm.h>
 
-#if WARM_CONFIG_SUPPORT_THREAD_ROUTING
-#include <openthread/thread.h>
-#endif // WARM_CONFIG_SUPPORT_THREAD_ROUTING
-
 namespace nl {
 namespace Weave {
 namespace DeviceLayer {
@@ -72,14 +68,8 @@ void GenericConnectivityManagerImpl_Thread<ImplClass>::_OnPlatformEvent(const We
                                     event->ThreadStateChange.RoleChanged);
     if (threadRoleChanged)
     {
-        otDeviceRole role;
-        ThreadStackMgrImpl().LockThreadStack();
-        role = otThreadGetDeviceRole(ThreadStackMgrImpl().OTInstance());
-        ThreadStackMgrImpl().UnlockThreadStack();
-
-        bool isThreadRouter = (role == OT_DEVICE_ROLE_LEADER || role == OT_DEVICE_ROLE_ROUTER);
-
-        nl::Weave::Warm::InterfaceState interfaceState = isThreadRouter
+        ConnectivityManager::ThreadDeviceType deviceType = ThreadStackMgr().GetThreadDeviceType();
+        nl::Weave::Warm::InterfaceState interfaceState = (deviceType == ConnectivityManager::ThreadDeviceType::kThreadDeviceType_Router)
                                                          ? nl::Weave::Warm::kInterfaceStateUp
                                                          : nl::Weave::Warm::kInterfaceStateDown;
         Warm::ThreadRoutingStateChange(interfaceState);

--- a/src/warm/WarmCore.cpp
+++ b/src/warm/WarmCore.cpp
@@ -836,7 +836,7 @@ static PlatformResult ThreadAdvertisementAction(ActionType inAction, bool inActi
 {
     Inet::IPPrefix prefix;
 
-    MakePrefix(inGlobalId, 0, kGlobalULAPrefixLength, prefix);
+    MakePrefix(inGlobalId, kWeaveSubnetId_ThreadMesh, kThreadULAAddressPrefixLength, prefix);
 
     return Platform::StartStopThreadAdvertisement(kInterfaceTypeThread, prefix, inActivate);
 }


### PR DESCRIPTION
This PR adds related openthread api call to WarmSupport in LwIP.

- When add or removing thread addresses, will also add weave thread subnet mesh prefix to thread stack.
- Add fabric prefix to thread border router.