### PR TITLE
Weave Data Management mobile support improvements

### DIFF
--- a/src/device-manager/cocoa/Makefile.am
+++ b/src/device-manager/cocoa/Makefile.am
@@ -66,6 +66,8 @@ libNLWeaveDeviceManager_a_HEADERS        = \
     NLWdmClient.h                          \
     NLGenericTraitUpdatableDataSink.h      \
     NLResourceIdentifier.h                 \
+    NLWdmClientFlushUpdateError.h          \
+    NLWdmClientFlushUpdateDeviceStatusError.h       \
     $(NULL)
 
 noinst_HEADERS                           = \
@@ -75,8 +77,8 @@ noinst_HEADERS                           = \
     NLWeaveError_Protected.h               \
     NLWeaveDeviceManager_Protected.h       \
     NLWdmClient_Protected.h                \
-    NLGenericTraitUpdatableDataSink_Protected.h       \
     NLResourceIdentifier_Protected.h       \
+    NLGenericTraitUpdatableDataSink_Protected.h     \
     $(NULL)
 
 libNLWeaveDeviceManager_a_SOURCES        = \
@@ -102,6 +104,8 @@ libNLWeaveDeviceManager_a_SOURCES        = \
     NLWdmClient.mm                         \
     NLGenericTraitUpdatableDataSink.mm     \
     NLResourceIdentifier.mm                \
+    NLWdmClientFlushUpdateError.mm         \
+    NLWdmClientFlushUpdateDeviceStatusError.mm                \
     $(NULL)
 
 endif # WEAVE_WITH_COCOA

--- a/src/device-manager/cocoa/NLGenericTraitUpdatableDataSink.h
+++ b/src/device-manager/cocoa/NLGenericTraitUpdatableDataSink.h
@@ -45,7 +45,7 @@ typedef void (^GenericTraitUpdatableDataSinkFailureBlock)(id owner, NSError * er
 - (NSString *)toErrorString:(WEAVE_ERROR)err;
 
 /**
- * clear trait data
+ * clear the whole trait data
  */
 - (void)clear;
 
@@ -229,12 +229,12 @@ typedef void (^GenericTraitUpdatableDataSinkFailureBlock)(id owner, NSError * er
 /**
  * Get the string value assigned to the property at the given path within this trait.
  */
-- (NSString *)getString:(NSString *)path;
+- (WEAVE_ERROR)getString:(NSString **)val path:(NSString *)path;
 
 /**
  * Get the bytes value assigned to the property at the given path within this trait.
  */
-- (NSData *)getBytes:(NSString *)path;
+- (WEAVE_ERROR)getBytes:(NSData **)val path:(NSString *)path;
 
 /**
  * Check if null property at the given path within this trait.
@@ -244,9 +244,11 @@ typedef void (^GenericTraitUpdatableDataSinkFailureBlock)(id owner, NSError * er
 /**
  * Get the string array value assigned to the property at the given path within this trait.
  */
-- (NSArray *)getStringArray:(NSString *)path;
+- (WEAVE_ERROR)getStringArray:(NSMutableArray **)val path:(NSString *)path;
 
 /** Returns the version of the trait represented by this data sink. */
 - (WEAVE_ERROR)getVersion:(uint64_t *)val;
 
+/** Delete the trait property data on particular path. */
+- (WEAVE_ERROR)deleteData:(NSString *)path;
 @end

--- a/src/device-manager/cocoa/NLGenericTraitUpdatableDataSink.mm
+++ b/src/device-manager/cocoa/NLGenericTraitUpdatableDataSink.mm
@@ -128,18 +128,18 @@ exit:
     return result;
 }
 
-static void handleGenericUpdatableDataSinkComplete(void * dataSink, void * reqState)
+static void onGenericUpdatableDataSinkComplete(void * dataSink, void * reqState)
 {
-    WDM_LOG_DEBUG(@"handleGenericUpdatableDataSinkComplete");
+    WDM_LOG_DEBUG(@"onGenericUpdatableDataSinkComplete");
 
     NLGenericTraitUpdatableDataSink * sink = (__bridge NLGenericTraitUpdatableDataSink *) reqState;
     [sink DispatchAsyncCompletionBlock:nil];
 }
 
-static void handleGenericUpdatableDataSinkError(
+static void onGenericUpdatableDataSinkError(
     void * dataSink, void * appReqState, WEAVE_ERROR code, nl::Weave::DeviceManager::DeviceStatus * devStatus)
 {
-    WDM_LOG_DEBUG(@"handleGenericUpdatableDataSinkError");
+    WDM_LOG_DEBUG(@"onGenericUpdatableDataSinkError with error code %d\n", code);
 
     NSError * error = nil;
     NSDictionary * userInfo = nil;
@@ -336,7 +336,7 @@ exit:
             _mFailureHandler = [failureHandler copy];
 
             WEAVE_ERROR err = _mWeaveCppGenericTraitUpdatableDataSink->RefreshData(
-                (__bridge void *) self, handleGenericUpdatableDataSinkComplete, handleGenericUpdatableDataSinkError);
+                (__bridge void *) self, onGenericUpdatableDataSinkComplete, onGenericUpdatableDataSinkError);
 
             if (WEAVE_NO_ERROR != err) {
                 [self DispatchAsyncDefaultFailureBlockWithCode:err];
@@ -364,11 +364,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->SetData([path UTF8String], val, isConditionalBool);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from SetSigned, ignore");
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
@@ -390,12 +385,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->SetData([path UTF8String], val, isConditionalBool);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from SetUnsigned, ignore");
-
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
@@ -417,11 +406,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->SetData([path UTF8String], val, isConditionalBool);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from SetDouble, ignore");
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
@@ -443,10 +427,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->SetBoolean([path UTF8String], valBool, isConditionalBool);
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from SetBoolean, ignore");
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
@@ -467,11 +447,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->SetString([path UTF8String], [val UTF8String], isConditionalBool);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from SetData, ignore");
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
@@ -493,11 +468,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->SetNull([path UTF8String], isConditionalBool);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from SetData, ignore");
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
@@ -521,11 +491,6 @@ exit:
             uint32_t valLen = (uint32_t)[val length];
             uint8_t * pVal = (uint8_t *) [val bytes];
             err = _mWeaveCppGenericTraitUpdatableDataSink->SetBytes([path UTF8String], pVal, valLen, isConditionalBool);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from SetBytes, ignore");
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
@@ -552,10 +517,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->SetStringArray([path UTF8String], stringVector, isConditionalBool);
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from SetStringArray, ignore");
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
@@ -620,13 +581,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->GetData([path UTF8String], result);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from GetSigned, ignore");
-
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-                result = 0;
-            }
         });
     }
 
@@ -653,13 +607,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->GetData([path UTF8String], result);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from GetUnsigned, ignore");
-
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-                result = 0;
-            }
         });
     }
 
@@ -686,13 +633,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->GetData([path UTF8String], result);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from GetDouble, ignore");
-
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-                result = 0;
-            }
         });
     }
 
@@ -719,12 +659,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->GetBoolean([path UTF8String], result);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from GetBoolean, ignore");
-
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
@@ -736,32 +670,29 @@ exit:
     return err;
 }
 
-- (NSString *)getString:(NSString *)path
+- (WEAVE_ERROR)getString:(NSString **)val path:(NSString *)path
 {
     __block WEAVE_ERROR err = WEAVE_NO_ERROR;
     __block nl::Weave::DeviceManager::BytesData bytesData;
-    NSString * result = nil;
+
     WDM_LOG_METHOD_SIG();
 
     VerifyOrExit(NULL != _mWeaveCppGenericTraitUpdatableDataSink, err = WEAVE_ERROR_INCORRECT_STATE);
 
     // need this bracket to use Verify macros
     {
-        // we use sync so the result is immediately available to the caller upon return
+        // we use sync so the bytesData is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->GetBytes([path UTF8String], &bytesData);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from GetString, ignore");
-
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
-    result = [[NSString alloc] initWithBytes:bytesData.mpDataBuf length:bytesData.mDataLen encoding:NSUTF8StringEncoding];
 
 exit:
-    return result;
+    if ((WEAVE_NO_ERROR == err) && (NULL != val))
+    {
+        *val = [[NSString alloc] initWithBytes:bytesData.mpDataBuf length:bytesData.mDataLen encoding:NSUTF8StringEncoding];
+    }
+    return err;
 }
 
 - (WEAVE_ERROR)isNull:(BOOL *)val path:(NSString *)path;
@@ -779,12 +710,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->IsNull([path UTF8String], result);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from isNull, ignore");
-
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
@@ -796,64 +721,59 @@ exit:
     return err;
 }
 
-- (NSData *)getBytes:(NSString *)path
+- (WEAVE_ERROR)getBytes:(NSData **)val path:(NSString *)path
 {
     __block WEAVE_ERROR err = WEAVE_NO_ERROR;
     __block nl::Weave::DeviceManager::BytesData bytesData;
-    NSData * result = nil;
     WDM_LOG_METHOD_SIG();
 
     VerifyOrExit(NULL != _mWeaveCppGenericTraitUpdatableDataSink, err = WEAVE_ERROR_INCORRECT_STATE);
+    VerifyOrExit(NULL != val, err = WEAVE_ERROR_INVALID_ARGUMENT);
 
     // need this bracket to use Verify macros
     {
-        // we use sync so the result is immediately available to the caller upon return
+        // we use sync so the bytesData is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->GetBytes([path UTF8String], &bytesData);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from GetBytes, ignore");
-
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
-    result = [NSData dataWithBytes:bytesData.mpDataBuf length:bytesData.mDataLen];
 exit:
-    return result;
+    if ((WEAVE_NO_ERROR == err) && (NULL != val))
+    {
+        *val = [NSData dataWithBytes:bytesData.mpDataBuf length:bytesData.mDataLen];
+    }
+
+    return err;
 }
 
-- (NSArray *)getStringArray:(NSString *)path
+- (WEAVE_ERROR)getStringArray:(NSMutableArray **)val path:(NSString *)path
 {
     __block WEAVE_ERROR err = WEAVE_NO_ERROR;
     __block std::vector<std::string> stringVector;
-    NSMutableArray * arrayOut = [[NSMutableArray alloc] init];
 
     WDM_LOG_METHOD_SIG();
 
     VerifyOrExit(NULL != _mWeaveCppGenericTraitUpdatableDataSink, err = WEAVE_ERROR_INCORRECT_STATE);
+    VerifyOrExit(NULL != val, err = WEAVE_ERROR_INVALID_ARGUMENT);
 
     // need this bracket to use Verify macros
     {
-        // we use sync so the result is immediately available to the caller upon return
+        // we use sync so the stringVector is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             err = _mWeaveCppGenericTraitUpdatableDataSink->GetStringArray([path UTF8String], stringVector);
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from GetStringArray, ignore");
-
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-            }
         });
     }
 
-    for (auto iter = stringVector.begin(); iter < stringVector.end(); iter++) {
-        [arrayOut addObject:[NSString stringWithCString:iter->c_str() encoding:[NSString defaultCStringEncoding]]];
-    }
-
 exit:
-    return arrayOut;
+    if ((WEAVE_NO_ERROR == err) && (NULL != val))
+    {
+        *val = [[NSMutableArray alloc] init];
+        for (auto iter = stringVector.begin(); iter < stringVector.end(); iter++) {
+            [*val addObject:[NSString stringWithCString:iter->c_str() encoding:[NSString defaultCStringEncoding]]];
+        }
+    }
+    return err;
 }
 
 - (WEAVE_ERROR)getVersion:(uint64_t *)val
@@ -871,13 +791,6 @@ exit:
         // we use sync so the result is immediately available to the caller upon return
         dispatch_sync(_mWeaveWorkQueue, ^() {
             result = _mWeaveCppGenericTraitUpdatableDataSink->GetVersion();
-
-            if (err == WEAVE_ERROR_INCORRECT_STATE) {
-                WDM_LOG_DEBUG(@"Got incorrect state error from GetVersion, ignore");
-
-                err = WEAVE_NO_ERROR; // No exception, just return 0.
-                result = 0;
-            }
         });
     }
 
@@ -886,6 +799,26 @@ exit:
         *val = result;
     }
 
+    return err;
+}
+
+- (WEAVE_ERROR)deleteData:(NSString *)path
+{
+    __block WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    WDM_LOG_METHOD_SIG();
+
+    VerifyOrExit(NULL != _mWeaveCppGenericTraitUpdatableDataSink, err = WEAVE_ERROR_INCORRECT_STATE);
+
+    // need this bracket to use Verify macros
+    {
+        // we use sync so the result is immediately available to the caller upon return
+        dispatch_sync(_mWeaveWorkQueue, ^() {
+            err = _mWeaveCppGenericTraitUpdatableDataSink->DeleteData([path UTF8String]);
+        });
+    }
+
+exit:
     return err;
 }
 

--- a/src/device-manager/cocoa/NLWdmClient.h
+++ b/src/device-manager/cocoa/NLWdmClient.h
@@ -75,7 +75,11 @@ typedef void (^WdmClientFailureBlock)(id owner, NSError * error);
 
 /**
  * Begins a flush of all trait data. The result of this operation can be observed through the CompletionHandler and
- * failureHandler
+ * failureHandler, when operation completes, onWdmClientFlushUpdateComplete is called, application would receive statusResultsList,
+ * if it is empty, it means success without failed path, if anything inside, the array member could be NLWdmClientFlushUpdateError(local client error)
+ * or NLWdmClientFlushUpdateDeviceStatus(remote device status), application can use the path and dataSink from the above member to clear
+ * particular data or skip the error if necessary. When operation fails, it usually means the operation cannot complete at all, for example
+ * communication or protocol issue, onWdmClientError would be called.
  */
 - (void)flushUpdate:(WdmClientCompletionBlock)completionHandler failure:(WdmClientFailureBlock)failureHandler;
 

--- a/src/device-manager/cocoa/NLWdmClientFlushUpdateDeviceStatusError.h
+++ b/src/device-manager/cocoa/NLWdmClientFlushUpdateDeviceStatusError.h
@@ -1,0 +1,44 @@
+/*
+ *
+ *    Copyright (c) 2020 Google, LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Objective-C representation of a device status for WdmClient flush update operation
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "NLProfileStatusError.h"
+#import "NLGenericTraitUpdatableDataSink.h"
+#import "NLGenericTraitUpdatableDataSink.h"
+
+@interface NLWdmClientFlushUpdateDeviceStatusError : NLProfileStatusError
+
+@property (nonatomic, readonly) NSString * path;
+@property (nonatomic, readonly) NLGenericTraitUpdatableDataSink * dataSink;
+
+- (id)initWithProfileId:(uint32_t)profileId
+             statusCode:(uint16_t)statusCode
+              errorCode:(uint32_t)errorCode
+           statusReport:(NSString *)statusReport
+                   path:(NSString *)path
+               dataSink:(NLGenericTraitUpdatableDataSink *)dataSink;
+- (NSInteger)translateErrorCode;
+
+@end

--- a/src/device-manager/cocoa/NLWdmClientFlushUpdateDeviceStatusError.mm
+++ b/src/device-manager/cocoa/NLWdmClientFlushUpdateDeviceStatusError.mm
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2020 Google, LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Objective-C representation of a device status for WdmClient flush update operation
+ *
+ */
+
+// Note that the choice of namespace alias must be made up front for each and every compile unit
+// This is because many include paths could set the default alias to unintended target.
+
+#import "NLProfileStatusError.h"
+#import "NLWdmClientFlushUpdateDeviceStatusError.h"
+
+@interface NLWdmClientFlushUpdateDeviceStatusError () {
+    NSString * _statusReport;
+}
+
+@end
+
+@implementation NLWdmClientFlushUpdateDeviceStatusError
+
+- (id)initWithProfileId:(uint32_t)profileId
+             statusCode:(uint16_t)statusCode
+              errorCode:(uint32_t)errorCode
+           statusReport:(NSString *)statusReport
+                   path:(NSString *)path
+               dataSink:(NLGenericTraitUpdatableDataSink*) dataSink
+{
+    self = [super initWithProfileId:profileId statusCode:statusCode errorCode:errorCode statusReport:statusReport];
+    if (self)
+    {
+        _path = path;
+        _dataSink = dataSink;
+    }
+    return self;
+}
+
+- (NSString *)description
+{
+    NSString * emptyStatusReport =
+            [NSString stringWithFormat:@"No StatusReport available. profileId = %ld, statusCode = %ld, SysErrorCode = %ld, failed path is %@ ",
+                                       (long) self.profileId, (long) self.statusCode, (long) self.errorCode, _path];
+
+    return _statusReport ? ([NSString stringWithFormat:@"%@, SysErrorCode = %ld, failed path is %@", _statusReport, (long) self.errorCode, _path])
+                         : emptyStatusReport;
+}
+
+@end

--- a/src/device-manager/cocoa/NLWdmClientFlushUpdateError.h
+++ b/src/device-manager/cocoa/NLWdmClientFlushUpdateError.h
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2020 Google, LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Objective-C representation of a local client error for WdmClient flush update operation
+ *
+ */
+
+#import <Foundation/Foundation.h>
+#import "NLWeaveDeviceManagerTypes.h"
+#import "NLWeaveErrorCodes.h"
+#import "NLWeaveError.h"
+#import "NLGenericTraitUpdatableDataSink.h"
+
+@interface NLWdmClientFlushUpdateError : NLWeaveError
+
+@property (nonatomic, readonly) NSString * path;
+@property (nonatomic, readonly) NLGenericTraitUpdatableDataSink * dataSink;
+
+- (id)initWithWeaveError:(WEAVE_ERROR)weaveError
+                  report:(NSString *)report
+                    path:(NSString *)path
+                dataSink:(NLGenericTraitUpdatableDataSink*) dataSink;
+
+@end

--- a/src/device-manager/cocoa/NLWdmClientFlushUpdateError.mm
+++ b/src/device-manager/cocoa/NLWdmClientFlushUpdateError.mm
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2020 Google, LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Translation of WdmClientFlushUpdate errors into native Objective C types.
+ *
+ */
+
+#import "NLWeaveError_Protected.h"
+#import "NLWdmClientFlushUpdateError.h"
+
+@interface NLWdmClientFlushUpdateError () {
+    NSString * _errorReport;
+}
+@end
+
+@implementation NLWdmClientFlushUpdateError
+
+- (id)initWithWeaveError:(WEAVE_ERROR)weaveError
+                  report:(NSString *)report
+                    path:(NSString *)path
+                dataSink:(NLGenericTraitUpdatableDataSink*) dataSink
+{
+    self = [super initWithWeaveError:weaveError report:report];
+    if (self)
+    {
+        _path = path;
+        _dataSink = dataSink;
+    }
+    return self;
+}
+
+- (NSString *)description
+{
+    NSString * emptyErrorReport = [NSString
+        stringWithFormat:@"No Error information available. errorCode = %ld (0x%lx), failed path is %@", (long) self.errorCode, (long) self.errorCode, _path];
+
+    return _errorReport ? ([NSString stringWithFormat:@"%@ - errorCode: %ld, failed path is %@", _errorReport, (long) self.errorCode, _path])
+                        : emptyErrorReport;
+}
+@end

--- a/src/device-manager/cocoa/NLWdmClient_Protected.h
+++ b/src/device-manager/cocoa/NLWdmClient_Protected.h
@@ -38,5 +38,6 @@
 - (NSString *)statusReportToString:(NSUInteger)profileId statusCode:(NSInteger)statusCode;
 
 - (void)removeDataSinkRef:(long long)traitInstancePtr;
+- (NLGenericTraitUpdatableDataSink *)getDataSink:(long long)traitInstancePtr;
 
 @end

--- a/src/device-manager/java/Makefile.am
+++ b/src/device-manager/java/Makefile.am
@@ -110,6 +110,8 @@ WeaveDeviceManager_jar_JAVA_SRCS                   =        \
     nl/Weave/DataManagement/GenericTraitUpdatableDataSinkImpl.java \
     nl/Weave/DataManagement/WdmClientFactory.java           \
     nl/Weave/DataManagement/ResourceIdentifier.java         \
+    nl/Weave/DataManagement/WdmClientFlushUpdateException.java          \
+    nl/Weave/DataManagement/WdmClientFlushUpdateDeviceException.java    \
     $(NULL)
 
 WeaveDeviceManager_jar_JFLAGS                      = -source 6 -target 6

--- a/src/device-manager/java/src/nl/Weave/DataManagement/GenericTraitUpdatableDataSink.java
+++ b/src/device-manager/java/src/nl/Weave/DataManagement/GenericTraitUpdatableDataSink.java
@@ -36,7 +36,7 @@ import java.util.Iterator;
 public interface GenericTraitUpdatableDataSink
 {
     /**
-     * clear trait data
+     * clear the whole trait data.
      */
     public void clear();
 
@@ -331,6 +331,9 @@ public interface GenericTraitUpdatableDataSink
 
     /** Returns the version of the trait represented by this data sink. */
     public long getVersion();
+
+    /** Delete the trait property data on on particular path. */
+    public void deleteData(String path);
 
     /**
      * Begins a sync of the trait data. The result of this operation can be observed through the {@link CompletionHandler}

--- a/src/device-manager/java/src/nl/Weave/DataManagement/GenericTraitUpdatableDataSinkImpl.java
+++ b/src/device-manager/java/src/nl/Weave/DataManagement/GenericTraitUpdatableDataSinkImpl.java
@@ -278,6 +278,13 @@ public class GenericTraitUpdatableDataSinkImpl implements GenericTraitUpdatableD
     }
 
     @Override
+    public void deleteData(String path)
+    {
+        ensureNotClosed();
+        deleteData(mTraitInstancePtr, path);
+    }
+
+    @Override
     public void beginRefreshData()
     {
         ensureNotClosed();
@@ -371,4 +378,5 @@ public class GenericTraitUpdatableDataSinkImpl implements GenericTraitUpdatableD
     private native boolean isNull(long genericTraitUpdatableDataSinkPtr, String path);
     private native String[] getStringArray(long genericTraitUpdatableDataSinkPtr, String path);
     private native long getVersion(long genericTraitUpdatableDataSinkPtr);
+    private native void deleteData(long genericTraitUpdatableDataSinkPtr, String path);
 };

--- a/src/device-manager/java/src/nl/Weave/DataManagement/WdmClient.java
+++ b/src/device-manager/java/src/nl/Weave/DataManagement/WdmClient.java
@@ -52,7 +52,12 @@ public interface WdmClient
 
     /**
      * Begins a flush of all trait data. The result of this operation can be observed through the {@link CompletionHandler}
-     * that has been assigned via {@link #setCompletionHandler}.
+     * that has been assigned via {@link #setCompletionHandler}.when operation completes, onFlushUpdateComplete is called,
+     * application would receive throwable exception list, if it is empty, it means success without failed path,
+     * if anything inside, the array member could be WdmClientFlushUpdateException(local client error)
+     * or WdmClientFlushUpdateDeviceException(remote device status), application can use the path and dataSink from the above member to clear
+     * particular data or skip the error if necessary. When operation fails, it usually means the operation cannot complete at all, for example
+     * communication or protocol issue, onError would be called.
      */
     public void beginFlushUpdate();
 
@@ -65,9 +70,11 @@ public interface WdmClient
     public CompletionHandler getCompletionHandler();
     public void setCompletionHandler(CompletionHandler compHandler);
 
+    public GenericTraitUpdatableDataSink getDataSink(long traitInstancePtr);
+
     public interface CompletionHandler
     {
-        void onFlushUpdateComplete();
+        void onFlushUpdateComplete(Throwable[] exceptions, WdmClient wdmClient);
         void onRefreshDataComplete();
         void onError(Throwable err);
     }

--- a/src/device-manager/java/src/nl/Weave/DataManagement/WdmClientFlushUpdateDeviceException.java
+++ b/src/device-manager/java/src/nl/Weave/DataManagement/WdmClientFlushUpdateDeviceException.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *    Copyright (c) 2020 Google, LLC.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package nl.Weave.DataManagement;
+import nl.Weave.DeviceManager.WeaveDeviceException;
+
+/** Represents a exception that occurred on a Weave device during the WdmClient FlushUpdate operation.
+ */
+public class WdmClientFlushUpdateDeviceException extends WeaveDeviceException {
+    public WdmClientFlushUpdateDeviceException (int statusCode, int profileId, int sysErrorCode, String description, String pathStr, long dataSink) {
+        super(statusCode, profileId, sysErrorCode, description != null ? description : String.format("Error Code %d, Profile Id %d, StatusCode %d, path %s", sysErrorCode, profileId, statusCode, pathStr));
+        path = pathStr;
+        dataSinkPtr = dataSink;
+    }
+
+    /**
+     * Get data sink
+     *
+     * @param wdmClient weave data management client
+     *
+     */
+    public GenericTraitUpdatableDataSink getDataSink(WdmClient wdmClient)
+    {
+        return wdmClient.getDataSink(dataSinkPtr);
+    }
+
+    /**
+     * A flushed path
+     */
+    public final String path;
+
+    /**
+     * A data sink reference related to this exception
+     */
+    private final long dataSinkPtr;
+}

--- a/src/device-manager/java/src/nl/Weave/DataManagement/WdmClientFlushUpdateException.java
+++ b/src/device-manager/java/src/nl/Weave/DataManagement/WdmClientFlushUpdateException.java
@@ -1,0 +1,53 @@
+/*
+
+    Copyright (c) 2020 Google, LLC.
+    All rights reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+package nl.Weave.DataManagement;
+import nl.Weave.DeviceManager.WeaveDeviceManagerException;
+
+/** Represents a exception that occurred on the client side during the WdmClient FlushUpdate operation.
+ */
+public class WdmClientFlushUpdateException extends WeaveDeviceManagerException
+{
+    public WdmClientFlushUpdateException(int errorCode, String message, String pathStr, long dataSink)
+    {
+        super(errorCode, message != null ? message : String.format("Error Code %d, Path %s", errorCode, pathStr));
+        path      = pathStr;
+        dataSinkPtr  = dataSink;
+    }
+
+    /**
+     * Get data sink
+     *
+     * @param wdmClient weave data management client
+     *
+     */
+    public GenericTraitUpdatableDataSink getDataSink(WdmClient wdmClient)
+    {
+        return wdmClient.getDataSink(dataSinkPtr);
+    }
+
+    /**
+     * A flushed path
+     */
+    public final String path;
+
+    /**
+     * A data sink reference related to this exception
+     */
+    private final long dataSinkPtr;
+}

--- a/src/device-manager/java/src/nl/Weave/DataManagement/WdmClientImpl.java
+++ b/src/device-manager/java/src/nl/Weave/DataManagement/WdmClientImpl.java
@@ -27,11 +27,11 @@ import android.os.Build;
 import android.util.Log;
 import java.math.BigInteger;
 import java.util.EnumSet;
-import java.util.Random;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 
 public class WdmClientImpl implements WdmClient
 {
@@ -135,6 +135,16 @@ public class WdmClientImpl implements WdmClient
         mCompHandler = compHandler;
     }
 
+    public GenericTraitUpdatableDataSink getDataSink(long traitInstancePtr)
+    {
+        GenericTraitUpdatableDataSink trait = null;
+        if (mTraitMap != null) {
+          trait = mTraitMap.get(traitInstancePtr);
+        }
+
+        return trait;
+    }
+
     // ----- Protected Members -----
     protected void removeDataSinkRef(long traitInstancePtr)
     {
@@ -159,9 +169,9 @@ public class WdmClientImpl implements WdmClient
         requireCompletionHandler().onError(err);
     }
 
-    private void onFlushUpdateComplete()
+    private void onFlushUpdateComplete(Throwable[] exceptions)
     {
-        requireCompletionHandler().onFlushUpdateComplete();
+        requireCompletionHandler().onFlushUpdateComplete(exceptions, this);
     }
 
     private void onRefreshDataComplete()

--- a/src/device-manager/java/src/nl/Weave/DeviceManager/TestMain.java
+++ b/src/device-manager/java/src/nl/Weave/DeviceManager/TestMain.java
@@ -127,6 +127,7 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
         GenericTraitUpdatableDataSink testCTrait;
 
         ResourceIdentifier resourceIdentifier = new ResourceIdentifier();
+
         localSettingsTrait = mockWdmClient.newDataSink(resourceIdentifier, 20, 0, "/");
         testCTrait = mockWdmClient.newDataSink(resourceIdentifier, 593165827, 0, "/");
         localSettingsTrait.setCompletionHandler(this);
@@ -153,6 +154,8 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
         GenericTraitUpdatableDataSink testCTrait;
 
         ResourceIdentifier resourceIdentifier = new ResourceIdentifier();
+        int ExpectedSystemErrors[] = {0, 0, 0, 0, 0, 0};
+
         localSettingsTrait = mockWdmClient.newDataSink(resourceIdentifier, 20, 0, "/");
         testCTrait = mockWdmClient.newDataSink(resourceIdentifier, 593165827, 0, "/");
         localSettingsTrait.setCompletionHandler(this);
@@ -176,7 +179,128 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
         System.out.println("testWdmClientDataSinkSetFlushData Test Succeeded");
     }
 
-    void testWdmClientDataSinkRefreshGetDataRefresh(WeaveDeviceManager deviceMgr)
+    void testWdmClientDataSinkSetFlushInvalidData(WeaveDeviceManager deviceMgr)
+    {
+        WdmClientFactory wdmClientFactory = new WdmClientFactory();
+        WdmClient mockWdmClient = wdmClientFactory.create(deviceMgr);
+        mockWdmClient.setCompletionHandler(this);
+
+        GenericTraitUpdatableDataSink localSettingsTrait;
+        GenericTraitUpdatableDataSink testCTrait;
+
+        ResourceIdentifier resourceIdentifier = new ResourceIdentifier();
+
+        localSettingsTrait = mockWdmClient.newDataSink(resourceIdentifier, 20, 0, "/");
+        testCTrait = mockWdmClient.newDataSink(resourceIdentifier, 593165827, 0, "/");
+        localSettingsTrait.setCompletionHandler(this);
+        testCTrait.setCompletionHandler(this);
+
+        // set invalid data in /1
+        localSettingsTrait.set("/1", 0.1);
+        testCTrait.set("/1", false);
+        testCTrait.setSigned("/2", 15);
+
+        testCTrait.setUnsigned("/3/1", -5);
+        testCTrait.set("/3/2", false);
+        testCTrait.setUnsigned("/4", -6);
+
+        TestResult = null;
+        mockWdmClient.beginFlushUpdate();
+        ExpectSuccess("FlushUpdate");
+
+        System.out.println("testWdmClientDataSinkSetFlushInvalidData Test Stage 1 Succeeded");
+
+        //flush again, expect the empty path result
+
+        TestResult = null;
+        mockWdmClient.beginFlushUpdate();
+        ExpectSuccess("FlushUpdate");
+        System.out.println("testWdmClientDataSinkSetFlushInvalidData Test Stage 2 Succeeded");
+
+        mockWdmClient.close();
+        mockWdmClient = null;
+        localSettingsTrait = null;
+        testCTrait = null;
+        System.out.println("testWdmClientDataSinkSetFlushInvalidData Test Succeeded");
+    }
+
+    void testWdmClientDataSinkSetFlushDataDeleteData(WeaveDeviceManager deviceMgr)
+    {
+        WdmClientFactory wdmClientFactory = new WdmClientFactory();
+        WdmClient mockWdmClient = wdmClientFactory.create(deviceMgr);
+        mockWdmClient.setCompletionHandler(this);
+
+        GenericTraitUpdatableDataSink localSettingsTrait;
+        GenericTraitUpdatableDataSink testCTrait;
+
+        ResourceIdentifier resourceIdentifier = new ResourceIdentifier();
+        int ExpectedSystemErrors[] = {0};
+        localSettingsTrait = mockWdmClient.newDataSink(resourceIdentifier, 20, 0, "/");
+        testCTrait = mockWdmClient.newDataSink(resourceIdentifier, 593165827, 0, "/");
+        localSettingsTrait.setCompletionHandler(this);
+        testCTrait.setCompletionHandler(this);
+
+        localSettingsTrait.set("/1", "en-US");
+        testCTrait.set("/1", false);
+        testCTrait.setSigned("/2", 15);
+        testCTrait.setUnsigned("/3/1", -5);
+        testCTrait.set("/3/2", false);
+        testCTrait.setUnsigned("/4", -5);
+
+        localSettingsTrait.deleteData("/1");
+        testCTrait.deleteData("/1");
+        testCTrait.deleteData("/2");
+        testCTrait.deleteData("/3/1");
+        testCTrait.deleteData("/3/2");
+ 
+        TestResult = null;
+        mockWdmClient.beginFlushUpdate();
+        ExpectSuccess("FlushUpdate");
+
+        mockWdmClient.close();
+        mockWdmClient = null;
+        localSettingsTrait = null;
+        testCTrait = null;
+        System.out.println("testWdmClientDataSinkSetFlushDataDeleteData Test Succeeded");
+    }
+
+    void testWdmClientDataSinkSetClearFlushData(WeaveDeviceManager deviceMgr)
+    {
+        WdmClientFactory wdmClientFactory = new WdmClientFactory();
+        WdmClient mockWdmClient = wdmClientFactory.create(deviceMgr);
+        mockWdmClient.setCompletionHandler(this);
+
+        GenericTraitUpdatableDataSink localSettingsTrait;
+        GenericTraitUpdatableDataSink testCTrait;
+
+        ResourceIdentifier resourceIdentifier = new ResourceIdentifier();
+        localSettingsTrait = mockWdmClient.newDataSink(resourceIdentifier, 20, 0, "/");
+        testCTrait = mockWdmClient.newDataSink(resourceIdentifier, 593165827, 0, "/");
+        localSettingsTrait.setCompletionHandler(this);
+        testCTrait.setCompletionHandler(this);
+
+        localSettingsTrait.set("/1", "en-US");
+        testCTrait.set("/1", false);
+        testCTrait.setSigned("/2", 15);
+        testCTrait.setUnsigned("/3/1", -5);
+        testCTrait.set("/3/2", false);
+        testCTrait.setUnsigned("/4", -5);
+
+        localSettingsTrait.clear();
+        testCTrait.clear();
+
+        TestResult = null;
+        mockWdmClient.beginFlushUpdate();
+        ExpectSuccess("FlushUpdate");
+
+        mockWdmClient.close();
+        mockWdmClient = null;
+        localSettingsTrait = null;
+        testCTrait = null;
+        System.out.println("testWdmClientDataSinkSetClearFlushData Test Succeeded");
+    }
+
+    void testWdmClientDataSinkRefreshGetDataRefreshClear(WeaveDeviceManager deviceMgr)
     {
         WdmClientFactory wdmClientFactory = new WdmClientFactory();
         WdmClient mockWdmClient = wdmClientFactory.create(deviceMgr);
@@ -229,11 +353,13 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
         testCTraitVersion = testCTrait.getVersion();
         System.out.println("testCTrait GetVersion " + testCTraitVersion);
 
+        testCTrait.clear();
+
         mockWdmClient.close();
         mockWdmClient = null;
         localSettingsTrait = null;
         testCTrait = null;
-        System.out.println("testWdmClientDataSinkRefreshGetDataRefresh Test Succeeded");
+        System.out.println("testWdmClientDataSinkRefreshGetDataRefreshClear Test Succeeded");
     }
 
     void testWdmClientDataSinkRefreshIndividualGetDataRefresh(WeaveDeviceManager deviceMgr)
@@ -342,6 +468,80 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
         localSettingsTrait = null;
         testCTrait = null;
         System.out.println("testWdmClientDataSinkSetFlushRefreshGetData Succeeded");
+    }
+
+    void testWdmClientDataSinkSetFlushEmptyStringRefreshGetData(WeaveDeviceManager deviceMgr)
+    {
+        WdmClientFactory wdmClientFactory = new WdmClientFactory();
+        WdmClient mockWdmClient = wdmClientFactory.create(deviceMgr);
+        mockWdmClient.setCompletionHandler(this);
+
+        BigInteger self_node_id = new BigInteger("-2");
+        mockWdmClient.setNodeId(self_node_id);
+
+        GenericTraitUpdatableDataSink localSettingsTrait;
+        GenericTraitUpdatableDataSink localCapabilitiesTrait;
+        GenericTraitUpdatableDataSink testCTrait;
+
+        ResourceIdentifier resourceIdentifier = new ResourceIdentifier();
+        localSettingsTrait = mockWdmClient.newDataSink(resourceIdentifier, 20, 0, "/");
+        localCapabilitiesTrait = mockWdmClient.newDataSink(resourceIdentifier, 21, 0, "/");
+        testCTrait = mockWdmClient.newDataSink(resourceIdentifier, 593165827, 0, "/");
+
+        localSettingsTrait.setCompletionHandler(this);
+        localCapabilitiesTrait.setCompletionHandler(this);
+        testCTrait.setCompletionHandler(this);
+
+        localSettingsTrait.set("/1", "");
+
+        String[] arr = new String[2];
+        arr[0] = "";
+        arr[1] = "";
+        localCapabilitiesTrait.set("/2", arr);
+
+        testCTrait.set("/1", false);
+        testCTrait.setSigned("/2", 15);
+        testCTrait.setUnsigned("/3/1", -5);
+        testCTrait.set("/3/2", false);
+        testCTrait.setUnsigned("/4", -5);
+
+        TestResult = null;
+        mockWdmClient.beginFlushUpdate();
+        ExpectSuccess("FlushUpdate");
+        System.out.println("FlushUpdate Test Succeeded");
+
+        TestResult = null;
+        mockWdmClient.beginRefreshData();
+        ExpectSuccess("RefreshData");
+        System.out.println("RefreshData Test Succeeded");
+
+        String localeProperty = localSettingsTrait.getString("/1");
+        System.out.println("GetString " + localeProperty);
+
+        String[] localeCapabilitiesArray= localCapabilitiesTrait.getStringArray("/2");
+        System.out.println("GetStringArray " + Arrays.toString(localeCapabilitiesArray));
+
+        boolean tca = testCTrait.getBoolean("/1");
+        System.out.println("GetBoolean " + tca);
+
+        int tcb = testCTrait.getInt("/2");
+        System.out.println("getInt " + tcb);
+
+        int tcc_sca = testCTrait.getInt("/3/1");
+        System.out.println("GetUnsigned" + tcc_sca);
+
+        boolean tcc_scb = testCTrait.getBoolean("/3/2");
+        System.out.println("GetBoolean " + tcc_scb);
+
+        int tcd = testCTrait.getInt("/4");
+        System.out.println("GetUnsigned " + tcd);
+
+        mockWdmClient.close();
+        mockWdmClient = null;
+        localSettingsTrait = null;
+        testCTrait = null;
+
+        System.out.println("testWdmClientDataSinkSetFlushEmptyStringRefreshGetData Succeeded");
     }
 
     void testWdmClientDataSinkSetFlushRefreshGetBigInteger(WeaveDeviceManager deviceMgr)
@@ -656,18 +856,23 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
     void RunMockWdmClientTest(WeaveDeviceManager deviceMgr)
     {
         System.out.println("Run Weave Data Management Start");
-
         testWdmClientCreateClose(deviceMgr);
         testWdmClientDataSinkCreateClose(deviceMgr);
+        testWdmClientDataSinkEmptyFlushData(deviceMgr);
         testWdmClientDataSinkSetFlushData(deviceMgr);
-        testWdmClientDataSinkRefreshGetDataRefresh(deviceMgr);
+        testWdmClientDataSinkSetFlushInvalidData(deviceMgr);
+        testWdmClientDataSinkSetFlushDataDeleteData(deviceMgr);
+        testWdmClientDataSinkSetClearFlushData(deviceMgr);
+        testWdmClientDataSinkRefreshGetDataRefreshClear(deviceMgr);
         testWdmClientDataSinkRefreshIndividualGetDataRefresh(deviceMgr);
         testWdmClientDataSinkSetFlushRefreshGetData(deviceMgr);
+        testWdmClientDataSinkSetFlushEmptyStringRefreshGetData(deviceMgr);
         testWdmClientDataSinkSetFlushRefreshGetBigInteger(deviceMgr);
         testWdmClientDataSinkSetBigIntegerFlushRefreshGetBigInteger(deviceMgr);
         testWdmClientDataSinkSetRefreshFlushGetData(deviceMgr);
         testWdmClientDataSinkResourceIdentifierMakeResTypeIDInt(deviceMgr);
         testWdmClientDataSinkResourceIdentifierMakeResTypeIdBytes(deviceMgr);
+
         System.out.println("Run Weave Data Management Complete");
     }
 
@@ -1156,8 +1361,30 @@ public class TestMain implements WeaveDeviceManager.CompletionHandler, WdmClient
     {
     }
 
-    public void onFlushUpdateComplete()
+    public void onFlushUpdateComplete(Throwable[] exceptions, WdmClient wdmClient)
     {
+        if (exceptions != null)
+        {
+            for (int i = 0; i < exceptions.length; i++)
+            {
+                System.out.println(exceptions[i].toString());
+
+                if (exceptions[i] instanceof WdmClientFlushUpdateException)
+                {
+                    GenericTraitUpdatableDataSink dataSink =  ((WdmClientFlushUpdateException)exceptions[i]).getDataSink(wdmClient);
+                    System.out.println(((WdmClientFlushUpdateDeviceException)exceptions[i]).path);
+                    System.out.println(((WdmClientFlushUpdateDeviceException)exceptions[i]).StatusCode);
+                    dataSink.deleteData(((WdmClientFlushUpdateException)exceptions[i]).path);
+                }
+                else if (exceptions[i] instanceof WdmClientFlushUpdateDeviceException)
+                {
+                    GenericTraitUpdatableDataSink dataSink =  ((WdmClientFlushUpdateDeviceException)exceptions[i]).getDataSink(wdmClient);
+                    System.out.println(((WdmClientFlushUpdateDeviceException)exceptions[i]).path);
+                    System.out.println(((WdmClientFlushUpdateDeviceException)exceptions[i]).StatusCode);
+                    dataSink.deleteData(((WdmClientFlushUpdateDeviceException)exceptions[i]).path);
+                }
+            }
+        }
         System.out.println("    Flush Update complete");
         TestResult = "Success";
     }

--- a/src/device-manager/python/WeaveDeviceManager-ScriptBinding.cpp
+++ b/src/device-manager/python/WeaveDeviceManager-ScriptBinding.cpp
@@ -267,7 +267,7 @@ extern "C" {
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_WdmClient_DeleteWdmClient(WdmClient *wdmClient);
     NL_DLL_EXPORT void nl_Weave_WdmClient_SetNodeId(WdmClient *wdmClient, uint64_t aNodeId);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_WdmClient_NewDataSink(WdmClient *wdmClient, const ResourceIdentifier *resourceIdentifier, uint32_t aProfileId, uint64_t aInstanceId, const char * apPath, GenericTraitUpdatableDataSink ** outGenericTraitUpdatableDataSink);
-    NL_DLL_EXPORT WEAVE_ERROR nl_Weave_WdmClient_FlushUpdate(WdmClient *wdmClient, DMCompleteFunct onComplete, DMErrorFunct onError);
+    NL_DLL_EXPORT WEAVE_ERROR nl_Weave_WdmClient_FlushUpdate(WdmClient *wdmClient, DMFlushUpdateCompleteFunct onComplete, DMErrorFunct onError);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_WdmClient_RefreshData(WdmClient *wdmClient, DMCompleteFunct onComplete, DMErrorFunct onError);
 
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_GenericTraitUpdatableDataSink_Clear(GenericTraitUpdatableDataSink * apGenericTraitUpdatableDataSink);
@@ -275,6 +275,7 @@ extern "C" {
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_GenericTraitUpdatableDataSink_SetTLVBytes(GenericTraitUpdatableDataSink * apGenericTraitUpdatableDataSink, const char * apPath, const uint8_t * dataBuf, size_t dataLen, bool aIsConditional);
     NL_DLL_EXPORT WEAVE_ERROR nl_Weave_GenericTraitUpdatableDataSink_GetTLVBytes(GenericTraitUpdatableDataSink * apGenericTraitUpdatableDataSink, const char * apPath, ConstructBytesArrayFunct aCallback);
     NL_DLL_EXPORT uint64_t nl_Weave_GenericTraitUpdatableDataSink_GetVersion(GenericTraitUpdatableDataSink * apGenericTraitUpdatableDataSink);
+    NL_DLL_EXPORT WEAVE_ERROR nl_Weave_GenericTraitUpdatableDataSink_DeleteData(GenericTraitUpdatableDataSink * apGenericTraitUpdatableDataSink, const char * apPath);
 #endif // WEAVE_CONFIG_DATA_MANAGEMENT_CLIENT_EXPERIMENTAL
 }
 
@@ -1424,7 +1425,7 @@ WEAVE_ERROR nl_Weave_WdmClient_NewDataSink(WdmClient *wdmClient, const ResourceI
     return err;
 }
 
-WEAVE_ERROR nl_Weave_WdmClient_FlushUpdate(WdmClient *wdmClient, DMCompleteFunct onComplete, DMErrorFunct onError)
+WEAVE_ERROR nl_Weave_WdmClient_FlushUpdate(WdmClient *wdmClient, DMFlushUpdateCompleteFunct onComplete, DMErrorFunct onError)
 {
     WEAVE_ERROR err = WEAVE_NO_ERROR;
     err = wdmClient->FlushUpdate(NULL, onComplete, onError);
@@ -1482,6 +1483,11 @@ uint64_t nl_Weave_GenericTraitUpdatableDataSink_GetVersion(GenericTraitUpdatable
 {
     uint64_t version = apGenericTraitUpdatableDataSink->GetVersion();
     return version;
+}
+
+WEAVE_ERROR nl_Weave_GenericTraitUpdatableDataSink_DeleteData(GenericTraitUpdatableDataSink * apGenericTraitUpdatableDataSink, const char * apPath)
+{
+    return apGenericTraitUpdatableDataSink->DeleteData(apPath);
 }
 
 namespace nl {

--- a/src/device-manager/python/openweave/GenericTraitUpdatableDataSink.py
+++ b/src/device-manager/python/openweave/GenericTraitUpdatableDataSink.py
@@ -35,7 +35,11 @@ _ErrorFunct                                 = CFUNCTYPE(None, c_void_p, c_void_p
 _ConstructBytesArrayFunct                   = CFUNCTYPE(None, c_void_p, c_uint32)
 
 class GenericTraitUpdatableDataSink:
-    def __init__(self, traitInstance, wdmClient):
+    def __init__(self, resourceIdentifier, profileId, instanceId, path, traitInstance, wdmClient):
+        self._resourceIdentifier = resourceIdentifier
+        self._profileId = profileId
+        self._instanceId = instanceId
+        self._path = path
         self._traitInstance = traitInstance
         self._wdmClient = wdmClient
         self._weaveStack = WeaveStack()
@@ -46,6 +50,22 @@ class GenericTraitUpdatableDataSink:
         self.close()
         self._weaveStack = None
         self._generictraitupdatabledatasinkLib = None
+
+    @property
+    def resourceIdentifier(self):
+        return self._resourceIdentifier
+
+    @property
+    def profileId(self):
+        return self._profileId
+
+    @property
+    def instanceId(self):
+        return self._instanceId
+
+    @property
+    def path(self):
+        return self._path
 
     def close(self):
         if self._wdmClient != None:
@@ -70,9 +90,7 @@ class GenericTraitUpdatableDataSink:
 
     def refreshData(self):
         self._ensureNotClosed()
-        self._weaveStack.CallAsync(
-            lambda: self._generictraitupdatabledatasinkLib.nl_Weave_GenericTraitUpdatableDataSink_RefreshData(self._traitInstance, self._weaveStack.cbHandleComplete, self._weaveStack.cbHandleError)
-        )
+        self._weaveStack.CallAsync(lambda: self._generictraitupdatabledatasinkLib.nl_Weave_GenericTraitUpdatableDataSink_RefreshData(self._traitInstance, self._weaveStack.cbHandleComplete, self._weaveStack.cbHandleError))
 
     def setData(self, path, val, isConditional=False):
         self._ensureNotClosed()
@@ -115,10 +133,16 @@ class GenericTraitUpdatableDataSink:
             )
 
     def getVersion(self):
-        if self._traitInstance != None:
-            return self._weaveStack.Call(
-                lambda: self._generictraitupdatabledatasinkLib.nl_Weave_GenericTraitUpdatableDataSink_GetVersion(self._traitInstance)
-            )
+        self._ensureNotClosed()
+        return self._weaveStack.Call(
+            lambda: self._generictraitupdatabledatasinkLib.nl_Weave_GenericTraitUpdatableDataSink_GetVersion(self._traitInstance)
+        )
+
+    def deleteData(self, path):
+        self._ensureNotClosed()
+        return self._weaveStack.Call(
+            lambda: self._generictraitupdatabledatasinkLib.nl_Weave_GenericTraitUpdatableDataSink_DeleteData(self._traitInstance, path)
+        )
 
     def _ensureNotClosed(self):
         if self._traitInstance == None:
@@ -138,3 +162,5 @@ class GenericTraitUpdatableDataSink:
             self._generictraitupdatabledatasinkLib.nl_Weave_GenericTraitUpdatableDataSink_GetTLVBytes.restype = c_uint32
             self._generictraitupdatabledatasinkLib.nl_Weave_GenericTraitUpdatableDataSink_GetVersion.argtypes = [ c_void_p ]
             self._generictraitupdatabledatasinkLib.nl_Weave_GenericTraitUpdatableDataSink_GetVersion.restype = c_uint64
+            self._generictraitupdatabledatasinkLib.nl_Weave_GenericTraitUpdatableDataSink_DeleteData.argtypes = [ c_void_p, c_char_p ]
+            self._generictraitupdatabledatasinkLib.nl_Weave_GenericTraitUpdatableDataSink_DeleteData.restype = c_uint32

--- a/src/device-manager/python/openweave/WeaveStack.py
+++ b/src/device-manager/python/openweave/WeaveStack.py
@@ -41,7 +41,7 @@ from threading import Thread, Lock, Event
 from ctypes import *
 from .WeaveUtility import WeaveUtility
 
-__all__ = [ 'DeviceStatusStruct', 'WeaveStackException', 'DeviceError', 'WeaveStackError', 'WeaveStack' ]
+__all__ = [ 'DeviceStatusStruct', 'WeaveStackException', 'DeviceError', 'WeaveStackError', 'WeaveStack']
 
 WeaveStackDLLBaseName = '_WeaveDeviceMgr.so'
 
@@ -83,13 +83,14 @@ class DeviceError(WeaveStackException):
         self.systemErrorCode = systemErrorCode
         if (msg == None):
             if (systemErrorCode):
-                return "[ %08X:%d ] (system err %d)" % (profileId, statusCode, systemErrorCode)
+                self.msg = "[ %08X:%d ] (system err %d)" % (profileId, statusCode, systemErrorCode)
             else:
-                return "[ %08X:%d ]" % (profileId, statusCode)
-        self.message = msg
+                self.msg = "[ %08X:%d ]" % (profileId, statusCode)
+        else:
+            self.msg = msg
 
     def __str__(self):
-        return "Device Error: " + self.message
+        return "Device Error: " + self.msg
 
 class LogCategory(object):
     '''Debug logging categories used by openweave.'''

--- a/src/lib/core/WeaveTLVDebug.cpp
+++ b/src/lib/core/WeaveTLVDebug.cpp
@@ -140,14 +140,20 @@ static void DumpHandler(DumpWriter aWriter, const char *aIndent, const TLVReader
             break;
 
         case kTLVType_UTF8String:
-            err = temp.GetDataPtr(strbuf);
-            VerifyOrExit(err == WEAVE_NO_ERROR, aWriter("Error in kTLVType_UTF8String"));
+            if (len > 0)
+            {
+                err = temp.GetDataPtr(strbuf);
+                VerifyOrExit(err == WEAVE_NO_ERROR, aWriter("Error in kTLVType_UTF8String"));
+            }
             aWriter("\"%-.*s\"", static_cast<int>(len), strbuf);
             break;
 
         case kTLVType_ByteString:
-            err = temp.GetDataPtr(strbuf);
-            VerifyOrExit(err == WEAVE_NO_ERROR, aWriter("Error in kTLVType_ByteString"));
+            if (len > 0)
+            {
+                err = temp.GetDataPtr(strbuf);
+                VerifyOrExit(err == WEAVE_NO_ERROR, aWriter("Error in kTLVType_ByteString"));
+            }
             aWriter("%p\n", strbuf);
             break;
 

--- a/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
@@ -2915,6 +2915,36 @@ exit:
     return err;
 }
 
+WEAVE_ERROR SubscriptionClient::ClearUpdated(TraitUpdatableDataSink * aDataSink, PropertyPathHandle aPropertyHandle)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    TraitDataHandle dataHandle;
+    const TraitSchemaEngine * schemaEngine;
+    bool needToSetUpdateRequiredVersion = false;
+    bool isTraitInstanceInUpdate = false;
+
+    LockUpdateMutex();
+
+    schemaEngine = aDataSink->GetSchemaEngine();
+
+    err = mDataSinkCatalog->Locate(aDataSink, dataHandle);
+    SuccessOrExit(err);
+
+    isTraitInstanceInUpdate = mPendingUpdateSet.IsTraitPresent(dataHandle);
+
+    if (!isTraitInstanceInUpdate)
+    {
+        WeaveLogDetail(DataManagement, "trait %d is not in update pending set, skip ClearUpdated", dataHandle);
+        goto exit;
+    }
+
+    mPendingUpdateSet.RemoveItem(TraitPath(dataHandle, aPropertyHandle));
+
+exit:
+    UnlockUpdateMutex();
+    return err;
+}
+
 /**
  * Tells the SubscriptionClient to empty the set of TraitPaths pending to be updated and abort the
  * update request that is in progress, if any.

--- a/src/lib/profiles/data-management/Current/SubscriptionClient.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.h
@@ -390,6 +390,7 @@ public:
     WEAVE_ERROR FlushUpdate();
     WEAVE_ERROR FlushUpdate(bool aForce);
     WEAVE_ERROR SetUpdated(TraitUpdatableDataSink * aDataSink, PropertyPathHandle aPropertyHandle, bool aIsConditional);
+    WEAVE_ERROR ClearUpdated(TraitUpdatableDataSink * aDataSink, PropertyPathHandle aPropertyHandle);
     void DiscardUpdates();
     void SuspendUpdateRetries();
     void OnCatalogChanged();

--- a/src/lib/profiles/data-management/Current/TraitData.h
+++ b/src/lib/profiles/data-management/Current/TraitData.h
@@ -36,6 +36,10 @@
 #include <Weave/Support/CodeUtils.h>
 #include <Weave/Profiles/data-management/MessageDef.h>
 
+#if WEAVE_CONFIG_DATA_MANAGEMENT_CLIENT_EXPERIMENTAL
+#include <string>
+#endif // WEAVE_CONFIG_DATA_MANAGEMENT_CLIENT_EXPERIMENTAL
+
 namespace nl {
 namespace Weave {
 namespace Profiles {
@@ -356,6 +360,16 @@ public:
      * @retval other           Was unable to convert the handle to a TLV path
      */
     WEAVE_ERROR MapHandleToPath(PropertyPathHandle aHandle, nl::Weave::TLV::TLVWriter & aPathWriter) const;
+
+#if WEAVE_CONFIG_DATA_MANAGEMENT_CLIENT_EXPERIMENTAL
+    /**
+     * Convert the path handle to a std string path
+     *
+     * @retval #WEAVE_NO_ERROR On success.
+     * @retval other           Was unable to convert the handle to a std string path
+     */
+    WEAVE_ERROR MapHandleToPath(PropertyPathHandle aHandle, std::string & aPathString) const;
+#endif //WEAVE_CONFIG_DATA_MANAGEMENT_CLIENT_EXPERIMENTAL
 
     /**
      * Given a path handle and a reader positioned on the corresponding data element, process the data buffer pointed to by the
@@ -793,6 +807,7 @@ public:
                                 bool & aIsNull, bool & aIsPresent) __OVERRIDE;
 
     WEAVE_ERROR SetUpdated(SubscriptionClient * apSubClient, PropertyPathHandle aPropertyHandle, bool aIsConditional = false);
+    WEAVE_ERROR ClearUpdated(SubscriptionClient * apSubClient, PropertyPathHandle aPropertyHandle);
 
     void Lock(SubscriptionClient * apSubClient);
     void Unlock(SubscriptionClient * apSubClient);

--- a/src/lib/profiles/data-management/Current/TraitPathStore.cpp
+++ b/src/lib/profiles/data-management/Current/TraitPathStore.cpp
@@ -254,6 +254,22 @@ void TraitPathStore::SetFailedTrait(TraitDataHandle aDataHandle)
     }
 }
 
+void TraitPathStore::RemoveItem(const TraitPath &aItem)
+{
+    for (size_t i = GetFirstValidItem(aItem.mTraitDataHandle);
+         i < GetPathStoreSize();
+         i = GetNextValidItem(i, aItem.mTraitDataHandle))
+    {
+        if (mStore[i].mTraitPath.mPropertyPathHandle == aItem.mPropertyPathHandle)
+        {
+            RemoveItemAt(i);
+            WeaveLogDetail(DataManagement, "Removing item %u t%u p%u", i,
+                           mStore[i].mTraitPath.mTraitDataHandle,
+                           mStore[i].mTraitPath.mPropertyPathHandle);
+        }
+    }
+}
+
 void TraitPathStore::RemoveItemAt(size_t aIndex)
 {
     VerifyOrDie(mNumItems > 0);

--- a/src/lib/profiles/data-management/Current/TraitPathStore.h
+++ b/src/lib/profiles/data-management/Current/TraitPathStore.h
@@ -81,6 +81,7 @@ struct TraitPathStore
         size_t GetNextValidItem(size_t i, TraitDataHandle aTraitDataHandle) const;
 
         void RemoveTrait(TraitDataHandle aDataHandle);
+        void RemoveItem(const TraitPath &aItem);
         void RemoveItemAt(size_t aIndex);
 
         void Compact();

--- a/src/test-apps/MockSourceTraits.cpp
+++ b/src/test-apps/MockSourceTraits.cpp
@@ -166,6 +166,7 @@ LocaleCapabilitiesTraitDataSource::LocaleCapabilitiesTraitDataSource()
     memcpy(mLocales[0], "pl-PL", MAX_LOCALE_SIZE);
     memcpy(mLocales[1], "ja-JP", MAX_LOCALE_SIZE);
     memcpy(mLocales[2], "fr-FR", MAX_LOCALE_SIZE);
+    mNumLocales = 3;
 }
 
 void LocaleCapabilitiesTraitDataSource::Mutate()


### PR DESCRIPTION
-- Add onFlushUpdateComplete callback to notify failed path results to
application, for each flushed path, if systemError is WEAVE_ERROR_STATUS_REPORT_RECEIVED,
application would receive the device Error Exception including status
report, particular path and dataSink object, otherwise, application would receive the
local error exception, particular path and dataSink object. Add objective C, Java, and Python implementation for the above exceptions.
-- Add DeleteData API so that application can delete data in particular
path.
-- Add length check for GetString and GetStringArray.
-- When GetTraitSchemaEngine fails, it means user does not load the
correct profile id, update err with WEAVE_ERROR_INVALID_PROFILE_ID
-- When refresh fails, we use onError to pass the status report and
error.
-- Fix some style issues.
-- Update onFlushUpdateComplete and DeleteData APIs for objective C, Java, Python
-- Clean redundant code in NLGenericTraitUpdatableDataSink
-- Adjust the signature for getString, getBytes, and getStringArray, and
pass val as reference, and return error code for objectice C support.
-- Fix TLV Dump for empty string.