### PR TITLE
Bug/fix generate weave node

### DIFF
--- a/src/device-manager/cocoa/NLWeaveStack.mm
+++ b/src/device-manager/cocoa/NLWeaveStack.mm
@@ -194,7 +194,7 @@ exit:
     _mFabricState.FabricId = 0;
 
     // Generate a unique node id for local Weave stack.
-    err = GenerateWeaveNodeId(_mFabricState.LocalNodeId);
+    err = ::nl::Weave::GenerateWeaveNodeId(_mFabricState.LocalNodeId);
     SuccessOrExit(err);
 
     // Configure the weave listening address, if one was provided


### PR DESCRIPTION
When compiling the ios build internally, we see the below error, add ::nl:Weave scope can resolve this issue.

  OBJCXX   libNLWeaveDeviceManager_a-NLWeaveKeyIds.o

/src/device-manager/cocoa/NLWeaveStack.mm:197:11: error: use of undeclared identifier 'GenerateWeaveNodeId'; did you mean 'nl::Weave::GenerateWeaveNodeId'?

    err = GenerateWeaveNodeId(_mFabricState.LocalNodeId);

          ^~~~~~~~~~~~~~~~~~~

          nl::Weave::GenerateWeaveNodeId

../../../src/include/Weave/Core/WeaveMessageLayer.h:1076:20: note: 'nl::Weave::GenerateWeaveNodeId' declared here

extern WEAVE_ERROR GenerateWeaveNodeId(uint64_t & nodeId);