### PR TITLE
Bug/fault injection tests

### DIFF
--- a/src/lib/profiles/data-management/Current/CommandSender.cpp
+++ b/src/lib/profiles/data-management/Current/CommandSender.cpp
@@ -392,6 +392,10 @@ WEAVE_ERROR CommandSender::SendCommand(PacketBuffer *aRequestBuf, Binding *aBind
     aRequestBuf = NULL;
 
 exit:
+    if ((err != WEAVE_NO_ERROR) && (aRequestBuf != NULL))
+    {
+        PacketBuffer::Free(aRequestBuf);
+    }
 
     WeaveLogFunctError(err);
     return err;

--- a/src/test-apps/MockWdmSubscriptionResponder.cpp
+++ b/src/test-apps/MockWdmSubscriptionResponder.cpp
@@ -1140,9 +1140,9 @@ void MockWdmSubscriptionResponderImpl::Command_Send(void)
         }
 
         err = mCommandSender.SendCommand(reqBuf, NULL, sendParams);
-        SuccessOrExit(err);
-
         reqBuf = NULL;
+
+        SuccessOrExit(err);
     }
 
 exit:


### PR DESCRIPTION
As detailed in the commit message for constituent commits:

* We're making the parsing more robust w.r.t. parsing percentage of packet loss
* We've fixed the semantics of the new `CommandSender::SendCommand` -- much like all other functions of the `Send*` form, the function MUST consume the buffer passed in.  This implies both a fix to the test and to the function. 