### PR TITLE
CommandSender: fix compiler warnings

### DIFF
--- a/src/lib/profiles/data-management/Current/CommandSender.cpp
+++ b/src/lib/profiles/data-management/Current/CommandSender.cpp
@@ -53,7 +53,7 @@ WEAVE_ERROR CommandSender::SynchronizedTraitState::Init()
     return WEAVE_NO_ERROR;
 }
 
-const bool CommandSender::SynchronizedTraitState::HasDataCaughtUp(void)
+bool CommandSender::SynchronizedTraitState::HasDataCaughtUp(void)
 {
     uint64_t dataSinkVersion;
 
@@ -403,17 +403,17 @@ void CommandSender::DefaultEventHandler(void *aAppState, EventType aEvent, const
     aOutParam.defaultHandlerCalled = true;
 }
 
-void CommandSender::OnSendError(ExchangeContext *aEC, WEAVE_ERROR error, void *aMsgCtxt)
+void CommandSender::OnSendError(ExchangeContext *aEC, WEAVE_ERROR sendError, void *aMsgCtxt)
 {
     CommandSender *_this = static_cast<CommandSender *>(aEC->AppState);
     InEventParam inParam;
     OutEventParam outParam;
-    WEAVE_ERROR err;
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
 
     VerifyOrExit(_this != NULL, err = WEAVE_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(_this->mEC != NULL, err = WEAVE_ERROR_INCORRECT_STATE);
 
-    inParam.CommunicationError.error = error;
+    inParam.CommunicationError.error = sendError;
     _this->mEventCallback(_this->mAppState, kEvent_CommunicationError, inParam, outParam);
 
     // After error, let's close out the exchange

--- a/src/lib/profiles/data-management/Current/CommandSender.h
+++ b/src/lib/profiles/data-management/Current/CommandSender.h
@@ -201,7 +201,7 @@ public:
 private:
     static void OnMessageReceived(nl::Weave::ExchangeContext *aEC, const nl::Weave::IPPacketInfo *aPktInfo, const nl::Weave::WeaveMessageInfo *aMsgInfo, uint32_t aProfileId, uint8_t aMsgType, nl::Weave::PacketBuffer *aPayload);
     static void OnResponseTimeout(nl::Weave::ExchangeContext *aEC);
-    static void OnSendError(nl::Weave::ExchangeContext *aEC, WEAVE_ERROR err, void *aMsgCtxt);
+    static void OnSendError(nl::Weave::ExchangeContext *aEC, WEAVE_ERROR sendError, void *aMsgCtxt);
 
     EventCallback mEventCallback;
     nl::Weave::Binding *mBinding = NULL;
@@ -233,7 +233,7 @@ private:
 struct CommandSender::SynchronizedTraitState
 {
     WEAVE_ERROR Init();
-    const bool HasDataCaughtUp(void);
+    bool HasDataCaughtUp(void);
 
 private:
     // If we dont' have a pre version, it means we're still in the act of subscribing after having received the command response.


### PR DESCRIPTION
- fix uninitialized value in OnSendError
- rename error to sendError to be more clear
- remove meaningless const qualifier from SynchronizedTraitState::HasDataCaughtUp(void)