### PR TITLE
Do not build python wheel packages for iOS.

### DIFF
--- a/Makefile-iOS
+++ b/Makefile-iOS
@@ -304,6 +304,7 @@ ac_cv_have_decl_clock_gettime=no \
 --disable-docs \
 --disable-java \
 --disable-python \
+--disable-installable-python-package \
 --disable-shared \
 --disable-tests \
 --disable-tools \


### PR DESCRIPTION
Autodection for python builds is triggered on availability of the wheel on the build platform.  Disable installable python package on iOS explicitly in the `Makefile-iOS`