### PR TITLE
Fix a bug in thread network telemetry.

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -721,9 +721,9 @@ WEAVE_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThrea
     eventId = nl::LogEvent(&counterEvent);
     WeaveLogProgress(DeviceLayer, "OpenThread Telemetry Stats Event Id: %u", eventId);
 
+exit:
     Impl()->UnlockThreadStack();
 
-exit:
     return err;
 }
 
@@ -778,9 +778,9 @@ WEAVE_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThrea
     eventId = nl::LogEvent(&topologyEvent);
     WeaveLogProgress(DeviceLayer, "OpenThread Telemetry Stats Event Id: %u", eventId);
 
+exit:
     Impl()->UnlockThreadStack();
 
-exit:
     if (err != WEAVE_NO_ERROR)
     {
         WeaveLogError(DeviceLayer, "GetAndLogThreadTopologyMinimal failed: %s", nl::ErrorStr(err));
@@ -986,9 +986,9 @@ WEAVE_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThrea
         WeaveLogProgress(DeviceLayer, "OpenThread Neighbor TopoEntry[%u] Event Id: %ld", i, eventId);
     }
 
+exit:
     Impl()->UnlockThreadStack();
 
-exit:
     if (err != WEAVE_NO_ERROR)
     {
         WeaveLogError(DeviceLayer, "GetAndLogThreadTopologyFull failed: %s", nl::ErrorStr(err));


### PR DESCRIPTION
-- In the Generic Thread Stack Manager Impl using OpenThread,
   thread stack was not unlocked before returning from an error encountered
   while gathering telemetry related information using openthread APIs.