### PR TITLE
Fix test code for MockWdmSubscriptionResponder

### DIFF
--- a/src/test-apps/MockWdmSubscriptionResponder.cpp
+++ b/src/test-apps/MockWdmSubscriptionResponder.cpp
@@ -737,7 +737,7 @@ void MockWdmSubscriptionResponderImpl::PublisherEventCallback (void * const aApp
                     aInParam.mSubscriptionEstablished.mHandler->GetBinding(),
                     responder, ClientEventCallback,
                     &(responder->mSinkCatalog), kResponseTimeoutMsec * 2);
-                VerifyOrExit(err == WEAVE_NO_ERROR, gBinding->Release());
+                SuccessOrExit(err);
 
                 // TODO: EVENT-DEMO
                 responder->mSubscriptionClient->InitiateCounterSubscription(


### PR DESCRIPTION
The test code for managing the binding in the
MockWdmSubscriptionResponder.  The logic bug was present for some
time, but skipped past unnoticed.  The core issue is as follows: we
grab a reference to `gBinding` when the SubscriptionEngine generates a
`kEvent_OnSubscriptionEstablished` (line 654 above the patch); that
reference is logically bound to the publisher and no to the client
(and to the mutual countersubscription).  As a result, the reference
to the binding object will be released as a result of
SubscriptionEngine generating a `kEvent_OnSubscriptionTerminated`; in
this code this takes place as a result of calling
`HandlePublisherRelease()` in line 802 below.  The error handling
takes place via checking for errors in the `exit:` label and takes a
form of `EndSubscription()`. As a result of both of these properties,
It is a logical error to `Release()` the binding because of a failed
call `NewClient()`.