### PR TITLE
Configure: check pkg-config before BlueZ

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1359,6 +1359,10 @@ if test "${CONFIG_DEVICE_LAYER}" = 1; then
 fi
 
 
+# Check if the build host has pkg-config
+
+AC_PATH_PROG([PKG_CONFIG],[pkg-config])
+
 #
 # WoBle over Bluez Peripheral support
 #
@@ -2029,10 +2033,6 @@ AC_LANG_POP([C++])
 # supplied out of package.
 #
 AC_MSG_NOTICE([checking package dependencies])
-
-# Check if the build host has pkg-config
-
-AC_PATH_PROG([PKG_CONFIG],[pkg-config])
 
 #
 # CuRL


### PR DESCRIPTION
Because NL_WITH_OPTIONAL_INTERNAL_PACKAGE may use pkg-config to find
external BlueZ library, pkg-config must be checked before it.

Change-Id: If48d395bf6da2db03c608efe7603ee37273c40a8