### PR TITLE
[ESP32] Add ESP-IDF 3.3 support

### DIFF
--- a/build/esp32/components/openweave/component.mk
+++ b/build/esp32/components/openweave/component.mk
@@ -121,17 +121,6 @@ endif
 COMPONENT_ADD_INCLUDEDIRS 	 = project-config \
                                $(REL_OUTPUT_DIR)/include
 
-# Linker flags to be included when building other components that use Weave. 
-COMPONENT_ADD_LDFLAGS        = -L$(OUTPUT_DIR)/lib \
-					           -lWeave \
-					           -lInetLayer \
-					           -lmincrypt \
-					           -lnlfaultinjection \
-					           -lSystemLayer \
-					           -luECC \
-					           -lWarm \
-					           -lDeviceLayer
-
 # Tell the ESP-IDF build system that the OpenWeave component defines its own build
 # and clean targets.
 COMPONENT_OWNBUILDTARGET 	 = 1
@@ -142,7 +131,7 @@ COMPONENT_OWNCLEANTARGET 	 = 1
 # Build Rules
 # ==================================================
 
-.PHONY : check-config-args-updated
+.PHONY : check-config-args-updated install-weave build-weave configure-weave
 check-config-args-updated : | $(OUTPUT_DIR)
 	echo $(OPENWEAVE_ROOT)/configure $(CONFIGURE_OPTIONS) > $(OUTPUT_DIR)/config.args.tmp; \
 	(test -r $(OUTPUT_DIR)/config.args && cmp -s $(OUTPUT_DIR)/config.args.tmp $(OUTPUT_DIR)/config.args) || \
@@ -170,11 +159,34 @@ build-weave : configure-weave
 	echo "BUILD OPENWEAVE..."
 	MAKEFLAGS= make -C $(OUTPUT_DIR) --no-print-directory all
 
-install-weave : | build-weave
+install-weave : build-weave
 	echo "INSTALL OPENWEAVE..."
 	MAKEFLAGS= make -C $(OUTPUT_DIR) --no-print-directory install
 
-build : build-weave install-weave
+# Openweave build routine builds several .a libraries (lib{Weave|InetLayer|...}.a)
+# instead of a single library (libopenweave.a) which is expected by esp-idf 3.3
+# Here, we extract the libraries and repack them into a one big library
+OPENWEAVE_STATIC_LIBRARIES = \
+	$(OUTPUT_DIR)/lib/libWeave.a             \
+	$(OUTPUT_DIR)/lib/libInetLayer.a         \
+	$(OUTPUT_DIR)/lib/libmincrypt.a          \
+	$(OUTPUT_DIR)/lib/libnlfaultinjection.a  \
+	$(OUTPUT_DIR)/lib/libSystemLayer.a       \
+	$(OUTPUT_DIR)/lib/libuECC.a              \
+	$(OUTPUT_DIR)/lib/libWarm.a              \
+	$(OUTPUT_DIR)/lib/libDeviceLayer.a       \
+
+# Extract and repack the %.a files into a single libopenweave.a
+$(OUTPUT_DIR)/libopenweave.a : install-weave
+	mkdir -p $(OUTPUT_DIR)/libopenweave.a.tmp
+	cd $(OUTPUT_DIR)/libopenweave.a.tmp; \
+	for files in $(OPENWEAVE_STATIC_LIBRARIES) ; do \
+	  $(AR) -x $$files ; \
+	done
+	$(AR) cru $@ $(OUTPUT_DIR)/libopenweave.a.tmp/*.o
+	rm -rf $(OUTPUT_DIR)/libopenweave.a.tmp
+
+build : build-weave install-weave $(OUTPUT_DIR)/libopenweave.a
 
 clean:
 	echo "RM $(OUTPUT_DIR)"

--- a/src/adaptations/device-layer/ESP32/AESBlockCipher.cpp
+++ b/src/adaptations/device-layer/ESP32/AESBlockCipher.cpp
@@ -64,7 +64,7 @@ void AES128BlockCipherEnc::EncryptBlock(const uint8_t *inBlock, uint8_t *outBloc
 
     esp_aes_init(&ctx);
     esp_aes_setkey(&ctx, mKey, kKeyLengthBits);
-    esp_aes_encrypt(&ctx, inBlock, outBlock);
+    esp_aes_crypt_ecb(&ctx, ESP_AES_ENCRYPT, inBlock, outBlock);
     esp_aes_free(&ctx);
 }
 
@@ -79,7 +79,7 @@ void AES128BlockCipherDec::DecryptBlock(const uint8_t *inBlock, uint8_t *outBloc
 
     esp_aes_init(&ctx);
     esp_aes_setkey(&ctx, mKey, kKeyLengthBits);
-    esp_aes_decrypt(&ctx, inBlock, outBlock);
+    esp_aes_crypt_ecb(&ctx, ESP_AES_DECRYPT, inBlock, outBlock);
     esp_aes_free(&ctx);
 }
 
@@ -109,7 +109,7 @@ void AES256BlockCipherEnc::EncryptBlock(const uint8_t *inBlock, uint8_t *outBloc
 
     esp_aes_init(&ctx);
     esp_aes_setkey(&ctx, mKey, kKeyLengthBits);
-    esp_aes_encrypt(&ctx, inBlock, outBlock);
+    esp_aes_crypt_ecb(&ctx, ESP_AES_ENCRYPT, inBlock, outBlock);
     esp_aes_free(&ctx);
 }
 
@@ -124,7 +124,7 @@ void AES256BlockCipherDec::DecryptBlock(const uint8_t *inBlock, uint8_t *outBloc
 
     esp_aes_init(&ctx);
     esp_aes_setkey(&ctx, mKey, kKeyLengthBits);
-    esp_aes_decrypt(&ctx, inBlock, outBlock);
+    esp_aes_crypt_ecb(&ctx, ESP_AES_DECRYPT, inBlock, outBlock);
     esp_aes_free(&ctx);
 }
 

--- a/src/adaptations/device-layer/ESP32/AESBlockCipher.cpp
+++ b/src/adaptations/device-layer/ESP32/AESBlockCipher.cpp
@@ -30,6 +30,7 @@
 #include <Weave/Support/crypto/AESBlockCipher.h>
 
 #include <hwcrypto/aes.h>
+#include <esp_system.h>
 
 namespace nl {
 namespace Weave {
@@ -64,7 +65,11 @@ void AES128BlockCipherEnc::EncryptBlock(const uint8_t *inBlock, uint8_t *outBloc
 
     esp_aes_init(&ctx);
     esp_aes_setkey(&ctx, mKey, kKeyLengthBits);
+#if ESP_IDF_VERSION_MAJOR > 3 || (ESP_IDF_VERSION_MAJOR == 3 && ESP_IDF_VERSION_MINOR >= 2)
     esp_aes_crypt_ecb(&ctx, ESP_AES_ENCRYPT, inBlock, outBlock);
+#else
+    esp_aes_encrypt(&ctx, inBlock, outBlock);
+#endif
     esp_aes_free(&ctx);
 }
 
@@ -79,7 +84,11 @@ void AES128BlockCipherDec::DecryptBlock(const uint8_t *inBlock, uint8_t *outBloc
 
     esp_aes_init(&ctx);
     esp_aes_setkey(&ctx, mKey, kKeyLengthBits);
+#if ESP_IDF_VERSION_MAJOR > 3 || (ESP_IDF_VERSION_MAJOR == 3 && ESP_IDF_VERSION_MINOR >= 2)
     esp_aes_crypt_ecb(&ctx, ESP_AES_DECRYPT, inBlock, outBlock);
+#else
+    esp_aes_decrypt(&ctx, inBlock, outBlock);
+#endif
     esp_aes_free(&ctx);
 }
 
@@ -109,7 +118,11 @@ void AES256BlockCipherEnc::EncryptBlock(const uint8_t *inBlock, uint8_t *outBloc
 
     esp_aes_init(&ctx);
     esp_aes_setkey(&ctx, mKey, kKeyLengthBits);
+#if ESP_IDF_VERSION_MAJOR > 3 || (ESP_IDF_VERSION_MAJOR == 3 && ESP_IDF_VERSION_MINOR >= 2)
     esp_aes_crypt_ecb(&ctx, ESP_AES_ENCRYPT, inBlock, outBlock);
+#else
+    esp_aes_encrypt(&ctx, inBlock, outBlock);
+#endif
     esp_aes_free(&ctx);
 }
 
@@ -124,7 +137,11 @@ void AES256BlockCipherDec::DecryptBlock(const uint8_t *inBlock, uint8_t *outBloc
 
     esp_aes_init(&ctx);
     esp_aes_setkey(&ctx, mKey, kKeyLengthBits);
+#if ESP_IDF_VERSION_MAJOR > 3 || (ESP_IDF_VERSION_MAJOR == 3 && ESP_IDF_VERSION_MINOR >= 2)
     esp_aes_crypt_ecb(&ctx, ESP_AES_DECRYPT, inBlock, outBlock);
+#else
+    esp_aes_decrypt(&ctx, inBlock, outBlock);
+#endif
     esp_aes_free(&ctx);
 }
 

--- a/src/adaptations/device-layer/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/adaptations/device-layer/ESP32/ConnectivityManagerImpl.cpp
@@ -78,7 +78,11 @@ ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMod
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
         bool autoConnect;
-        mWiFiStationMode = (esp_wifi_get_auto_connect(&autoConnect) == ESP_OK && autoConnect)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        WEAVE_ERROR err = esp_wifi_get_auto_connect(&autoConnect);
+#pragma GCC diagnostic pop
+        mWiFiStationMode = (err == ESP_OK && autoConnect)
                 ? kWiFiStationMode_Enabled
                 : kWiFiStationMode_Disabled;
     }
@@ -99,7 +103,10 @@ WEAVE_ERROR ConnectivityManagerImpl::_SetWiFiStationMode(WiFiStationMode val)
     if (val != kWiFiStationMode_ApplicationControlled)
     {
         bool autoConnect = (val == kWiFiStationMode_Enabled);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         err = esp_wifi_set_auto_connect(autoConnect);
+#pragma GCC diagnostic pop
         SuccessOrExit(err);
 
         SystemLayer.ScheduleWork(DriveStationState, NULL);

--- a/src/adaptations/device-layer/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/adaptations/device-layer/ESP32/ConnectivityManagerImpl.cpp
@@ -30,6 +30,7 @@
 
 #include "esp_event.h"
 #include "esp_wifi.h"
+#include "esp_system.h"
 
 #include <lwip/ip_addr.h>
 #include <lwip/netif.h>
@@ -941,8 +942,13 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
         if (netif != NULL && netif_is_up(netif) && netif_is_link_up(netif))
         {
             // Check if a DNS server is currently configured.  If so...
+#if ESP_IDF_VERSION_MAJOR > 3 || (ESP_IDF_VERSION_MAJOR == 3 && ESP_IDF_VERSION_MINOR >= 3)
+            const ip_addr_t* dnsServerAddr = dns_getserver(0);
+            if (!ip_addr_isany_val(*dnsServerAddr))
+#else
             ip_addr_t dnsServerAddr = dns_getserver(0);
             if (!ip_addr_isany_val(dnsServerAddr))
+#endif
             {
                 // If the station interface has been assigned an IPv4 address, and has
                 // an IPv4 gateway, then presume that the device has IPv4 Internet

--- a/src/inet/DNSResolver.cpp
+++ b/src/inet/DNSResolver.cpp
@@ -36,9 +36,9 @@
 #include <lwip/dns.h>
 #include <lwip/tcpip.h>
 
-#if LWIP_VERSION_MAJOR < 2
+#ifndef LWIP_DNS_FOUND_CALLBACK_TYPE
 #define LWIP_DNS_FOUND_CALLBACK_TYPE    dns_found_callback
-#endif // LWIP_VERSION_MAJOR < 2
+#endif
 #endif // WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if WEAVE_SYSTEM_CONFIG_USE_SOCKETS


### PR DESCRIPTION
This PR cherry picks [`f70c83b`](https://github.com/openweave/openweave-core/commit/f70c83b82b6202e36b5a782abe524edd4a997480) to master.

After patched ESP-IDF 3.2, these updates is required by ESP-IDF 3.3

- Update `component.mk` to build `libopenweave.a`
    ESP-IDF 3.3 assumed that `lib(componentname).a` is built
- dns_getserver now returns `const ip_addr_t*`

Testing this PR requires https://github.com/openweave/openweave-esp32-demo/pull/14 and its lwip submodule should be checked out to https://github.com/openweave/openweave-esp32-lwip/pull/2

Tested features:
 - [x] Compiling
 - [x] Connect via BLE
 - [x] Network provisioning
   - [x] WiFi
 - [x] Pairing
 - [x] `reset-config` from WDM
 - [ ] *more tests pending* 
