### PR TITLE
Make package name configurable to be able to distinguish between inte…

### DIFF
--- a/src/device-manager/python/Makefile.am
+++ b/src/device-manager/python/Makefile.am
@@ -130,20 +130,20 @@ EXTRA_DIST +=										\
     $(NULL)
 
 .openweave-wheel: $(srcdir)/build-openweave-wheel.py weave-device-mgr _WeaveDeviceMgr.la $(shell find $(srcdir) -type f -name '*.py')
-	rm -f openweave-*.whl
+	rm -f *.whl
 	$(PYTHON) $(srcdir)/build-openweave-wheel.py
 	touch .openweave-wheel
 
 install-exec-local: .openweave-wheel
 	mkdir -p $(DESTDIR)$(pyexecdir)
-	rm -f $(DESTDIR)$(pyexecdir)/openweave-*.whl
-	cp openweave-*.whl $(DESTDIR)$(pyexecdir)
+	rm -f $(DESTDIR)$(pyexecdir)/*.whl
+	cp *.whl $(DESTDIR)$(pyexecdir)
 
 uninstall-local:
-	rm -f $(DESTDIR)$(pyexecdir)/openweave-*.whl
+	rm -f $(DESTDIR)$(pyexecdir)/*.whl
 
 clean-local:
-	rm -f .openweave-wheel openweave-*.whl
+	rm -f .openweave-wheel *.whl
 
 endif # WEAVE_BUILD_INSTALLABLE_PYTHON_PACKAGE
 

--- a/src/device-manager/python/build-openweave-wheel.py
+++ b/src/device-manager/python/build-openweave-wheel.py
@@ -34,6 +34,7 @@ import platform
 owDLLName = '_WeaveDeviceMgr.so'
 deviceManagerShellName = 'weave-device-mgr.py'
 deviceManagerShellInstalledName = os.path.splitext(deviceManagerShellName)[0]
+packageName = os.environ.get('WEAVE_PACKAGE_NAME', 'openweave')
 
 # Record the current directory at the start of execution.
 curDir = os.curdir
@@ -66,7 +67,7 @@ try:
 
     # Make a copy of the openweave package in the tmp directory and ensure the copied
     # directory is writable.
-    owPackageDir = os.path.join(tmpDir, 'openweave')
+    owPackageDir = os.path.join(tmpDir, packageName)
     if os.path.isdir(owPackageDir):
         shutil.rmtree(owPackageDir)
     shutil.copytree(os.path.join(srcDir, 'openweave'), owPackageDir)
@@ -151,7 +152,7 @@ try:
     # Invoke the setuptools 'bdist_wheel' command to generate a wheel containing
     # the OpenWeave python packages, shared libraries and scripts.
     setup(
-        name='openweave',
+        name=packageName,
         version=owPackageVer,
         description='Python-base APIs and tools for OpenWeave.',
         long_description=buildDescription,
@@ -166,13 +167,13 @@ try:
         ],
         python_requires='>=2.7',
         packages=[
-            'openweave'                     # Arrange to install a package named "openweave"
+            packageName                     # Arrange to install a package named "openweave"
         ],
         package_dir={
             '':tmpDir,                      # By default, look in the tmp directory for packages/modules to be included.
         },
         package_data={
-            'openweave':[
+            packageName:[
                 owDLLName                   # Include the wrapper DLL as package data in the "openweave" package.
             ]
         },


### PR DESCRIPTION
…rnal and external builds

Make the default package name configurable but make the default 'openweave' to distinguish between internal and public package. Please see internal ticket for more context (can cc as requested).