### PR TITLE
Access Control relaxation for fetching device credentials over a PASE session

### DIFF
--- a/src/lib/profiles/fabric-provisioning/FabricProvisioning.h
+++ b/src/lib/profiles/fabric-provisioning/FabricProvisioning.h
@@ -187,6 +187,9 @@ public:
 
     void SetDelegate(FabricProvisioningDelegate *delegate);
 
+    // Check if the session is marked as privileged to retrieve fabric config information.
+    bool SessionHasFabricConfigAccessPrivilege(uint16_t keyId, uint64_t peerNodeId) const;
+
     virtual WEAVE_ERROR SendSuccessResponse(void);
     virtual WEAVE_ERROR SendStatusReport(uint32_t statusProfileId, uint16_t statusCode, WEAVE_ERROR sysError = WEAVE_NO_ERROR);
 
@@ -198,7 +201,27 @@ private:
     static void HandleClientRequest(ExchangeContext *ec, const IPPacketInfo *pktInfo, const WeaveMessageInfo *msgInfo, uint32_t profileId,
             uint8_t msgType, PacketBuffer *payload);
 
+    // Utility functions for managing registration with/notification from WeaveFabricState
+    // about whether the current security session is privileged to
+    // access fabric config information.
+    void GrantFabricConfigAccessPrivilege(uint16_t keyId, uint64_t peerNodeId);
+    void ClearFabricConfigAccessPrivilege(void);
+    static void HandleSessionEnd(uint16_t keyId, uint64_t peerNodeId, void *context);
+    WEAVE_ERROR RegisterSessionEndCallbackWithFabricState(void);
+
+    // Indicates the session that is privileged to
+    // retrieve fabric config information.
+    struct FabricConfigAccessSession
+    {
+        uint64_t PeerNodeId;
+        uint16_t SessionKeyId;
+    };
+    FabricConfigAccessSession mFabricConfigAccessSession;
+
+    nl::Weave::WeaveFabricState::SessionEndCbCtxt mSessionEndCbCtxt;
+
     FabricProvisioningServer(const FabricProvisioningServer&);   // not defined
+
 };
 
 

--- a/src/lib/profiles/network-provisioning/NetworkProvisioning.h
+++ b/src/lib/profiles/network-provisioning/NetworkProvisioning.h
@@ -429,7 +429,31 @@ private:
             uint8_t msgType, PacketBuffer *payload);
     WEAVE_ERROR SendCompleteWithNetworkList(uint8_t msgType, int8_t resultCount, PacketBuffer *resultTLV);
 
+    // Utility functions for managing registration with/notification from WeaveFabricState about whether the
+    // current security session is privileged to access network credential information.
+
+    // Check if the session is marked as privileged to retrieve secret
+    // credential information.
+    bool SessionHasCredentialAccessPrivilege(uint16_t keyId, uint64_t peerNodeId) const;
+
+    void GrantCredentialAccessPrivilege(uint16_t keyId, uint64_t peerNodeId);
+    void ClearCredentialAccessPrivilege(void);
+    static void HandleSessionEnd(uint16_t keyId, uint64_t peerNodeId, void *context);
+    WEAVE_ERROR RegisterSessionEndCallbackWithFabricState(void);
+
     NetworkProvisioningServer(const NetworkProvisioningServer&);   // not defined
+
+    // Indicates the session that is privileged to
+    // retrieve secret credential information.
+    struct CredentialAccessSession
+    {
+        uint64_t PeerNodeId;
+        uint16_t SessionKeyId;
+    };
+    CredentialAccessSession mCredentialAccessSession;
+
+    nl::Weave::WeaveFabricState::SessionEndCbCtxt mSessionEndCbCtxt;
+
 };
 
 } // namespace NetworkProvisioning


### PR DESCRIPTION
These relaxed access controls would allow a mobile client device that
is connected over PASE during first-device pairing to access device
credentials only over that same session, and cache them for
assisting other devices during subsequent pairing attempts.