### PR TITLE
DeviceLayer and DeviceManager: Add system managed network

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/ConnectivityManager.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/ConnectivityManager.h
@@ -99,6 +99,11 @@ public:
 
     struct ThreadPollingConfig;
 
+#if WEAVE_DEVICE_CONFIG_ENABLE_SYSTEM_MANAGED_NETWORK
+    // System managed network
+    WEAVE_ERROR ProvisionSystemManagedNetwork(void);
+#endif // WEAVE_DEVICE_CONFIG_ENABLE_SYSTEM_MANAGED_NETWORK
+
     // WiFi station methods
     WiFiStationMode GetWiFiStationMode(void);
     WEAVE_ERROR SetWiFiStationMode(WiFiStationMode val);
@@ -254,6 +259,13 @@ extern ConnectivityManagerImpl & ConnectivityMgrImpl(void);
 namespace nl {
 namespace Weave {
 namespace DeviceLayer {
+
+#if WEAVE_DEVICE_CONFIG_ENABLE_SYSTEM_MANAGED_NETWORK
+inline WEAVE_ERROR ConnectivityManager::ProvisionSystemManagedNetwork(void)
+{
+    return static_cast<ImplClass*>(this)->_ProvisionSystemManagedNetwork();
+}
+#endif // WEAVE_DEVICE_CONFIG_ENABLE_SYSTEM_MANAGED_NETWORK
 
 inline ConnectivityManager::WiFiStationMode ConnectivityManager::GetWiFiStationMode(void)
 {

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/WeaveDeviceConfig.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/WeaveDeviceConfig.h
@@ -576,6 +576,18 @@
 #define WEAVE_DEVICE_CONFIG_THREAD_CONNECTIVITY_TIMEOUT 30000
 #endif
 
+// -------------------- Misc Network Configuration --------------------
+
+/**
+ * WEAVE_DEVICE_CONFIG_ENABLE_SYSTEM_MANAGED_NETWORK
+ *
+ * Enable support for system managed network
+ */
+#ifndef WEAVE_DEVICE_CONFIG_ENABLE_SYSTEM_MANAGED_NETWORK
+#define WEAVE_DEVICE_CONFIG_ENABLE_SYSTEM_MANAGED_NETWORK 0
+#endif
+
+
 // -------------------- Tunnel Configuration --------------------
 
 /**

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/DeviceNetworkInfo.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/DeviceNetworkInfo.h
@@ -35,6 +35,7 @@ enum
 {
     kThreadNetworkId                                = 1,
     kWiFiStationNetworkId                           = 2,
+    kSystemManagedNetworkId                         = 3,
 };
 
 class DeviceNetworkInfo

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericNetworkProvisioningServerImpl.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/internal/GenericNetworkProvisioningServerImpl.ipp
@@ -364,6 +364,19 @@ WEAVE_ERROR GenericNetworkProvisioningServerImpl<ImplClass>::HandleAddUpdateNetw
 
 #endif // WEAVE_DEVICE_CONFIG_ENABLE_THREAD
 
+#if WEAVE_DEVICE_CONFIG_ENABLE_SYSTEM_MANAGED_NETWORK
+
+    case kNetworkType_SystemManaged:
+
+        err = ConnectivityMgr().ProvisionSystemManagedNetwork();
+        VerifyOrExit(err == WEAVE_NO_ERROR, SendStatusReport(kWeaveProfile_NetworkProvisioning, 0, err));
+
+        netId = kSystemManagedNetworkId;
+
+        break;
+
+#endif // WEAVE_DEVICE_CONFIG_ENABLE_SYSTEM_MANAGED_NETWORK
+
     default:
 
         WeaveLogProgress(DeviceLayer, "%sUnsupported network type: %d", sLogPrefix, netInfo.NetworkType);

--- a/src/device-manager/python/openweave/WeaveDeviceMgr.py
+++ b/src/device-manager/python/openweave/WeaveDeviceMgr.py
@@ -49,6 +49,7 @@ __all__ = [ 'WeaveDeviceManager', 'NetworkInfo', 'DeviceDescriptor' ]
 
 NetworkType_WiFi                            = 1
 NetworkType_Thread                          = 2
+NetworkType_SystemManaged                   = 3
 
 WiFiMode_AdHoc                              = 1
 WiFiMode_Managed                            = 2
@@ -1301,6 +1302,8 @@ def NetworkTypeToString(val):
         return "WiFi"
     if (val == NetworkType_Thread):
         return "Thread"
+    if (val == NetworkType_SystemManaged):
+        return "SystemManaged"
     if (val != None):
         return "UNKNOWN (" + str(val)+ ")"
     return None
@@ -1313,6 +1316,8 @@ def ParseNetworkType(val):
         return NetworkType_WiFi
     if (val == "thread"):
         return NetworkType_Thread
+    if (val == "system"):
+        return NetworkType_SystemManaged
     raise Exception("Invalid network type: " + str(val))
 
 def WiFiModeToString(val):

--- a/src/device-manager/python/weave-device-mgr.py
+++ b/src/device-manager/python/weave-device-mgr.py
@@ -238,6 +238,7 @@ class DeviceMgrCmd(Cmd):
         'passive-rendezvous',
         'remote-passive-rendezvous',
         'reconnect',
+        'add-system-managed-network',
         'scan-networks',
         'add-wifi-network',
         'add-thread-network',
@@ -1026,6 +1027,33 @@ class DeviceMgrCmd(Cmd):
             self.devMgr.CloseEndpoints()
         except WeaveStack.WeaveStackException as ex:
             print(str(ex))
+
+    def do_addsystemmanagednetwork(self, line):
+        """
+          add-system-managed-network
+
+            Provision a system managed network.
+        """
+
+        args = shlex.split(line)
+
+        if (len(args) != 0):
+            print("Usage:")
+            self.do_help('add-system-managed-network')
+            return
+
+        networkInfo = WeaveDeviceMgr.NetworkInfo(
+            networkType = WeaveDeviceMgr.NetworkType_SystemManaged)
+
+        try:
+            addResult = self.devMgr.AddNetwork(networkInfo)
+        except WeaveStack.WeaveStackException as ex:
+            print(str(ex))
+            return
+
+        self.lastNetworkId = addResult
+
+        print("Add system managed network complete (network id = " + str(addResult) + ")")
 
     def do_enableconnectionmonitor(self, line):
         """

--- a/src/lib/profiles/network-provisioning/NetworkProvisioning.h
+++ b/src/lib/profiles/network-provisioning/NetworkProvisioning.h
@@ -162,7 +162,8 @@ enum NetworkType
     kNetworkType_NotSpecified                   = -1,
 
     kNetworkType_WiFi                           = 1,
-    kNetworkType_Thread                         = 2
+    kNetworkType_Thread                         = 2,
+    kNetworkType_SystemManaged                  = 3,
 };
 
 /**


### PR DESCRIPTION
The system managed network uses the network already existing on the
system. It can be used for demonstration and daily development. It
requires no extra hardware at all, and easy to set up.

The patch includes interface to implement system managed network, it can
be implemented in the device layer of the target platform outside the
source tree. Linux device layer will have its own implementation using
the given interface.

Change-Id: Ibb488010e9fc2711bc0c00beba73d6e829a91fe5