### PR TITLE
Add virtual d'tors, specify cast

### DIFF
--- a/src/ble/BleApplicationDelegate.h
+++ b/src/ble/BleApplicationDelegate.h
@@ -36,6 +36,8 @@ namespace Ble {
 class NL_DLL_EXPORT BleApplicationDelegate
 {
 public:
+    virtual ~BleApplicationDelegate(void) = default;
+
     // Weave calls this function once it closes the last BLEEndPoint associated with a BLE given connection object.
     // A call to this function means Weave no longer cares about the state of the given BLE connection.
     // The application can use this callback to e.g. close the underlying BLE conection if it is no longer needed,

--- a/src/ble/BlePlatformDelegate.h
+++ b/src/ble/BlePlatformDelegate.h
@@ -40,6 +40,8 @@ using ::nl::Weave::System::PacketBuffer;
 class NL_DLL_EXPORT BlePlatformDelegate
 {
 public:
+    virtual ~BlePlatformDelegate(void) = default;
+
     // Following APIs must be implemented by platform:
 
     // Subscribe to updates and indications on the specfied characteristic

--- a/src/lib/core/WeaveFabricState.h
+++ b/src/lib/core/WeaveFabricState.h
@@ -449,6 +449,7 @@ class WeaveFabricState;
 class FabricStateDelegate
 {
 public:
+    virtual ~FabricStateDelegate(void) = default;
     /**
      * This method is called when WeaveFabricState joins or creates a new fabric.
      *

--- a/src/lib/core/WeaveServerBase.h
+++ b/src/lib/core/WeaveServerBase.h
@@ -76,6 +76,8 @@ private:
 class WeaveServerDelegateBase
 {
     friend class WeaveServerBase;
+public:
+    virtual ~WeaveServerDelegateBase(void) = default;
 
 protected:
     WeaveServerDelegateBase(void) { }

--- a/src/lib/profiles/common/WeaveMessage.h
+++ b/src/lib/profiles/common/WeaveMessage.h
@@ -126,7 +126,7 @@ namespace Profiles {
       // Con/destructors
       RetainedPacketBuffer(void);
       RetainedPacketBuffer(const RetainedPacketBuffer &aRetainedPacketBuffer);
-      ~RetainedPacketBuffer(void);
+      virtual ~RetainedPacketBuffer(void);
 
       RetainedPacketBuffer &operator =(const RetainedPacketBuffer &aRetainedPacketBuffer);
 
@@ -150,6 +150,8 @@ namespace Profiles {
   public:
     // constructor
     MessageIterator(System::PacketBuffer*);
+    virtual ~MessageIterator(void) = default;
+
     // reading and writing
     WEAVE_ERROR readByte(uint8_t*);
     WEAVE_ERROR read16(uint16_t*);
@@ -188,6 +190,7 @@ namespace Profiles {
   public:
     // constructor
     ReferencedString(void);
+    virtual ~ReferencedString(void) = default;
     // initializers
     WEAVE_ERROR init(uint16_t aLength, char* aString, System::PacketBuffer* aBuffer);
     WEAVE_ERROR init(uint16_t aLength, char* aString);
@@ -235,6 +238,7 @@ namespace Profiles {
     // constructor
 
     ReferencedTLVData(void);
+    virtual ~ReferencedTLVData(void) = default;
 
     // initializers
 

--- a/src/lib/profiles/data-management/Current/NotificationEngine.h
+++ b/src/lib/profiles/data-management/Current/NotificationEngine.h
@@ -47,6 +47,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
 class IDataElementAccessControlDelegate
 {
 public:
+    virtual ~IDataElementAccessControlDelegate(void) = default;
     virtual WEAVE_ERROR DataElementAccessCheck(const TraitPath & aTraitPath, const TraitCatalogBase<TraitDataSink> & aCatalog) = 0;
 };
 

--- a/src/lib/profiles/data-management/Current/SubscriptionClient.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.h
@@ -56,6 +56,8 @@ typedef uint16_t TraitDataHandle;
 class IWeaveWDMMutex
 {
 public:
+    virtual ~IWeaveWDMMutex(void) = default;
+
     virtual void Lock(void)   = 0;
     virtual void Unlock(void) = 0;
 };

--- a/src/lib/profiles/data-management/Current/SubscriptionEngine.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionEngine.h
@@ -49,6 +49,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
 class IWeavePublisherLock
 {
 public:
+    virtual ~IWeavePublisherLock(void) = default;
     virtual WEAVE_ERROR Lock(void)   = 0;
     virtual WEAVE_ERROR Unlock(void) = 0;
 };
@@ -57,6 +58,7 @@ public:
 class IUpdateRequestDataElementAccessControlDelegate
 {
 public:
+    virtual ~IUpdateRequestDataElementAccessControlDelegate(void) = default;
     virtual WEAVE_ERROR DataElementAccessCheck(const TraitPath & aTraitPath,
                                                const TraitCatalogBase<TraitDataSource> & aCatalog) = 0;
 };
@@ -386,6 +388,7 @@ private:
     {
     public:
         SubscriptionlessNotifyDataElementAccessControlDelegate(const WeaveMessageInfo * aMsgInfo) { mMsgInfo = aMsgInfo; }
+        virtual ~SubscriptionlessNotifyDataElementAccessControlDelegate(void) = default;
 
         WEAVE_ERROR DataElementAccessCheck(const TraitPath & aTraitPath, const TraitCatalogBase<TraitDataSink> & aCatalog);
 
@@ -403,6 +406,7 @@ private:
     {
     public:
         UpdateRequestDataElementAccessControlDelegate(const WeaveMessageInfo * aMsgInfo) { mMsgInfo = aMsgInfo; }
+        virtual ~UpdateRequestDataElementAccessControlDelegate(void) = default;
 
         WEAVE_ERROR DataElementAccessCheck(const TraitPath & aTraitPath, const TraitCatalogBase<TraitDataSource> & aCatalog);
 

--- a/src/lib/profiles/data-management/Current/TraitCatalog.h
+++ b/src/lib/profiles/data-management/Current/TraitCatalog.h
@@ -88,6 +88,7 @@ template <typename T>
 class TraitCatalogBase
 {
 public:
+    virtual ~TraitCatalogBase(void) = default;
     /**
      * Given a reader positioned at the Path::kCsTag_RootSection structure on a WDM path, parse that structure
      * and return the matching handle to the trait.

--- a/src/lib/profiles/data-management/Current/TraitData.h
+++ b/src/lib/profiles/data-management/Current/TraitData.h
@@ -108,6 +108,7 @@ inline bool IsNullPropertyPathHandle(PropertyPathHandle aHandle)
 class IPathFilter
 {
 public:
+    virtual ~IPathFilter(void) = default;
     virtual bool FilterPath(PropertyPathHandle aPathhandle) = 0;
 };
 
@@ -121,6 +122,7 @@ class UpdateDirtyPathFilter : public IPathFilter
 public:
     UpdateDirtyPathFilter(SubscriptionClient * apSubClient, TraitDataHandle traitDataHandle,
                           const TraitSchemaEngine * aSchemaEngine);
+    virtual ~UpdateDirtyPathFilter(void) = default;
     virtual bool FilterPath(PropertyPathHandle aPathhandle);
 
 private:
@@ -132,6 +134,7 @@ private:
 class IDirtyPathCut
 {
 public:
+    virtual ~IDirtyPathCut(void) = default;
     virtual WEAVE_ERROR CutPath(PropertyPathHandle aPathhandle, const TraitSchemaEngine * apEngine) = 0;
 };
 
@@ -144,6 +147,7 @@ class UpdateDictionaryDirtyPathCut : public IDirtyPathCut
 {
 public:
     UpdateDictionaryDirtyPathCut(TraitDataHandle aTraitDataHandle, UpdateEncoder * pEncoder);
+    virtual ~UpdateDictionaryDirtyPathCut(void) = default;
     virtual WEAVE_ERROR CutPath(PropertyPathHandle aPathhandle, const TraitSchemaEngine * apEngine);
 
 private:
@@ -224,6 +228,7 @@ public:
             kSetDataEvent_DictionaryItemModifyEnd,
         };
 
+        virtual ~ISetDataDelegate(void) = default;
         /**
          * Given a path handle to a leaf node and a TLV reader, set the leaf data in the callee.
          *
@@ -264,6 +269,7 @@ public:
     class IGetDataDelegate
     {
     public:
+        virtual ~IGetDataDelegate(void) = default;
         /**
          * Given a path handle to a leaf node and a TLV writer, get the data from the callee.
          *

--- a/src/lib/profiles/data-management/Legacy/ClientDataManager.h
+++ b/src/lib/profiles/data-management/Legacy/ClientDataManager.h
@@ -59,7 +59,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
     class ClientDataManager
     {
     public:
-
+        virtual ~ClientDataManager(void) = default;
         /**
          *  @brief
          *    Confirm a failed view request.

--- a/src/lib/profiles/data-management/Legacy/DMClient.h
+++ b/src/lib/profiles/data-management/Legacy/DMClient.h
@@ -184,6 +184,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
             public DMTransaction
         {
         public:
+            virtual ~View(void) = default;
             WEAVE_ERROR Init(DMClient *aClient,
                              ReferencedTLVData &aPathList,
                              uint16_t aTxnId,
@@ -215,6 +216,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
             public DMTransaction
         {
         public:
+            virtual ~Subscribe(void) = default;
             WEAVE_ERROR Init(DMClient *aClient,
                              const TopicIdentifier &aTopicId,
                              uint16_t aTxnId,
@@ -245,6 +247,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
             public DMTransaction
         {
         public:
+            virtual ~CancelSubscription(void) = default;
             WEAVE_ERROR Init(DMClient *aClient,
                              const TopicIdentifier &aTopicId,
                              uint16_t aTxnId,
@@ -271,6 +274,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
             public DMTransaction
         {
         public:
+            virtual ~Update(void) = default;
             WEAVE_ERROR Init(DMClient *aClient,
                              ReferencedTLVData &aDataList,
                              uint16_t aTxnId,

--- a/src/lib/profiles/data-management/Legacy/DMPublisher.h
+++ b/src/lib/profiles/data-management/Legacy/DMPublisher.h
@@ -226,6 +226,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
         {
 
         public:
+            virtual ~Notify(void) = default;
             WEAVE_ERROR Init(DMPublisher *aPublisher,
                              const TopicIdentifier &aTopicId,
                              ReferencedTLVData &aDataList,

--- a/src/lib/profiles/data-management/Legacy/ProfileDatabase.h
+++ b/src/lib/profiles/data-management/Legacy/ProfileDatabase.h
@@ -449,7 +449,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
     class ProfileDatabase
     {
     public:
-
+        virtual ~ProfileDatabase(void) = default;
         /**
          *  @class ProfileData
          *

--- a/src/lib/profiles/data-management/Legacy/ProtocolEngine.h
+++ b/src/lib/profiles/data-management/Legacy/ProtocolEngine.h
@@ -90,7 +90,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
             friend class DMClient;
             friend class DMPublisher;
         public:
-
+            virtual ~DMTransaction(void) = default;
             void OnMsgReceived(const uint64_t &aResponderId, uint32_t aProfileId, uint8_t aMsgType, PacketBuffer *aMsg);
 
             /*

--- a/src/lib/profiles/data-management/Legacy/PublisherDataManager.h
+++ b/src/lib/profiles/data-management/Legacy/PublisherDataManager.h
@@ -60,7 +60,7 @@ namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNames
     class PublisherDataManager
     {
     public:
-
+        virtual ~PublisherDataManager(void) = default;
         /**
          *  @brief
          *    Indicate receipt of a view request.

--- a/src/lib/profiles/device-control/DeviceControl.h
+++ b/src/lib/profiles/device-control/DeviceControl.h
@@ -136,6 +136,7 @@ enum
 class DeviceControlDelegate : public WeaveServerDelegateBase
 {
 public:
+    virtual ~DeviceControlDelegate(void) = default;
     /**
      * Determine whether a server connection, if present, should be closed prior to
      * a configuration reset.
@@ -298,6 +299,7 @@ class NL_DLL_EXPORT DeviceControlServer : public WeaveServerBase
 {
 public:
     DeviceControlServer(void);
+    virtual ~DeviceControlServer(void) = default;
 
     WEAVE_ERROR Init(WeaveExchangeManager *exchangeMgr);
     WEAVE_ERROR Shutdown(void);

--- a/src/lib/profiles/fabric-provisioning/FabricProvisioning.h
+++ b/src/lib/profiles/fabric-provisioning/FabricProvisioning.h
@@ -112,6 +112,8 @@ enum
 class FabricProvisioningDelegate : public WeaveServerDelegateBase
 {
 public:
+    virtual ~FabricProvisioningDelegate(void) = default;
+
     /**
      * Indicates that the device has created a new Fabric.
      *
@@ -181,6 +183,7 @@ class NL_DLL_EXPORT FabricProvisioningServer : public WeaveServerBase
 {
 public:
     FabricProvisioningServer(void);
+    virtual ~FabricProvisioningServer(void) = default;
 
     WEAVE_ERROR Init(WeaveExchangeManager *exchangeMgr);
     WEAVE_ERROR Shutdown(void);

--- a/src/lib/profiles/network-provisioning/NetworkProvisioning.h
+++ b/src/lib/profiles/network-provisioning/NetworkProvisioning.h
@@ -247,6 +247,7 @@ enum GetNetworkFlags
 class NetworkProvisioningDelegate : public WeaveServerDelegateBase
 {
 public:
+    virtual ~NetworkProvisioningDelegate(void) = default;
     NetworkProvisioningServer * Server;         /**< [READ ONLY] The server object to which this delegate is attached. */
 
    /**
@@ -400,6 +401,7 @@ class NL_DLL_EXPORT NetworkProvisioningServer : public WeaveServerBase
 {
 public:
     NetworkProvisioningServer(void);
+    virtual ~NetworkProvisioningServer(void) = default;
 
     WEAVE_ERROR Init(WeaveExchangeManager *exchangeMgr);
     WEAVE_ERROR Shutdown(void);

--- a/src/lib/profiles/security/WeaveApplicationKeys.h
+++ b/src/lib/profiles/security/WeaveApplicationKeys.h
@@ -122,6 +122,7 @@ public:
 class NL_DLL_EXPORT GroupKeyStoreBase
 {
 public:
+    virtual ~GroupKeyStoreBase(void) = default;
 
     // Manage application group key material storage.
     virtual WEAVE_ERROR RetrieveGroupKey(uint32_t keyId, WeaveGroupKey& key) = 0;

--- a/src/lib/profiles/security/WeaveCASE.h
+++ b/src/lib/profiles/security/WeaveCASE.h
@@ -216,7 +216,7 @@ public:
 class WeaveCASEAuthDelegate
 {
 public:
-
+    virtual ~WeaveCASEAuthDelegate(void) = default;
 #if !WEAVE_CONFIG_LEGACY_CASE_AUTH_DELEGATE
 
     // ===== Abstract Interface methods

--- a/src/lib/profiles/security/WeaveCertProvisioning.h
+++ b/src/lib/profiles/security/WeaveCertProvisioning.h
@@ -50,7 +50,7 @@ namespace CertProvisioning {
 class WeaveNodeOpAuthDelegate
 {
 public:
-
+    virtual ~WeaveNodeOpAuthDelegate(void) = default;
     // ===== Abstract Interface methods
 
     /**
@@ -93,7 +93,7 @@ public:
 class WeaveNodeMfrAttestDelegate
 {
 public:
-
+    virtual ~WeaveNodeMfrAttestDelegate(void) = default;
     // ===== Abstract Interface methods
 
     /**

--- a/src/lib/profiles/security/WeaveKeyExport.h
+++ b/src/lib/profiles/security/WeaveKeyExport.h
@@ -143,6 +143,7 @@ enum
 class WeaveKeyExportDelegate
 {
 public:
+    virtual ~WeaveKeyExportDelegate(void) = default;
 
     // ===== Abstract Interface methods
 

--- a/src/lib/profiles/security/WeaveSig.h
+++ b/src/lib/profiles/security/WeaveSig.h
@@ -55,6 +55,8 @@ enum {
 class WeaveSignatureGeneratorBase
 {
 public:
+    virtual ~WeaveSignatureGeneratorBase(void) = default;
+
     enum
     {
         kFlag_None                                          = 0,
@@ -87,6 +89,7 @@ protected:
 class WeaveSignatureGenerator : public WeaveSignatureGeneratorBase
 {
 public:
+    virtual ~WeaveSignatureGenerator(void) = default;
     const uint8_t * PrivKey;
     uint16_t PrivKeyLen;
 

--- a/src/lib/profiles/security/WeaveTAKE.h
+++ b/src/lib/profiles/security/WeaveTAKE.h
@@ -123,6 +123,8 @@ enum {
 class WeaveTAKEChallengerAuthDelegate
 {
 public:
+    virtual ~WeaveTAKEChallengerAuthDelegate(void) = default;
+
     // Rewind Identification Key Iterator.
     // Called to prepare for a new Identification Key search.
     virtual WEAVE_ERROR RewindIdentificationKeyIterator(void) = 0;
@@ -159,6 +161,8 @@ public:
 class WeaveTAKETokenAuthDelegate
 {
 public:
+    virtual ~WeaveTAKETokenAuthDelegate(void) = default;
+
     // Get the token Master key. size: kTokenMasterKeySize
     virtual WEAVE_ERROR GetTokenMasterKey(uint8_t *tokenMasterKey) const = 0;
 

--- a/src/lib/profiles/service-provisioning/ServiceProvisioning.h
+++ b/src/lib/profiles/service-provisioning/ServiceProvisioning.h
@@ -179,6 +179,7 @@ public:
 class ServiceProvisioningDelegate : public WeaveServerDelegateBase
 {
 public:
+    virtual ~ServiceProvisioningDelegate(void) = default;
     virtual WEAVE_ERROR HandleRegisterServicePairAccount(RegisterServicePairAccountMessage& msg) = 0;
     virtual WEAVE_ERROR HandleUpdateService(UpdateServiceMessage& msg) = 0;
     virtual WEAVE_ERROR HandleUnregisterService(uint64_t serviceId) = 0;
@@ -218,6 +219,7 @@ class NL_DLL_EXPORT ServiceProvisioningServer : public WeaveServerBase
 {
 public:
     ServiceProvisioningServer(void);
+    virtual ~ServiceProvisioningServer(void) = default;
 
     WEAVE_ERROR Init(WeaveExchangeManager *exchangeMgr);
     WEAVE_ERROR Shutdown(void);

--- a/src/lib/profiles/software-update/WeaveImageAnnounceServer.h
+++ b/src/lib/profiles/software-update/WeaveImageAnnounceServer.h
@@ -43,6 +43,8 @@ namespace SoftwareUpdate {
 class IWeaveImageAnnounceServerDelegate
 {
 public:
+    virtual ~IWeaveImageAnnounceServerDelegate(void) = default;
+
     /// Delegate function called on Image Announce
     /**
      * Called by WeaveImageAnnounceServer when image announcement is received.

--- a/src/lib/profiles/token-pairing/TokenPairing.h
+++ b/src/lib/profiles/token-pairing/TokenPairing.h
@@ -104,6 +104,7 @@ class NL_DLL_EXPORT TokenPairingServer : public WeaveServerBase
 {
 public:
     TokenPairingServer(void);
+    virtual ~TokenPairingServer(void) = default;
 
     WEAVE_ERROR Init(WeaveExchangeManager *exchangeMgr);
     WEAVE_ERROR Shutdown(void);

--- a/src/lib/support/WeaveCounter.h
+++ b/src/lib/support/WeaveCounter.h
@@ -40,7 +40,7 @@ class Counter
 {
 public:
     Counter(void) { };
-    ~Counter(void) { };
+    virtual ~Counter(void) { };
 
     /**
      *  @brief

--- a/src/lib/support/crypto/RSA.cpp
+++ b/src/lib/support/crypto/RSA.cpp
@@ -198,7 +198,7 @@ WEAVE_ERROR VerifyRSASignature(OID sigAlgoOID,
     shaNID = ShaNIDFromSigAlgoOID(sigAlgoOID);
     VerifyOrExit(shaNID != NID_undef, err = WEAVE_ERROR_UNSUPPORTED_SIGNATURE_TYPE);
 
-    certBuf = BIO_new_mem_buf(certDER, certDERLen);
+    certBuf = BIO_new_mem_buf(reinterpret_cast<void*>(const_cast<uint8_t*>(certDER)), certDERLen);
     VerifyOrExit(certBuf != NULL, err = WEAVE_ERROR_NO_MEMORY);
 
     cert = d2i_X509_bio(certBuf, NULL);

--- a/src/warm/Warm.h
+++ b/src/warm/Warm.h
@@ -155,6 +155,8 @@ class WarmFabricStateDelegate
     : public FabricStateDelegate
 {
 public:
+    virtual ~WarmFabricStateDelegate(void) = default;
+
     /**
      *  This method is invoked by WeaveFabricState when joining/creating a new fabric.
      *


### PR DESCRIPTION
This resolves some compilation errors when cross-compiling with clang in our project. No behavior is changed, just clarified to avoid compiler warnings that we have set as errors.