### PR TITLE
Specifically cast certDER to void*.

### DIFF
--- a/src/lib/support/crypto/RSA.cpp
+++ b/src/lib/support/crypto/RSA.cpp
@@ -198,7 +198,7 @@ WEAVE_ERROR VerifyRSASignature(OID sigAlgoOID,
     shaNID = ShaNIDFromSigAlgoOID(sigAlgoOID);
     VerifyOrExit(shaNID != NID_undef, err = WEAVE_ERROR_UNSUPPORTED_SIGNATURE_TYPE);
 
-    certBuf = BIO_new_mem_buf(certDER, certDERLen);
+    certBuf = BIO_new_mem_buf(reinterpret_cast<void*>(const_cast<uint8_t*>(certDER)), certDERLen);
     VerifyOrExit(certBuf != NULL, err = WEAVE_ERROR_NO_MEMORY);
 
     cert = d2i_X509_bio(certBuf, NULL);


### PR DESCRIPTION
clang complained about the implicit conversion - this more clearly
shows what is being done to the pointer.

Bug: 155214583
Change-Id: I90f01a46c4f0eb08388a0c6dcf9c4dbdd5a73d75