### PR TITLE
Fix null version case for VersionList::Parser::GetVersion

### DIFF
--- a/src/lib/profiles/data-management/Current/MessageDef.cpp
+++ b/src/lib/profiles/data-management/Current/MessageDef.cpp
@@ -2822,7 +2822,17 @@ bool VersionList::Parser::IsNull(void)
 
 WEAVE_ERROR VersionList::Parser::GetVersion(uint64_t * const apVersion)
 {
-    return mReader.Get(*apVersion);
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    if (mReader.GetType() == kTLVType_Null)
+    {
+        *apVersion = 0;
+        WeaveLogDetail(DataManagement, "Version is null in GetVersion");
+    }
+    else
+    {
+        err = mReader.Get(*apVersion);
+    }
+    return err;
 }
 
 VersionList::Builder & VersionList::Builder::AddVersion(const uint64_t aVersion)

--- a/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
@@ -2576,6 +2576,7 @@ void SubscriptionClient::OnUpdateResponse(WEAVE_ERROR aReason, nl::Weave::Profil
         if (IsStatusListPresent)
         {
             err = statusList.Next();
+            SuccessOrExit(err);
 
             err = statusList.GetProfileIDAndStatusCode(&profileID, &statusCode);
             SuccessOrExit(err);

--- a/src/test-apps/happy/lib/WeaveDeviceManager.py
+++ b/src/test-apps/happy/lib/WeaveDeviceManager.py
@@ -544,6 +544,30 @@ def testWdmClientDataSinkResourceIdentifierMakeResTypeIdBytes(testObject):
     testObject.closeWdmClient()
     print "testWdmClientDataSinkResourceIdentifierMakeResTypeIdBytes completes"
 
+def testWdmClientDataSinkSetFlushInvalidInstanceId(testObject):
+    testObject.createWdmClient()
+    localeSettingsTrait = testObject.newDataSink(20, 1, "/")
+    TestCTrait = testObject.newDataSink(593165827, 0, "/")
+    testObject.setData(localeSettingsTrait, "/1", "en-US")
+    testObject.setData(TestCTrait, "/1", False)
+    testObject.setData(TestCTrait, "/2", 15)
+    testObject.setData(TestCTrait, "/3/1", 16)
+    testObject.setData(TestCTrait, "/3/2", False)
+    testObject.setData(TestCTrait, "/4", 17)
+    result = testObject.flushUpdate()
+    if len(result) != 1:
+        raise ValueError("testWdmClientDataSinkSetFlushInvalidInstanceId fails")
+    else:
+        if not (result[0].profileId == 0xb and result[0].statusCode == 0x21):
+            raise ValueError("testWdmClientDataSinkSetFlushInvalidInstanceId profileId and StatusCode check fails")
+
+        print "clear trait: " + str(result[0].dataSink.profileId)
+        print "clear trait path:" + str(result[0].path)
+        testObject.deleteData(result[0].dataSink, result[0].path)
+
+    testObject.closeWdmClient()
+    print "testWdmClientDataSinkSetFlushInvalidInstanceId completes"
+
 def RunWdmClientTest():
     print "Run Weave Data Management Test"
     testObject = MockWeaveDataManagementClientImp()
@@ -561,6 +585,7 @@ def RunWdmClientTest():
     testWdmClientDataSinkSetRefreshFlushGetData(testObject)
     testWdmClientDataSinkResourceIdentifierMakeResTypeIdInt(testObject)
     testWdmClientDataSinkResourceIdentifierMakeResTypeIdBytes(testObject)
+    testWdmClientDataSinkSetFlushInvalidInstanceId(testObject)
 
     print "Run Weave Data Management Complete"
 


### PR DESCRIPTION
-- There exists VersionList::Builder::AddNull API which has been used
for null version set when trait version cannot be obtained in server
side in some situations, for example, trait access denied or profile id
or instance id is not correct and so on. In correspondence, we need to
do the null version correctly in VersionList::Parser::GetVersion(current
implementation does not check this null version case), and set apVersion
as 0 which means invalid version, and return WEAVE_NO_ERROR, otherwise,
SubscriptionClient would fails to process OnUpdateResponse and go to exit when
triggering versionList.GetVersion in L2572, and further set the internal
error for all paths in current flush operation even though other paths
have been updated correctly.

-- Add test case to validate this case.