### PR TITLE
Fix TLVreader context tag err

### DIFF
--- a/src/lib/core/WeaveFabricState.cpp
+++ b/src/lib/core/WeaveFabricState.cpp
@@ -832,7 +832,7 @@ WEAVE_ERROR WeaveFabricState::RestoreSession(uint8_t * serializedSession, uint16
         err = reader.EnterContainer(container2);
         SuccessOrExit(err);
 
-        while ((err = reader.Next(kTLVType_UnsignedInteger, kTLVTagControl_Anonymous)) == WEAVE_NO_ERROR)
+        while ((err = reader.Next(kTLVType_UnsignedInteger, AnonymousTag)) == WEAVE_NO_ERROR)
         {
             uint64_t altNodeId;
 


### PR DESCRIPTION
Should use AnonymousTag to read out shared session endnode.