### PR TITLE
Reduce possibilities of null ptr dereference in PacketBuffer and TCPEndPoint

### DIFF
--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -1844,7 +1844,10 @@ void TCPEndPoint::HandleDataSent(uint16_t lenSent)
     if (IsConnected())
     {
         // Consume data off the head of the send queue equal to the amount of data being acknowledged.
-        mSendQueue = mSendQueue->Consume(lenSent);
+        if (mSendQueue)
+        {
+            mSendQueue = mSendQueue->Consume(lenSent);
+        }
 
 #if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
         // Only change the UserTimeout timer if lenSent > 0,

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -333,7 +333,7 @@ PacketBuffer* PacketBuffer::Consume(uint16_t aConsumeLength)
 {
     PacketBuffer* lPacket = this;
 
-    while (lPacket != NULL && aConsumeLength > 0)
+    while (aConsumeLength > 0)
     {
         const uint16_t kLength = lPacket->DataLength();
 
@@ -341,6 +341,10 @@ PacketBuffer* PacketBuffer::Consume(uint16_t aConsumeLength)
         {
             lPacket = PacketBuffer::FreeHead(lPacket);
             aConsumeLength -= kLength;
+            if (lPacket == NULL)
+            {
+                break;
+            }
         }
         else
         {


### PR DESCRIPTION
1. remove an initial NULL this pointer check in PacketBuffer::Consume()
which might mislead a reader to think that it is checking for this == NULL
case. Compiler assumes this can never be NULL and does not do the initial
check.
2. Check for null sendqueue in TCPEndPoint::HandleDataSent()