### PR TITLE
Support new OpenThread with OPENTHREAD_API_VERSION

### DIFF
--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/OpenThread/GenericThreadStackManagerImpl_OpenThread.ipp
@@ -290,19 +290,19 @@ WEAVE_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetThreadProvi
             memcpy(netInfo.ThreadNetworkKey, activeDataset.mMasterKey.m8, sizeof(netInfo.ThreadNetworkKey));
             netInfo.FieldPresent.ThreadNetworkKey = true;
         }
-#ifdef EFR32_OPENTHREAD_API
+#if defined(EFR32_OPENTHREAD_API) || defined(OPENTHREAD_API_VERSION)
         if (activeDataset.mComponents.mIsPskcPresent)
         {
             memcpy(netInfo.ThreadPSKc, activeDataset.mPskc.m8, sizeof(netInfo.ThreadPSKc));
             netInfo.FieldPresent.ThreadPSKc = true;
         }
-#else // !EFR32_OPENTHREAD_API
+#else // !EFR32_OPENTHREAD_API && !OPENTHREAD_API_VERSION
         if (activeDataset.mComponents.mIsPSKcPresent)
         {
             memcpy(netInfo.ThreadPSKc, activeDataset.mPSKc.m8, sizeof(netInfo.ThreadPSKc));
             netInfo.FieldPresent.ThreadPSKc = true;
         }
-#endif // !EFR32_OPENTHREAD_API
+#endif // !EFR32_OPENTHREAD_API && !OPENTHREAD_API_VERSION
     }
     if (activeDataset.mComponents.mIsPanIdPresent)
     {
@@ -350,13 +350,13 @@ WEAVE_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetThreadProvi
     }
     if (netInfo.FieldPresent.ThreadPSKc)
     {
-#ifdef EFR32_OPENTHREAD_API
+#if defined(EFR32_OPENTHREAD_API) || defined(OPENTHREAD_API_VERSION)
         memcpy(newDataset.mPskc.m8, netInfo.ThreadPSKc, sizeof(newDataset.mPskc.m8));
         newDataset.mComponents.mIsPskcPresent = true;
-#else // !EFR32_OPENTHREAD_API
+#else // !EFR32_OPENTHREAD_API && !OPENTHREAD_API_VERSION
         memcpy(newDataset.mPSKc.m8, netInfo.ThreadPSKc, sizeof(newDataset.mPSKc.m8));
         newDataset.mComponents.mIsPSKcPresent = true;
-#endif // !EFR32_OPENTHREAD_API
+#endif // !EFR32_OPENTHREAD_API && !OPENTHREAD_API_VERSION
     }
     if (netInfo.ThreadPANId != kThreadPANId_NotSpecified)
     {
@@ -401,11 +401,11 @@ ConnectivityManager::ThreadDeviceType GenericThreadStackManagerImpl_OpenThread<I
 
     if (linkMode.mDeviceType)
     {
-#ifdef EFR32_OPENTHREAD_API
+#if defined(EFR32_OPENTHREAD_API) || defined(OPENTHREAD_API_VERSION)
         if (otThreadIsRouterEligible(mOTInst))
-#else // !EFR32_OPENTHREAD_API
+#else // !EFR32_OPENTHREAD_API && !OPENTHREAD_API_VERSION
         if (otThreadIsRouterRoleEnabled(mOTInst))
-#endif // !EFR32_OPENTHREAD_API
+#endif // !EFR32_OPENTHREAD_API && !OPENTHREAD_API_VERSION
         {
             deviceType = ConnectivityManager::kThreadDeviceType_Router;
         }
@@ -480,11 +480,11 @@ WEAVE_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetThreadDevic
     case ConnectivityManager::kThreadDeviceType_FullEndDevice:
         linkMode.mDeviceType = true;
         linkMode.mRxOnWhenIdle = true;
-#ifdef EFR32_OPENTHREAD_API
+#if defined(EFR32_OPENTHREAD_API) || defined(OPENTHREAD_API_VERSION)
         otThreadSetRouterEligible(mOTInst, deviceType == ConnectivityManager::kThreadDeviceType_Router);
-#else // !EFR32_OPENTHREAD_API
+#else // !EFR32_OPENTHREAD_API && !OPENTHREAD_API_VERSION
         otThreadSetRouterRoleEnabled(mOTInst, deviceType == ConnectivityManager::kThreadDeviceType_Router);
-#endif // !EFR32_OPENTHREAD_API
+#endif // !EFR32_OPENTHREAD_API && !OPENTHREAD_API_VERSION
         break;
     case ConnectivityManager::kThreadDeviceType_MinimalEndDevice:
         linkMode.mDeviceType = false;


### PR DESCRIPTION
To use new OpenThread, set OPENTHREAD_API_VERSION_MINIMAL to a
non-zero value which indicates the minimal OpenThread API version
required for the project.

This commit keeps OPENTHREAD_API_VERSION_MINIMAL to 0 by default because
other openweave projects is still using an old OpenThread.