### PR TITLE
Add WEAVE_TRAILER_RESERVE_SIZE to Tunnel pbuf allocation from LwIP

### DIFF
--- a/src/inet/TunEndPoint.cpp
+++ b/src/inet/TunEndPoint.cpp
@@ -550,10 +550,10 @@ err_t TunEndPoint::LwIPPostToInetEventQ (struct netif *netif, struct pbuf *p)
     TunEndPoint*            ep              = static_cast<TunEndPoint *>(netif->state);
     Weave::System::Layer&   lSystemLayer    = ep->SystemLayer();
 
-    // Starting off with a reserved size of the default WEAVE_SYSTEM_CONFIG_HEADER_RESERVE_SIZE
-    // which allows for adding the Weave header and the underlying transport and IP headers
-    // encapsulating this tunneled packet. Also need to request space for trailer.
-
+    // Allocate space for the tunneled IP packet. The reserved space will be the
+    // default for the Weave and underlying TCP/IP headers (WEAVE_SYSTEM_CONFIG_HEADER_RESERVE_SIZE).
+    // The requested data size will include the full pbuf received from LwIP plus
+    // WEAVE_TRAILER_RESERVE_SIZE for holding the HMAC.
     PacketBuffer* buf = PacketBuffer::NewWithAvailableSize(p->tot_len + WEAVE_TRAILER_RESERVE_SIZE);
     VerifyOrExit(buf != NULL, lwipErr = ERR_MEM);
 

--- a/src/inet/TunEndPoint.cpp
+++ b/src/inet/TunEndPoint.cpp
@@ -549,12 +549,12 @@ err_t TunEndPoint::LwIPPostToInetEventQ (struct netif *netif, struct pbuf *p)
     INET_ERROR              err             = INET_NO_ERROR;
     TunEndPoint*            ep              = static_cast<TunEndPoint *>(netif->state);
     Weave::System::Layer&   lSystemLayer    = ep->SystemLayer();
-    PacketBuffer*           buf             = PacketBuffer::NewWithAvailableSize(p->tot_len);
 
     // Starting off with a reserved size of the default WEAVE_SYSTEM_CONFIG_HEADER_RESERVE_SIZE
     // which allows for adding the Weave header and the underlying transport and IP headers
-    // encapsulating this tunneled packet.
+    // encapsulating this tunneled packet. Also need to request space for trailer.
 
+    PacketBuffer* buf = PacketBuffer::NewWithAvailableSize(p->tot_len + WEAVE_TRAILER_RESERVE_SIZE);
     VerifyOrExit(buf != NULL, lwipErr = ERR_MEM);
 
     buf->SetDataLength(p->tot_len);


### PR DESCRIPTION
TunEndPoint::LwIPPostToInetEventQ() does not currently account for WEAVE_TRAILER_RESERVE_SIZE when it allocates a new PacketBuffer for a packet received from the LwIP layer. This space is needed for encryption information.