### PR TITLE
Fix incorrect usage of xEventGroupSetBitsFromISR

### DIFF
--- a/src/adaptations/device-layer/EFR32/BLEManagerImpl.cpp
+++ b/src/adaptations/device-layer/EFR32/BLEManagerImpl.cpp
@@ -183,7 +183,7 @@ void BLEManagerImpl::bluetoothStackEventHandler(void *p_arg)
     while (1)
     {
         // wait for Bluetooth stack events, do not consume set flag
-        flags |=
+        flags =
             xEventGroupWaitBits(bluetooth_event_flags,            /* The event group being tested. */
                                 BLUETOOTH_EVENT_FLAG_EVT_WAITING, /* The bits within the event group to wait for. */
                                 pdFALSE,                          /* Dont clear flags before returning */
@@ -272,7 +272,7 @@ void BLEManagerImpl::bluetoothStackEventHandler(void *p_arg)
 
         PlatformMgr().UnlockWeaveStack();
 
-        flags = vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_EVT_HANDLED, NULL);
+        vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_EVT_HANDLED);
     }
 }
 

--- a/src/adaptations/device-layer/EFR32/freertos_bluetooth.c
+++ b/src/adaptations/device-layer/EFR32/freertos_bluetooth.c
@@ -100,28 +100,19 @@ errorcode_t bluetooth_start(UBaseType_t               ll_priority,
 // sets flag to trigger Link Layer Task
 void BluetoothLLCallback()
 {
-    EventBits_t eventBits;
-    BaseType_t  pxHigherPriorityTaskWoken = pdFALSE;
-    eventBits =
-        vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_LL, &pxHigherPriorityTaskWoken);
-    (void)eventBits;
+  vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_LL);
 }
 // This callback is called from Bluetooth stack
 // Called from kernel aware interrupt context (RTCC interrupt) and from Bluetooth task
 // sets flag to trigger running Bluetooth stack
 void BluetoothUpdate()
 {
-    EventBits_t eventBits;
-    BaseType_t  pxHigherPriorityTaskWoken = pdFALSE;
-    eventBits =
-        vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_STACK, &pxHigherPriorityTaskWoken);
-    (void)eventBits;
+    vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_STACK);
 }
 // Bluetooth task, it waits for events from bluetooth and handles them
 void BluetoothTask(void *p)
 {
     EventBits_t flags = BLUETOOTH_EVENT_FLAG_EVT_HANDLED | BLUETOOTH_EVENT_FLAG_STACK;
-    EventBits_t eventBits;
     TickType_t  xTicksToWait;
 
     while (1)
@@ -134,8 +125,7 @@ void BluetoothTask(void *p)
             sli_bt_cmd_handler_delegate(header, cmd_handler, (void *)command_data);
             command_handler_func = NULL;
             flags &= ~BLUETOOTH_EVENT_FLAG_CMD_WAITING;
-            eventBits = vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_RSP_WAITING, NULL);
-            (void)eventBits;
+            vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_RSP_WAITING);
         }
 
         // Bluetooth stack needs updating, and evt can be used
@@ -144,9 +134,7 @@ void BluetoothTask(void *p)
             bluetooth_evt = gecko_wait_event();
             if (bluetooth_evt != NULL)
             { // we got event, notify event handler. evt state is now waiting handling
-                eventBits =
-                    vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_EVT_WAITING, NULL);
-                (void)eventBits;
+                vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_EVT_WAITING);
                 flags &= ~(BLUETOOTH_EVENT_FLAG_EVT_HANDLED);
                 if (wakeupCB != NULL)
                 {
@@ -240,7 +228,7 @@ void sli_bt_cmd_handler_rtos_delegate(uint32_t header, gecko_cmd_handler handler
     command_handler_func = handler;
     command_data         = (void *)payload;
     // Command structure is filled, notify the stack
-    uxBits = vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_CMD_WAITING, NULL);
+    vRaiseEventFlagBasedOnContext(bluetooth_event_flags, BLUETOOTH_EVENT_FLAG_CMD_WAITING);
 
     // wait for response
     uxBits = xEventGroupWaitBits(bluetooth_event_flags,            /* The event group being tested. */
@@ -346,27 +334,32 @@ void vApplicationGetTimerTaskMemory(StaticTask_t **ppxTimerTaskTCBBuffer,
     *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
 }
 
-EventBits_t vRaiseEventFlagBasedOnContext(EventGroupHandle_t xEventGroup,
-                                          EventBits_t        uxBitsToWaitFor,
-                                          BaseType_t *       pxHigherPriorityTaskWoken)
+void vRaiseEventFlagBasedOnContext(EventGroupHandle_t xEventGroup,
+				   EventBits_t        uxBitsToWaitFor)
 {
     EventBits_t eventBits;
+    BaseType_t  eventBitsFromISRStatus;
     BaseType_t  higherPrioTaskWoken = pdFALSE;
 
     if (xPortIsInsideInterrupt())
     {
-        eventBits = xEventGroupSetBitsFromISR(xEventGroup, uxBitsToWaitFor, &higherPrioTaskWoken);
+        eventBitsFromISRStatus = xEventGroupSetBitsFromISR(xEventGroup, uxBitsToWaitFor, &higherPrioTaskWoken);
+        if (eventBitsFromISRStatus != pdFAIL)
+        {
+#ifdef portYIELD_FROM_ISR
+            portYIELD_FROM_ISR(higherPrioTaskWoken);
+#elif portEND_SWITCHING_ISR // portYIELD_FROM_ISR or portEND_SWITCHING_ISR
+            portEND_SWITCHING_ISR(higherPrioTaskWoken);
+#else                       // portYIELD_FROM_ISR or portEND_SWITCHING_ISR
+#error "Must have portYIELD_FROM_ISR or portEND_SWITCHING_ISR"
+#endif // portYIELD_FROM_ISR or portEND_SWITCHING_ISR
+        }
     }
     else
     {
         eventBits = xEventGroupSetBits(xEventGroup, uxBitsToWaitFor);
+        (void)eventBits;
     }
-
-    if (pxHigherPriorityTaskWoken != NULL)
-    {
-        *pxHigherPriorityTaskWoken = higherPrioTaskWoken;
-    }
-    return eventBits;
 }
 
 EventBits_t vSendToQueueBasedOnContext(QueueHandle_t xQueue,

--- a/src/adaptations/device-layer/include/Weave/DeviceLayer/EFR32/freertos_bluetooth.h
+++ b/src/adaptations/device-layer/include/Weave/DeviceLayer/EFR32/freertos_bluetooth.h
@@ -72,9 +72,8 @@ extern void BluetoothLLCallback(void);
 void BluetoothPend(void);
 void BluetoothPost(void);
 
-EventBits_t vRaiseEventFlagBasedOnContext(EventGroupHandle_t xEventGroup,
-                                          EventBits_t        uxBitsToWaitFor,
-                                          BaseType_t *       pxHigherPriorityTaskWoken);
+void vRaiseEventFlagBasedOnContext(EventGroupHandle_t xEventGroup,
+				   EventBits_t        uxBitsToWaitFor);
 EventBits_t vSendToQueueBasedOnContext(QueueHandle_t xQueue,
                                        void *        xItemToQueue,
                                        TickType_t    xTicksToWait,


### PR DESCRIPTION
There were a few changes here:

1) xEventGroupSetBitsFromISR returns a BaseType_t but this return
value was being assigned to an EventBits_t and then being returned
from vRaiseEventFlagBasedOnContext.  Whatever values ended up in the
BaseType_t are not likely to be correct for an EventBits_t.  The fix
here is to change vRaiseEventFlagBasedOnContext to return void, since
none of the callers actually use the return value anyway.

2) Per the documentation at
https://www.freertos.org/xEventGroupSetBitsFromISR.html
xEventGroupSetBitsFromISR requires that portYIELD_FROM_ISR or
portEND_SWITCHING_ISR be called if xEventGroupSetBitsFromISR doesn't
fail.  This code was not doing that, and the fix was to call whichever
of those we have available.

3) The higherPrioTaskWoken outparam was unused by consumers and is
really only needed for the portYIELD_FROM_ISR/portEND_SWITCHING_ISR
call, so that got removed as well.