### PR TITLE
Add Log lines to monitor dropped events, by importance level

### DIFF
--- a/src/lib/profiles/data-management/Current/LoggingManagement.cpp
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.cpp
@@ -1676,6 +1676,8 @@ WEAVE_ERROR LoggingManagement::EvictEvent(WeaveCircularTLVBuffer & inBuffer, voi
 
         eventBuffer->RemoveEvent(numEventsToDrop);
         eventBuffer->mFirstEventTimestamp += context.mDeltaTime;
+        WeaveLogProgress(EventLogging, "Dropped events do to overflow: { importance_level: %d, count: %d };", imp, numEventsToDrop);
+
 #if WEAVE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS
         eventBuffer->mFirstEventUTCTimestamp += context.mDeltaUtc;
 #endif // WEAVE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS


### PR DESCRIPTION
Print importance level and dropped event count as a parsable format