### PR TITLE
Tunnel CASE Session persistence support.

### DIFF
--- a/src/lib/core/WeaveSecurityMgr.cpp
+++ b/src/lib/core/WeaveSecurityMgr.cpp
@@ -2514,6 +2514,7 @@ WEAVE_ERROR WeaveSecurityManager::SendKeyErrorMsg(WeaveMessageInfo *rcvdMsgInfo,
     }
     else
     {
+        con->PeerNodeId = rcvdMsgInfo->SourceNodeId;
         ec = ExchangeManager->NewContext(con, this);
     }
     VerifyOrExit(ec != NULL, err = WEAVE_ERROR_NO_MEMORY);

--- a/src/lib/core/WeaveTunnelConfig.h
+++ b/src/lib/core/WeaveTunnelConfig.h
@@ -469,6 +469,30 @@
 #define WEAVE_CONFIG_TUNNEL_INTERFACE_MTU                           (1536)
 #endif // WEAVE_CONFIG_TUNNEL_INTERFACE_MTU
 
+/**
+ * @def WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+ *
+ * @brief
+ *    Set to true if the Tunnel CASE session needs to be persisted,
+ *    false otherwise.
+ */
+#ifndef WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+#define WEAVE_CONFIG_PERSIST_CONNECTED_SESSION                      (0)
+#endif // WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+
+/**
+ * @def WEAVE_CONFIG_TUNNEL_SESSION_RESUMPTION_MSG_ID_OFFSET
+ *
+ * @brief
+ *   The offset to use to move the message id forward when
+ *   computing the resumption message ids when suspending
+ *   the current secure tunnel session.
+ *
+ */
+#ifndef WEAVE_CONFIG_TUNNEL_SESSION_RESUMPTION_MSG_ID_OFFSET
+#define WEAVE_CONFIG_TUNNEL_SESSION_RESUMPTION_MSG_ID_OFFSET      (10000)
+#endif // WEAVE_CONFIG_TUNNEL_SESSION_RESUMPTION_MSG_ID_OFFSET
+
 // clang-format on
 
 #endif /* WEAVE_TUNNEL_CONFIG_H_ */

--- a/src/lib/profiles/security/WeaveSecurity.h
+++ b/src/lib/profiles/security/WeaveSecurity.h
@@ -342,7 +342,12 @@ enum
     kTag_SerializedSession_AES128CTRSHA1_DataKey        = 11, // [ BYTE STRING, len 16 ] For sessions supporting AES128CTRSHA1
                                                               //    message encryption, the data encryption key.
     kTag_SerializedSession_AES128CTRSHA1_IntegrityKey   = 12, // [ BYTE STRING, len 20 ] For sessions supporting AES128CTRSHA1
-                                                              //    message encryption, the data integrity key.
+    kTag_SerializedSession_AreResumptionMsgIdsValid     = 13, // [ BOOLEAN ] Are session resumption message Ids valid
+    kTag_SerializedSession_ResumptionSendMessageId      = 14, // [ UNSIGNED INT, range 32bits ] Send message id for a persisted
+                                                              //    session to resume from.
+    kTag_SerializedSession_ResumptionRecvMessageId      = 15, // [ UNSIGNED INT, range 32bits ] Next expected receive message id
+                                                              //    for a session resumed after persistence.
+    kTag_SerializedSession_IsUsedOverConnection         = 16, // [ BOOLEAN ] Is session used over a connection
 };
 
 // Weave-defined elliptic curve ids

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.cpp
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.cpp
@@ -365,6 +365,19 @@ WeaveTunnelAgent::AgentState WeaveTunnelAgent::GetWeaveTunnelAgentState(void)
     return mTunAgentState;
 }
 
+#if WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+void WeaveTunnelAgent::SetCallbacksForPersistedTunnelConnection(WeaveTunnelConnectionMgr::PersistedSecureSessionExistsFunct aIsPersistedTunnelSessionPresent,
+                                                                WeaveTunnelConnectionMgr::LoadPersistedSessionFunct aLoadPersistedTunnelSession)
+{
+    mPrimaryTunConnMgr.SetCallbacksForPersistedTunnelConnection(aIsPersistedTunnelSessionPresent, aLoadPersistedTunnelSession);
+
+#if WEAVE_CONFIG_TUNNEL_FAILOVER_SUPPORTED
+    mBackupTunConnMgr.SetCallbacksForPersistedTunnelConnection(aIsPersistedTunnelSessionPresent, aLoadPersistedTunnelSession);
+#endif // WEAVE_CONFIG_TUNNEL_FAILOVER_SUPPORTED
+
+}
+#endif // WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+
 /**
  * Shutdown the Tunnel Agent. This tears down connection to the Service and closes the TunEndPoint
  * interface after removing addresses and routes associated with the tunnel interface.

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.h
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.h
@@ -265,6 +265,14 @@ public:
  */
     WEAVE_ERROR ResetPrimaryReconnectBackoff(bool reconnectImmediately);
 
+#if WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+/**
+ * Set Callbacks for persisted tunnel connection
+ */
+    void SetCallbacksForPersistedTunnelConnection(WeaveTunnelConnectionMgr::PersistedSecureSessionExistsFunct aIsPersistedTunnelSessionPresent,
+                                                  WeaveTunnelConnectionMgr::LoadPersistedSessionFunct aLoadPersistedTunnelSession);
+#endif // WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+
 #if WEAVE_CONFIG_TUNNEL_FAILOVER_SUPPORTED
 
 /**

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.h
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.h
@@ -112,6 +112,24 @@ class NL_DLL_EXPORT WeaveTunnelConnectionMgr
 
     WeaveTunnelConnectionMgr(void);
 
+#if WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+/**
+ * Check if a persisted secure session for the tunnel exists
+ */
+    typedef bool (*PersistedSecureSessionExistsFunct)(uint64_t peerNodeId);
+    PersistedSecureSessionExistsFunct IsPersistedTunnelSessionPresent;
+
+/**
+ * Populate the persisted secure session within the passed WeaveConnection object
+ */
+    typedef void (*LoadPersistedSessionFunct)(WeaveConnection *con);
+    LoadPersistedSessionFunct LoadPersistedTunnelSession;
+
+    void SetCallbacksForPersistedTunnelConnection(PersistedSecureSessionExistsFunct aIsPersistedTunnelSessionPresent,
+                                                  LoadPersistedSessionFunct aLoadPersistedTunnelSession);
+
+#endif // WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+
 /**
  * Initialize the WeaveTunnelConnectionMgr.
  */

--- a/src/test-apps/Makefile.am
+++ b/src/test-apps/Makefile.am
@@ -499,6 +499,8 @@ network_test_programs                          = \
     TestWRMP                                     \
     TestWeaveMessageLayer                        \
     TestWeaveTunnelBR                            \
+    TestWeaveTunnelCASEPersistClient             \
+    TestWeaveTunnelCASEPersistServer             \
     TestWeaveTunnelServer                        \
     TestWdmNext                                  \
     TestWdmOneWayCommandSender                   \
@@ -1399,6 +1401,14 @@ TestWeaveSignature_LDADD                 = $(COMMON_LDADD)
 TestWeaveTunnelBR_SOURCES                = TestWeaveTunnelBR.cpp
 TestWeaveTunnelBR_LDFLAGS                = $(AM_CPPFLAGS)
 TestWeaveTunnelBR_LDADD                  = libWeaveTestCommon.a $(COMMON_LDADD)
+
+TestWeaveTunnelCASEPersistClient_SOURCES = TestWeaveTunnelCASEPersistClient.cpp
+TestWeaveTunnelCASEPersistClient_LDFLAGS = $(AM_CPPFLAGS)
+TestWeaveTunnelCASEPersistClient_LDADD   = libWeaveTestCommon.a $(COMMON_LDADD)
+
+TestWeaveTunnelCASEPersistServer_SOURCES = TestWeaveTunnelCASEPersistServer.cpp
+TestWeaveTunnelCASEPersistServer_LDFLAGS = $(AM_CPPFLAGS)
+TestWeaveTunnelCASEPersistServer_LDADD   = libWeaveTestCommon.a $(COMMON_LDADD)
 
 TestWeaveTunnelServer_SOURCES            = TestWeaveTunnelServer.cpp
 TestWeaveTunnelServer_LDFLAGS            = $(AM_CPPFLAGS)

--- a/src/test-apps/TestWeaveTunnel.h
+++ b/src/test-apps/TestWeaveTunnel.h
@@ -82,6 +82,7 @@ enum
     kTestNum_TestTunnelNoStatusReportResetReconnectBackoff      = 26,
     kTestNum_TestTunnelRestrictedRoutingOnStandaloneTunnelOpen  = 27,
     kTestNum_TestTunnelTCPIdle                                  = 28,
+    kTestNum_TestTunnelPersistCASESession                       = 29,
 };
 
 #endif // WEAVE_CONFIG_ENABLE_TUNNELING

--- a/src/test-apps/TestWeaveTunnelCASEPersistClient.cpp
+++ b/src/test-apps/TestWeaveTunnelCASEPersistClient.cpp
@@ -1,0 +1,573 @@
+/*
+ *
+ *    Copyright (c) 2020 Google LLC.
+ *    Copyright (c) 2014-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the Weave Mock Weave Border Gateway.
+ *
+ *      This is used to instantiate a Tunnel Agent which opens a
+ *      tunnel endpoint and forwards IPv6 packets between the
+ *      Service connection and the tunnel endpoint.
+ *
+ */
+
+#define __STDC_FORMAT_MACROS
+
+
+#include <inttypes.h>
+#include <unistd.h>
+#include <string.h>
+#include <fstream>
+
+#include "ToolCommon.h"
+#include "CASEOptions.h"
+#include <Weave/Support/logging/DecodedIPPacket.h>
+#include <Weave/Profiles/ProfileCommon.h>
+#include <Weave/Profiles/weave-tunneling/WeaveTunnelAgent.h>
+#include <Weave/Profiles/weave-tunneling/WeaveTunnelCommon.h>
+#include <InetLayer/InetInterface.h>
+#include <Weave/Support/WeaveFaultInjection.h>
+#include <Weave/Profiles/device-description/DeviceDescription.h>
+#include <Weave/Profiles/vendor/nestlabs/device-description/NestProductIdentifiers.hpp>
+
+#if WEAVE_CONFIG_ENABLE_TUNNELING
+using namespace ::nl::Weave::Profiles::WeaveTunnel;
+
+#if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+using namespace ::nl::Weave::Profiles::DeviceDescription;
+#endif
+
+#define TOOL_NAME "TestTunnelCASEPersistClient"
+
+#define DEFAULT_BG_NODE_ID  (0x18b4300000000001)
+#define DEFAULT_TFE_NODE_ID (0x18b4300000000002)
+#define BUFF_AVAILABLE_SIZE (1024)
+#define PERSISTENT_TUNNEL_SESSION_PATH  "./persistentTunnelCASE-BR"
+
+static bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg);
+static bool HandleNonOptionArgs(const char *progName, int argc, char *argv[]);
+static void HandleLoadPersistedTunnelCASESession(nl::Weave::WeaveConnection *con);
+static void HandleSessionPersistOnTunnelClosure(nl::Weave::WeaveConnection *con);
+static WEAVE_ERROR RestorePersistedTunnelCASESession(nl::Weave::WeaveConnection *con);
+static WEAVE_ERROR SuspendAndPersistTunnelCASESession(nl::Weave::WeaveConnection *con);
+static bool IsPersistentTunnelSessionPresent(uint64_t peerNodeId);
+
+static void
+WeaveTunnelOnStatusNotifyHandlerCB(WeaveTunnelConnectionMgr::TunnelConnNotifyReasons reason,
+                                   WEAVE_ERROR aErr, void *appCtxt);
+static WeaveTunnelAgent gTunAgent;
+
+uint8_t gTunUpCount = 0;
+bool gTestSucceeded = false;
+static bool gTunnelLogging = false;
+static IPAddress gDestAddr = IPAddress::Any;
+static uint16_t gDestPort = 0;
+static uint64_t gDestNodeId = DEFAULT_TFE_NODE_ID;
+
+#if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+static bool gUseServiceDirForTunnel = false;
+static ServiceDirectory::WeaveServiceManager gServiceMgr;
+static uint8_t gServiceDirCache[500];
+#endif
+
+static uint8_t gRole = kClientRole_BorderGateway; //Default Value
+
+enum
+{
+    kToolOpt_ConnectTo          = 1000,
+    kToolOpt_UseServiceDir,
+};
+
+static OptionDef gToolOptionDefs[] =
+{
+    { "connect-to",          kArgumentRequired, kToolOpt_ConnectTo },
+#if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+    { "service-dir",         kNoArgument,       kToolOpt_UseServiceDir },
+#endif // WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+#if WEAVE_CONFIG_TUNNEL_ENABLE_TRANSIT_CALLBACK
+    { "tunnel-log",          kNoArgument,       'l' },
+#endif // WEAVE_CONFIG_TUNNEL_ENABLE_TRANSIT_CALLBACK
+    { }
+};
+
+static const char *const gToolOptionHelp =
+    "  --connect-to <addr>[:<port>][%<interface>]\n"
+    "       Connect to the tunnel service at the supplied address.\n"
+    "\n"
+#if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+    "  --service-dir\n"
+    "       Use service directory to lookup the address of the tunnel server.\n"
+    "\n"
+#endif // WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+#if WEAVE_CONFIG_TUNNEL_ENABLE_TRANSIT_CALLBACK
+    "  -l, --tunnel-log\n"
+    "       Use detailed logging of Tunneled IP packet\n"
+    "\n"
+#endif // WEAVE_CONFIG_TUNNEL_ENABLE_TRANSIT_CALLBACK
+    "";
+
+static OptionSet gToolOptions =
+{
+    HandleOption,
+    gToolOptionDefs,
+    "GENERAL OPTIONS",
+    gToolOptionHelp
+};
+
+static HelpOptions gHelpOptions(
+    TOOL_NAME,
+    "Usage: " TOOL_NAME " <options>\n",
+    WEAVE_VERSION_STRING "\n" WEAVE_TOOL_COPYRIGHT
+);
+
+static OptionSet *gToolOptionSets[] =
+{
+    &gToolOptions,
+    &gNetworkOptions,
+    &gWeaveNodeOptions,
+    &gWRMPOptions,
+    &gCASEOptions,
+    &gDeviceDescOptions,
+    &gServiceDirClientOptions,
+    &gFaultInjectionOptions,
+    &gHelpOptions,
+    NULL
+};
+
+bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg)
+{
+    switch (id)
+    {
+    case kToolOpt_ConnectTo:
+    {
+        const char *host;
+        uint16_t hostLen;
+        if (ParseHostAndPort(arg, strlen(arg), host, hostLen, gDestPort) != WEAVE_NO_ERROR)
+        {
+            PrintArgError("%s: Invalid value specified for --connect-to: %s\n", progName, arg);
+            return false;
+        }
+        char *hostCopy = strndup(host, hostLen);
+        bool isValidAddr = IPAddress::FromString(hostCopy, gDestAddr);
+        free(hostCopy);
+        if (!isValidAddr)
+        {
+            PrintArgError("%s: Invalid value specified for --connect-to (expected IP address): %s\n", progName, arg);
+            return false;
+        }
+        break;
+    }
+#if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+    case kToolOpt_UseServiceDir:
+        gUseServiceDirForTunnel = true;
+        break;
+#endif
+    case 'l':
+        gTunnelLogging = true;
+        break;
+    default:
+        PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+bool HandleNonOptionArgs(const char *progName, int argc, char *argv[])
+{
+    if (argc > 0)
+    {
+        if (argc > 1)
+        {
+            PrintArgError("%s: Unexpected argument: %s\n", progName, argv[1]);
+            return false;
+        }
+
+        if (!ParseNodeId(argv[0], gDestNodeId))
+        {
+            PrintArgError("%s: Invalid value specified for destination node-id: %s\n", progName, argv[0]);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+#if WEAVE_CONFIG_TUNNEL_ENABLE_TRANSIT_CALLBACK
+void TunneledPacketTransitHandler(const PacketBuffer &pkt, TunnelPktDirection pktDir, TunnelType tunnelType, bool &toDrop)
+{
+    DecodedIPPacket decodedPkt;
+    char InOrOut[9];
+    char tunTypeStr[9];
+
+    // Decode the packet; skip the tunnel header and pass the IP packet
+
+    decodedPkt.PacketHeaderDecode(pkt.Start() + TUN_HDR_SIZE_IN_BYTES, pkt.DataLength() - TUN_HDR_SIZE_IN_BYTES);
+
+    strncpy(InOrOut, (pktDir == kDir_Outbound) ? "Outbound" : "Inbound", sizeof(InOrOut));
+    strncpy(tunTypeStr, (tunnelType == kType_TunnelPrimary) ? "primary" : (tunnelType == kType_TunnelBackup) ? "backup" : "shortcut", sizeof(tunTypeStr));
+
+    WeaveLogDetail(WeaveTunnel, "Tun: %s over %s", InOrOut, tunTypeStr);
+
+    // Log the header fields
+
+    LogPacket(decodedPkt, true);
+
+    // Inject a packet drop by the application.
+    WEAVE_FAULT_INJECT(FaultInjection::kFault_TunnelPacketDropByPolicy,
+                       toDrop = true);
+
+}
+#endif // WEAVE_CONFIG_TUNNEL_ENABLE_TRANSIT_CALLBACK
+
+void
+WeaveTunnelOnStatusNotifyHandlerCB(WeaveTunnelConnectionMgr::TunnelConnNotifyReasons reason,
+                                   WEAVE_ERROR aErr, void *appCtxt)
+{
+    WeaveLogDetail(WeaveTunnel, "WeaveTunnelAgent notification reason code is %d", reason);
+
+    if (reason == WeaveTunnelConnectionMgr::kStatus_TunPrimaryUp)
+    {
+        if (gTunUpCount < 1)
+        {
+            gTunUpCount++;
+
+            gTunAgent.StopServiceTunnel(WEAVE_ERROR_TUNNEL_FORCE_ABORT);
+
+            gTunAgent.StartServiceTunnel();
+        }
+        else
+        {
+            gTestSucceeded = true;
+        }
+    }
+    else
+    {
+        gTestSucceeded = false;
+    }
+}
+
+bool PersistedSessionKeyExists(const char *name)
+{
+    return (access(name, F_OK) != -1);
+}
+
+WEAVE_ERROR
+SuspendAndPersistTunnelCASESession(nl::Weave::WeaveConnection *con)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    std::ofstream persistentTunOfStream;
+    nl::Weave::WeaveSessionKey * persistedTunnelSessionKey = NULL;
+    const char * persistentTunnelSessionPath = PERSISTENT_TUNNEL_SESSION_PATH;
+
+    VerifyOrExit(con, err = WEAVE_ERROR_INVALID_ARGUMENT);
+
+    // If exist, this functions has already been called
+    VerifyOrExit(!PersistedSessionKeyExists(persistentTunnelSessionPath),
+                 err = WEAVE_ERROR_SESSION_KEY_SUSPENDED);
+
+    uint8_t buf[BUFF_AVAILABLE_SIZE];
+    uint16_t dataLen;
+
+    err = FabricState.FindSessionKey(con->DefaultKeyId, con->PeerNodeId, false,
+                                      persistedTunnelSessionKey);
+    SuccessOrExit(err);
+
+    // Set the resumptionMsgIdValid flag
+    persistedTunnelSessionKey->SetResumptionMsgIdsValid(true);
+
+    // This call suspends the CASE session and returns a serialized byte stream
+    err = FabricState.SuspendSession(persistedTunnelSessionKey->MsgEncKey.KeyId,
+                                      persistedTunnelSessionKey->NodeId,
+                                      buf,
+                                      BUFF_AVAILABLE_SIZE,
+                                      dataLen);
+    SuccessOrExit(err);
+
+    // If success, set goodbit in the internal state flag
+    // In case of failure, set failbit.
+    persistentTunOfStream.open(persistentTunnelSessionPath, std::ofstream::binary | std::ios::trunc);
+    // If not open and associated with this stream object, directly fail
+    VerifyOrExit(persistentTunOfStream.is_open(),
+                 err = WEAVE_ERROR_PERSISTED_STORAGE_FAIL);
+    // If fail, sets badbit or failbit in the internal state flags
+    persistentTunOfStream.write((char*)buf, dataLen);
+    // In case of failure, set failbit.
+    persistentTunOfStream.close();
+    // Check the stream's state flags
+    VerifyOrExit(persistentTunOfStream.good(),
+                 err = WEAVE_ERROR_PERSISTED_STORAGE_FAIL);
+
+    printf("Suspending and persisting of tunnel CASE session successful\n");
+
+exit:
+    if (err != WEAVE_NO_ERROR)
+    {
+        printf("Suspending and persisting of tunnel CASE Session failed with Weave error: %d\n", err);
+    }
+
+    return err;
+}
+
+WEAVE_ERROR
+RestorePersistedTunnelCASESession(nl::Weave::WeaveConnection *con)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    std::ifstream persistentCASE;
+    const char * persistentTunnelSessionPath = PERSISTENT_TUNNEL_SESSION_PATH;
+
+    if (PersistedSessionKeyExists(persistentTunnelSessionPath))
+    {
+        printf("persistent tunnel CASE session exists\n");
+        uint8_t buf[BUFF_AVAILABLE_SIZE];
+
+        // In case of failure, set failbit.
+        persistentCASE.open(persistentTunnelSessionPath, std::ifstream::binary);
+        VerifyOrExit(persistentCASE.is_open(),
+                     err = WEAVE_ERROR_PERSISTED_STORAGE_FAIL);
+
+        persistentCASE.seekg(0, persistentCASE.end);
+        uint16_t dataLen = persistentCASE.tellg();
+        persistentCASE.seekg(0, persistentCASE.beg);
+
+        VerifyOrExit(dataLen <= BUFF_AVAILABLE_SIZE,
+                     err = WEAVE_ERROR_BUFFER_TOO_SMALL);
+
+        persistentCASE.read((char*) buf, dataLen);
+        // In case of failure, set failbit.
+        persistentCASE.close();
+
+        VerifyOrExit(!persistentCASE.fail(),
+                     err = WEAVE_ERROR_PERSISTED_STORAGE_FAIL);
+
+        // delete persist storage before restore session
+        VerifyOrExit(std::remove(persistentTunnelSessionPath) == 0,
+                     err = WEAVE_ERROR_PERSISTED_STORAGE_FAIL);
+
+        err = FabricState.RestoreSession(buf, dataLen, con);
+        SuccessOrExit(err);
+
+        printf("Restored persistent tunnel CASE session successfully\n");
+    }
+    else
+    {
+        printf("Persistent tunnel CASE Session doesn't exist\n");
+    }
+exit:
+    if (persistentCASE.is_open())
+    {
+        persistentCASE.close();
+    }
+
+    if (err != WEAVE_NO_ERROR)
+    {
+        printf("Restore Persistent CASE Session Failed with weave err: %d\n", err);
+    }
+
+    return err;
+}
+
+void HandleLoadPersistedTunnelCASESession(nl::Weave::WeaveConnection *con)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    err = RestorePersistedTunnelCASESession(con);
+
+    if (err != WEAVE_NO_ERROR)
+    {
+        printf("Restoring Tunnel CASE Session failed with Weave error: %d\n", err);
+    }
+}
+
+void HandleSessionPersistOnTunnelClosure(nl::Weave::WeaveConnection *con)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    err = SuspendAndPersistTunnelCASESession(con);
+
+    if (err != WEAVE_NO_ERROR)
+    {
+        printf("Suspending and persisting Tunnel CASE Session failed with Weave error: %d\n", err);
+    }
+}
+
+bool IsPersistentTunnelSessionPresent(uint64_t peerNodeId)
+{
+    const char * persistentTunnelSessionPath = PERSISTENT_TUNNEL_SESSION_PATH;
+
+    return (access(persistentTunnelSessionPath, F_OK) != -1);
+}
+#endif // WEAVE_CONFIG_ENABLE_TUNNELING
+
+int main(int argc, char *argv[])
+{
+#if WEAVE_CONFIG_ENABLE_TUNNELING
+    WEAVE_ERROR err;
+    gWeaveNodeOptions.LocalNodeId = DEFAULT_BG_NODE_ID;
+    WeaveAuthMode authMode = kWeaveAuthMode_CASE_AnyCert;
+
+    nl::Weave::System::Stats::Snapshot before;
+    nl::Weave::System::Stats::Snapshot after;
+    const bool printStats = true;
+
+    InitToolCommon();
+
+    SetupFaultInjectionContext(argc, argv);
+    UseStdoutLineBuffering();
+    SetSignalHandler(DoneOnHandleSIGUSR1);
+
+    // Configure some alternate defaults for the device descriptor values.
+    gDeviceDescOptions.BaseDeviceDesc.ProductId = nl::Weave::Profiles::Vendor::Nestlabs::DeviceDescription::kNestWeaveProduct_Onyx;
+    strcpy(gDeviceDescOptions.BaseDeviceDesc.SerialNumber, "test-weave-tunnel-persist");
+    strcpy(gDeviceDescOptions.BaseDeviceDesc.SoftwareVersion, "test-weave-tunnel-persist/1.0");
+    gDeviceDescOptions.BaseDeviceDesc.DeviceFeatures = WeaveDeviceDescriptor::kFeature_LinePowered;
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    if (!ParseArgsFromEnvVar(TOOL_NAME, TOOL_OPTIONS_ENV_VAR_NAME, gToolOptionSets, NULL, true) ||
+        !ParseArgs(TOOL_NAME, argc, argv, gToolOptionSets, HandleNonOptionArgs) ||
+        !ResolveWeaveNetworkOptions(TOOL_NAME, gWeaveNodeOptions, gNetworkOptions))
+    {
+        exit(EXIT_FAILURE);
+    }
+
+#if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+    if (gUseServiceDirForTunnel && gDestAddr != IPAddress::Any)
+    {
+        printf("ERROR: Please specify only one of --connect-to or --service-dir\n");
+        exit(EXIT_FAILURE);
+    }
+    if (!gUseServiceDirForTunnel && gDestAddr == IPAddress::Any)
+    {
+        printf("ERROR: Please specify how to find the tunnel server using either --connect-to or --service-dir\n");
+        exit(EXIT_FAILURE);
+    }
+#else
+    if (gDestAddr == IPAddress::Any)
+    {
+        printf("ERROR: Please specify the address of the tunnel server using --connect-to\n");
+        exit(EXIT_FAILURE);
+    }
+#endif
+
+    InitSystemLayer();
+
+    InitNetwork();
+
+    InitWeaveStack(false, true);
+
+    printf("Weave Node Configuration:\n");
+    printf("  Fabric Id: %" PRIX64 "\n", FabricState.FabricId);
+    printf("  Subnet Number: %X\n", FabricState.DefaultSubnet);
+    printf("  Node Id: %" PRIX64 "\n", FabricState.LocalNodeId);
+
+    nl::Weave::Stats::UpdateSnapshot(before);
+
+#if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+    err = gServiceMgr.init(&ExchangeMgr, gServiceDirCache, sizeof(gServiceDirCache),
+            GetRootServiceDirectoryEntry, kWeaveAuthMode_CASE_ServiceEndPoint,
+            NULL, NULL, OverrideServiceConnectArguments);
+    FAIL_ERROR(err, "gServiceMgr.Init failed");
+#endif
+
+#if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
+    if (gUseServiceDirForTunnel)
+    {
+        err = gTunAgent.Init(&Inet, &ExchangeMgr, gDestNodeId,
+                             authMode, &gServiceMgr,
+                             "weave-tun0", gRole);
+    }
+    else
+#endif
+    {
+        err = gTunAgent.Init(&Inet, &ExchangeMgr, gDestNodeId, gDestAddr,
+                             authMode,
+                             "weave-tun0", gRole);
+    }
+
+    FAIL_ERROR(err, "TunnelAgent.Init failed");
+
+    gTunAgent.OnServiceTunStatusNotify = WeaveTunnelOnStatusNotifyHandlerCB;
+
+    if (gDestAddr != IPAddress::Any)
+    {
+        gTunAgent.SetDestination(gDestNodeId, gDestAddr, gDestPort);
+    }
+
+#if WEAVE_CONFIG_TUNNEL_ENABLE_TRANSIT_CALLBACK
+    if (gTunnelLogging)
+    {
+        gTunAgent.OnTunneledPacketTransit = TunneledPacketTransitHandler;
+    }
+    else
+    {
+        gTunAgent.OnTunneledPacketTransit = NULL;
+    }
+#endif // WEAVE_CONFIG_TUNNEL_ENABLE_TRANSIT_CALLBACK
+
+#if WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+    gTunAgent.SetCallbacksForPersistedTunnelConnection(IsPersistentTunnelSessionPresent, HandleLoadPersistedTunnelCASESession);
+#endif // WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+    FabricState.BoundConnectionClosedForSession = HandleSessionPersistOnTunnelClosure;
+
+    // Test case of Starting the Tunnel by negotiating the CASE session
+    err = gTunAgent.StartServiceTunnel();
+    FAIL_ERROR(err, "TunnelAgent.StartServiceTunnel failed");
+
+    while (!Done)
+    {
+        struct timeval sleepTime;
+        sleepTime.tv_sec = 0;
+        sleepTime.tv_usec = 100000;
+
+        ServiceNetwork(sleepTime);
+
+        if (gTestSucceeded)
+        {
+            Done = true;
+        }
+        else
+        {
+            continue;
+        }
+    }
+
+    if (gSigusr1Received) {
+        printf("SIGUSR1 received: proceed to exit gracefully\n");
+    }
+
+    gTunAgent.StopServiceTunnel(WEAVE_ERROR_TUNNEL_FORCE_ABORT);
+    gTunAgent.Shutdown();
+
+    ProcessStats(before, after, printStats, NULL);
+    PrintFaultInjectionCounters();
+
+    ShutdownWeaveStack();
+    ShutdownNetwork();
+    ShutdownSystemLayer();
+
+#endif // WEAVE_CONFIG_ENABLE_TUNNELING
+    return EXIT_SUCCESS;
+}

--- a/src/test-apps/TestWeaveTunnelCASEPersistServer.cpp
+++ b/src/test-apps/TestWeaveTunnelCASEPersistServer.cpp
@@ -1,0 +1,571 @@
+/*
+ *
+ *    Copyright (c) 2018 Google LLC.
+ *    Copyright (c) 2014-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the Weave Mock Tunnel Service.
+ *
+ *      This instantiates a Server that accepts connections from
+ *      a border gateway and may perform routing functions
+ *      between different border gateways or respond to ping6
+ *      over the tunnel.
+ *      Beyond the Tunneling profile, the server also understands
+ *      private test profiles (@see TestWeaveTunnel.h).
+ *      The tunnel client implemented in @see TestWeaveTunnelBR.cpp
+ *      uses the private profiles to test various scenarios.
+ */
+
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include <unistd.h>
+#include <fstream>
+
+#include "ToolCommon.h"
+#include <Weave/Core/WeaveEncoding.h>
+#include <Weave/Core/WeaveSecurityMgr.h>
+#include <Weave/Profiles/security/WeaveSecurity.h>
+#include <Weave/Profiles/service-directory/ServiceDirectory.h>
+#include <Weave/Support/CodeUtils.h>
+#include <Weave/Support/logging/WeaveLogging.h>
+#include <Weave/Profiles/ProfileCommon.h>
+#include <Weave/Profiles/echo/WeaveEcho.h>
+#include <Weave/Core/WeaveTLV.h>
+#include "TestWeaveTunnel.h"
+#include "TestWeaveTunnelServer.h"
+
+#if WEAVE_CONFIG_ENABLE_TUNNELING
+
+#define TOOL_NAME "TestWeaveTunnelCASEPersistServer"
+
+#define TUNNEL_SERVICE_INTF "service-tun0"
+#define TUNNEL_SERVICE_LL_ADDR "fe80::2"
+#define DEFAULT_TFE_NODE_ID (0x18b4300000000002)
+#define BUFF_AVAILABLE_SIZE (1024)
+
+#define PERSISTENT_TUNNEL_SESSION_PATH  "./persistentTunnelCASE-Server"
+
+using nl::StatusReportStr;
+using namespace nl::Weave::Encoding;
+using namespace nl::Weave::Profiles::WeaveTunnel;
+using namespace nl::Weave::TLV;
+
+/**
+ * Handler for a Weave Tunnel control message.
+ */
+static void HandleTunnelControlMsg(ExchangeContext *ec, const IPPacketInfo *pktInfo,
+                                   const WeaveMessageInfo *msgInfo, uint32_t profileId,
+                                   uint8_t msgType, PacketBuffer *payload);
+
+static WEAVE_ERROR TunServerInit (WeaveExchangeManager *exchangeMgr);
+static WEAVE_ERROR TunServerShutdown (void);
+
+static void HandleConnectionClosed(WeaveConnection *con, WEAVE_ERROR conErr);
+
+static void HandleConnectionReceived(WeaveMessageLayer *msgLayer, WeaveConnection *con);
+
+static void HandleSecureSessionEstablished(WeaveSecurityManager *sm, WeaveConnection *con,
+                                           void *reqState, uint16_t sessionKeyId, uint64_t peerNodeId,
+                                           uint8_t encType);
+static void HandleSecureSessionError(WeaveSecurityManager *sm, WeaveConnection *con, void *reqState,
+                                     WEAVE_ERROR localErr, uint64_t peerNodeId, StatusReport *statusReport);
+
+static WEAVE_ERROR SendStatusReportResponse(ExchangeContext *ec, uint32_t profileId, uint32_t tunStatusCode,
+                                            bool isRoutingRestricted = false);
+
+static void HandleSessionPersistOnTunnelClosure(nl::Weave::WeaveConnection *con);
+static WEAVE_ERROR RestorePersistedTunnelCASESession(nl::Weave::WeaveConnection *con);
+static bool IsPersistentTunnelSessionPresent(uint64_t peerNodeId);
+
+static HelpOptions gHelpOptions(
+    TOOL_NAME,
+    "Usage: " TOOL_NAME " [<options...>]\n",
+    WEAVE_VERSION_STRING "\n" WEAVE_TOOL_COPYRIGHT
+);
+
+static OptionSet *gToolOptionSets[] =
+{
+    &gNetworkOptions,
+    &gWeaveNodeOptions,
+    &gCASEOptions,
+    &gDeviceDescOptions,
+    &gFaultInjectionOptions,
+    &gHelpOptions,
+    NULL
+};
+
+void HandleConnectionReceived(WeaveMessageLayer *msgLayer, WeaveConnection *con)
+{
+    char ipAddrStr[64];
+
+    con->PeerAddr.ToString(ipAddrStr, sizeof(ipAddrStr));
+
+    WeaveLogDetail(WeaveTunnel, "Connection received from node (%s)\n", ipAddrStr);
+
+    con->OnConnectionClosed = HandleConnectionClosed;
+
+    if (IsPersistentTunnelSessionPresent(kServiceEndpoint_WeaveTunneling))
+    {
+        RestorePersistedTunnelCASESession(con);
+    }
+}
+
+WEAVE_ERROR TunServerInit (WeaveExchangeManager *exchangeMgr)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    //ExchMgr = exchangeMgr;
+
+    MessageLayer.OnConnectionReceived = HandleConnectionReceived;
+    MessageLayer.OnReceiveError = HandleMessageReceiveError;
+    MessageLayer.OnAcceptError = HandleAcceptConnectionError;
+
+    ExchangeMgr.RegisterUnsolicitedMessageHandler(kWeaveProfile_Tunneling,
+                                                   kMsgType_TunnelOpenV2, HandleTunnelControlMsg,
+                                                   NULL);
+    ExchangeMgr.RegisterUnsolicitedMessageHandler(kWeaveProfile_Tunneling,
+                                                   kMsgType_TunnelRouteUpdate, HandleTunnelControlMsg,
+                                                   NULL);
+    ExchangeMgr.RegisterUnsolicitedMessageHandler(kWeaveProfile_Tunneling,
+                                                   kMsgType_TunnelClose, HandleTunnelControlMsg,
+                                                   NULL);
+    ExchangeMgr.RegisterUnsolicitedMessageHandler(kWeaveProfile_Tunneling,
+                                                   kMsgType_TunnelLiveness, HandleTunnelControlMsg,
+                                                   NULL);
+
+    SecurityMgr.OnSessionEstablished = HandleSecureSessionEstablished;
+    SecurityMgr.OnSessionError = HandleSecureSessionError;
+
+    return err;
+}
+
+WEAVE_ERROR TunServerShutdown (void)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    ExchangeMgr.UnregisterUnsolicitedMessageHandler(kWeaveProfile_Tunneling,
+                                                   kMsgType_TunnelOpenV2);
+    ExchangeMgr.UnregisterUnsolicitedMessageHandler(kWeaveProfile_Tunneling,
+                                                   kMsgType_TunnelRouteUpdate);
+    ExchangeMgr.UnregisterUnsolicitedMessageHandler(kWeaveProfile_Tunneling,
+                                                   kMsgType_TunnelClose);
+    ExchangeMgr.UnregisterUnsolicitedMessageHandler(kWeaveProfile_Tunneling,
+                                                   kMsgType_TunnelLiveness);
+
+    return err;
+}
+
+bool PersistedSessionKeyExists(const char *name)
+{
+    return (access(name, F_OK) != -1);
+}
+
+bool IsPersistentTunnelSessionPresent(uint64_t peerNodeId)
+{
+    const char * persistentTunnelSessionPath = PERSISTENT_TUNNEL_SESSION_PATH;
+
+    return PersistedSessionKeyExists(persistentTunnelSessionPath);
+}
+
+WEAVE_ERROR
+SuspendAndPersistTunnelCASESession(nl::Weave::WeaveConnection *con)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    std::ofstream persistentTunOfStream;
+    nl::Weave::WeaveSessionKey * persistedTunnelSessionKey;
+    const char * persistentTunnelSessionPath = PERSISTENT_TUNNEL_SESSION_PATH;
+
+    VerifyOrExit(con, err = WEAVE_ERROR_INVALID_ARGUMENT);
+
+    // If exist, this functions has already been called
+    VerifyOrExit(!PersistedSessionKeyExists(persistentTunnelSessionPath),
+                 err = WEAVE_ERROR_SESSION_KEY_SUSPENDED);
+
+    uint8_t buf[BUFF_AVAILABLE_SIZE];
+    uint16_t dataLen;
+
+    err = FabricState.FindSessionKey(con->DefaultKeyId, con->PeerNodeId, false,
+                                      persistedTunnelSessionKey);
+    SuccessOrExit(err);
+
+    // Set the resumptionMsgIdValid flag
+    persistedTunnelSessionKey->SetResumptionMsgIdsValid(true);
+
+    // This call suspends the CASE session and returns a serialized byte stream
+    err = FabricState.SuspendSession(persistedTunnelSessionKey->MsgEncKey.KeyId,
+                                      persistedTunnelSessionKey->NodeId,
+                                      buf,
+                                      BUFF_AVAILABLE_SIZE,
+                                      dataLen);
+    SuccessOrExit(err);
+
+    // If success, set goodbit in the internal state flag
+    // In case of failure, set failbit.
+    persistentTunOfStream.open(persistentTunnelSessionPath, std::ofstream::binary | std::ios::trunc);
+    // If not open and associated with this stream object, directly fail
+    VerifyOrExit(persistentTunOfStream.is_open(),
+                 err = WEAVE_ERROR_PERSISTED_STORAGE_FAIL);
+    // If fail, sets badbit or failbit in the internal state flags
+    persistentTunOfStream.write((char*)buf, dataLen);
+    // In case of failure, set failbit.
+    persistentTunOfStream.close();
+    // Check the stream's state flags
+    VerifyOrExit(persistentTunOfStream.good(),
+                 err = WEAVE_ERROR_PERSISTED_STORAGE_FAIL);
+
+    printf("Suspending and persisting of tunnel CASE session successful\n");
+
+exit:
+    if (err != WEAVE_NO_ERROR)
+    {
+        printf("Suspending and persisting of tunnel CASE Session failed with Weave error: %d\n", err);
+    }
+
+    return err;
+}
+
+WEAVE_ERROR
+RestorePersistedTunnelCASESession(nl::Weave::WeaveConnection *con)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    std::ifstream persistentCASE;
+    const char * persistentTunnelSessionPath = PERSISTENT_TUNNEL_SESSION_PATH;
+
+    if (PersistedSessionKeyExists(persistentTunnelSessionPath))
+    {
+        printf("persistent tunnel CASE session exists\n");
+        uint8_t buf[BUFF_AVAILABLE_SIZE];
+
+        // In case of failure, set failbit.
+        persistentCASE.open(persistentTunnelSessionPath, std::ifstream::binary);
+        VerifyOrExit(persistentCASE.is_open(),
+                     err = WEAVE_ERROR_PERSISTED_STORAGE_FAIL);
+
+        persistentCASE.seekg(0, persistentCASE.end);
+        uint16_t dataLen = persistentCASE.tellg();
+        persistentCASE.seekg(0, persistentCASE.beg);
+
+        VerifyOrExit(dataLen <= BUFF_AVAILABLE_SIZE,
+                     err = WEAVE_ERROR_BUFFER_TOO_SMALL);
+
+        persistentCASE.read((char*) buf, dataLen);
+        // In case of failure, set failbit.
+        persistentCASE.close();
+
+        VerifyOrExit(!persistentCASE.fail(),
+                     err = WEAVE_ERROR_PERSISTED_STORAGE_FAIL);
+
+        // delete persist storage before restore session
+        VerifyOrExit(std::remove(persistentTunnelSessionPath) == 0,
+                     err = WEAVE_ERROR_PERSISTED_STORAGE_FAIL);
+
+        con->AuthMode = kWeaveAuthModeCategory_CASE;
+        err = FabricState.RestoreSession(buf, dataLen, con);
+        SuccessOrExit(err);
+
+        printf("Restored persistent tunnel CASE session successfully\n");
+    }
+    else
+    {
+        printf("Persistent tunnel CASE Session doesn't exist\n");
+    }
+exit:
+    if (persistentCASE.is_open())
+    {
+        persistentCASE.close();
+    }
+
+    if (err != WEAVE_NO_ERROR)
+    {
+        printf("Restore Persistent CASE Session Failed with weave err: %d\n", err);
+    }
+
+    return err;
+}
+
+void HandleSessionPersistOnTunnelClosure(nl::Weave::WeaveConnection *con)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    err = SuspendAndPersistTunnelCASESession(con);
+
+    if (err != WEAVE_NO_ERROR)
+    {
+        printf("Suspending and persisting Tunnel CASE Session failed with Weave error: %d\n", err);
+    }
+}
+
+/* Send a tunnel control status report message */
+WEAVE_ERROR SendStatusReportResponse(ExchangeContext *ec, uint32_t profileId, uint32_t tunStatusCode,
+                                     bool isRoutingRestricted)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    StatusReport tunStatusReport;
+    PacketBuffer *msgBuf = NULL;
+    nl::Weave::TLV::TLVWriter tunWriter;
+    nl::Weave::TLV::TLVType containerType;
+    uint8_t *p = NULL;
+
+    msgBuf = PacketBuffer::New();
+    VerifyOrExit(msgBuf != NULL, err = WEAVE_ERROR_NO_MEMORY);
+
+    p = msgBuf->Start();
+
+    // Encode the profile id and status code.
+    LittleEndian::Write32(p, profileId);
+    LittleEndian::Write16(p, tunStatusCode);
+    msgBuf->SetDataLength(4 + 2);
+
+    if (isRoutingRestricted)
+    {
+        // Encode the Tunnel TLVData.
+        tunWriter.Init(msgBuf);
+
+        // Start the anonymous container that wraps the contents.
+        err = tunWriter.StartContainer(AnonymousTag, kTLVType_Structure, containerType);
+        SuccessOrExit(err);
+
+        // Write the boolean tag
+        err = tunWriter.PutBoolean(ProfileTag(kWeaveProfile_Tunneling, kTag_TunnelRoutingRestricted), true);
+        SuccessOrExit(err);
+
+        // End the anonymous container that wraps the contents.
+        err = tunWriter.EndContainer(containerType);
+        SuccessOrExit(err);
+
+        err = tunWriter.Finalize();
+        SuccessOrExit(err);
+    }
+
+    err = ec->SendMessage(kWeaveProfile_Common, Common::kMsgType_StatusReport, msgBuf, 0);
+    msgBuf = NULL;
+
+exit:
+    if (msgBuf != NULL)
+        PacketBuffer::Free(msgBuf);
+
+    return err;
+}
+
+void HandleTunnelControlMsg (ExchangeContext *ec, const IPPacketInfo *pktInfo,
+                             const WeaveMessageInfo *msgInfo, uint32_t profileId,
+                             uint8_t msgType, PacketBuffer *payload)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    WeaveTunnelRoute tunRoute;
+    uint64_t msgFabricId = 0;
+    uint8_t *p = NULL;
+    Role role;
+    TunnelType tunnelType;
+    SrcInterfaceType srcIntfType;
+    LivenessStrategy livenessStrategy;
+    uint16_t livenessTimeout;
+    bool isRoutingRestricted = false;
+
+    if (profileId == kWeaveProfile_Tunneling)
+    {
+        switch (msgType)
+        {
+            case kMsgType_TunnelOpenV2:
+                //Decode the Tunnel Device Role, TunnelType and Source Interface
+                p = payload->Start();
+
+                role = static_cast<Role>(nl::Weave::Encoding::Read8(p));
+
+                tunnelType = static_cast<TunnelType>(nl::Weave::Encoding::Read8(p));
+
+                srcIntfType = static_cast<SrcInterfaceType>(nl::Weave::Encoding::Read8(p));
+
+                livenessStrategy = static_cast<LivenessStrategy>(nl::Weave::Encoding::Read8(p));
+
+                livenessTimeout = nl::Weave::Encoding::LittleEndian::Read16(p);
+
+                WeaveLogDetail(WeaveTunnel, "Received TunOpenV2 message for Tunnel role :%u, type :%u, \
+                                             srcIntf :%u, livenessStrategy :%u, livenessTimeout:%u\n",
+                                            role, tunnelType, srcIntfType, livenessStrategy, livenessTimeout);
+
+                // Set the buffer start pointer for the subsequent parsing of the fabric and routes
+                payload->SetStart(p);
+
+                //Save the routes and connection object
+                memset(&tunRoute, 0, sizeof(tunRoute));
+                err = WeaveTunnelRoute::DecodeFabricTunnelRoutes(&msgFabricId, &tunRoute, payload);
+                SuccessOrExit(err);
+
+                // Send a status report
+
+                err = SendStatusReportResponse(ec, kWeaveProfile_Common, Common::kStatus_Success, isRoutingRestricted);
+                SuccessOrExit(err);
+
+                break;
+            case kMsgType_TunnelRouteUpdate:
+
+                // The reason this is not implemented yet is because for all practical purposes of developmental testing
+                // we have not needed to modify the routes that were already sent with the TunnelOpen messages. However,
+                // this message keeps that possibility open to modify the routes that have been sent before.
+
+                // Send a status report
+
+                err = SendStatusReportResponse(ec, kWeaveProfile_Common, Common::kStatus_Success);
+                SuccessOrExit(err);
+
+                break;
+            case kMsgType_TunnelClose:
+
+                err = WeaveTunnelRoute::DecodeFabricTunnelRoutes(&msgFabricId, &tunRoute, payload);
+                SuccessOrExit(err);
+
+                err = SendStatusReportResponse(ec, kWeaveProfile_Common, Common::kStatus_Success);
+                SuccessOrExit(err);
+
+                break;
+            case kMsgType_TunnelLiveness:
+
+                err = SendStatusReportResponse(ec, kWeaveProfile_Common, Common::kStatus_Success);
+                SuccessOrExit(err);
+
+                break;
+        }
+    }
+
+exit:
+    // Discard the exchange context.
+    ec->Close();
+
+    if (payload != NULL)
+    {
+        PacketBuffer::Free(payload);
+    }
+}
+
+void HandleConnectionClosed (WeaveConnection *con, WEAVE_ERROR conErr)
+{
+    char ipAddrStr[64];
+
+    con->PeerAddr.ToString(ipAddrStr, sizeof(ipAddrStr));
+
+    if (conErr == WEAVE_NO_ERROR)
+    {
+        WeaveLogDetail(WeaveTunnel, "Connection closed with node %" PRIx64 " (%s)\n",
+                       con->PeerNodeId, ipAddrStr);
+    }
+    else
+    {
+        WeaveLogError(WeaveTunnel, "Connection ABORTED with node %" PRIx64 " (%s): %ld\n",
+                      con->PeerNodeId, ipAddrStr, (long)conErr);
+    }
+
+    con->Close();
+}
+
+void HandleSecureSessionEstablished (WeaveSecurityManager *sm, WeaveConnection *con,
+                                     void *reqState, uint16_t sessionKeyId,
+                                     uint64_t peerNodeId, uint8_t encType)
+{
+    char ipAddrStr[64] = "";
+
+    if (con)
+    {
+        con->PeerAddr.ToString(ipAddrStr, sizeof(ipAddrStr));
+        con->DefaultKeyId = sessionKeyId;
+        con->PeerNodeId = peerNodeId;
+    }
+    WeaveLogDetail(WeaveTunnel, "Secure session established with node %" PRIX64 " (%s)\n", peerNodeId, ipAddrStr);
+}
+
+void HandleSecureSessionError (WeaveSecurityManager *sm, WeaveConnection *con,
+                               void *reqState, WEAVE_ERROR localErr,
+                               uint64_t peerNodeId, StatusReport *statusReport)
+{
+    char ipAddrStr[64] = "";
+
+    if (con)
+        con->PeerAddr.ToString(ipAddrStr, sizeof(ipAddrStr));
+
+    if (localErr == WEAVE_ERROR_STATUS_REPORT_RECEIVED && statusReport != NULL)
+        WeaveLogError(WeaveTunnel, "FAILED to establish secure session to node %" PRIX64 " (%s): %s\n", peerNodeId,
+               ipAddrStr, StatusReportStr(statusReport->mProfileId, statusReport->mStatusCode));
+    else
+        WeaveLogDetail(WeaveTunnel, "FAILED to establish secure session to node %" PRIX64 " (%s): %s\n", peerNodeId,
+               ipAddrStr, ErrorStr(localErr));
+}
+
+#endif //WEAVE_CONFIG_ENABLE_TUNNELING
+
+
+int main(int argc, char *argv[])
+{
+
+#if WEAVE_CONFIG_ENABLE_TUNNELING
+    WEAVE_ERROR err;
+    nl::Weave::System::Stats::Snapshot before;
+    nl::Weave::System::Stats::Snapshot after;
+    const bool printStats = true;
+
+    gWeaveNodeOptions.LocalNodeId = DEFAULT_TFE_NODE_ID;
+
+    SetupFaultInjectionContext(argc, argv);
+    SetSignalHandler(DoneOnHandleSIGUSR1);
+
+    if (!ParseArgsFromEnvVar(TOOL_NAME, TOOL_OPTIONS_ENV_VAR_NAME, gToolOptionSets, NULL, true) ||
+        !ParseArgs(TOOL_NAME, argc, argv, gToolOptionSets) ||
+        !ResolveWeaveNetworkOptions(TOOL_NAME, gWeaveNodeOptions, gNetworkOptions))
+    {
+        exit(EXIT_FAILURE);
+    }
+
+    InitSystemLayer();
+    InitNetwork();
+    InitWeaveStack(true, true);
+
+    FabricState.BoundConnectionClosedForSession = HandleSessionPersistOnTunnelClosure;
+
+    WeaveLogDetail(WeaveTunnel, "Weave Node Configuration:\n");
+    WeaveLogDetail(WeaveTunnel, "Fabric Id: %" PRIX64 "\n", FabricState.FabricId);
+    WeaveLogDetail(WeaveTunnel, "Subnet Number: %X\n", FabricState.DefaultSubnet);
+    WeaveLogDetail(WeaveTunnel, "Node Id: %" PRIX64 "\n", FabricState.LocalNodeId);
+
+    nl::Weave::Stats::UpdateSnapshot(before);
+
+    err = TunServerInit(&ExchangeMgr);
+    FAIL_ERROR(err, "TunnelServer.Init failed");
+
+    while (!Done)
+    {
+        struct timeval sleepTime;
+        sleepTime.tv_sec = 0;
+        sleepTime.tv_usec = 100000;
+
+        ServiceNetwork(sleepTime);
+
+    }
+
+    TunServerShutdown();
+
+    ProcessStats(before, after, printStats, NULL);
+    PrintFaultInjectionCounters();
+
+    ShutdownWeaveStack();
+    ShutdownNetwork();
+    ShutdownSystemLayer();
+
+#endif //WEAVE_CONFIG_ENABLE_TUNNELING
+    return 0;
+}


### PR DESCRIPTION
Changes to support persistence of CASE session for the Tunnel.

During connection establishment by the Tunnel Agent, if a persisted
session key exists, the TunnelAgent first establishes an unsecured 
WeaveConnection and then calls back into the application to load the
session key for the created Weave connection object.
When the connection goes down, and before the FabricState removes the
SessionKey, the application is called back to suspend the session into
a serialized form to be persisted.
At time of suspension, resumption message Ids(for both the next message
id to send, as well as the last received message id from peer) are
calculated using a fixed offset and included within the session key.
When the session resumes, it would start off communication using the
resumption message ids.

Added Test Client and Server for testing persistence of Tunnel CASE
session.