### PR TITLE
Surface a getter function for retrieving the WeaveConnection object for the Tunnel connection

### DIFF
--- a/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.cpp
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.cpp
@@ -365,6 +365,18 @@ WeaveTunnelAgent::AgentState WeaveTunnelAgent::GetWeaveTunnelAgentState(void)
     return mTunAgentState;
 }
 
+/**
+ * Get a pointer to the Weave Tunnel Connection.
+ *
+ * @return WeaveConnection pointer for an established Weave Tunnel. If tunnel is
+ *         not in the established state, a null pointer is returned.
+ *
+ */
+nl::Weave::WeaveConnection * WeaveTunnelAgent::GetPrimaryTunnelConnection(void) const
+{
+    return mPrimaryTunConnMgr.GetTunnelConnection();
+}
+
 #if WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
 void WeaveTunnelAgent::SetCallbacksForPersistedTunnelConnection(WeaveTunnelConnectionMgr::PersistedSecureSessionExistsFunct aIsPersistedTunnelSessionPresent,
                                                                 WeaveTunnelConnectionMgr::LoadPersistedSessionFunct aLoadPersistedTunnelSession)

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.h
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.h
@@ -216,6 +216,12 @@ public:
  */
     AgentState GetWeaveTunnelAgentState(void);
 
+/**
+ * Get the Primary Tunnel Connection
+ *
+ */
+    nl::Weave::WeaveConnection * GetPrimaryTunnelConnection(void) const;
+
 #if WEAVE_CONFIG_TUNNEL_TCP_USER_TIMEOUT_SUPPORTED
 /**
  *  Configure the TCP user timeout option on the primary tunnel connection.

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.cpp
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.cpp
@@ -650,6 +650,27 @@ void WeaveTunnelConnectionMgr::ServiceTunnelClose(WEAVE_ERROR err)
 }
 
 /**
+ * Get a pointer to the Weave Tunnel Connection object for this
+ * Tunnel Connection Manager.
+ *
+ * @return pointer to the WeaveConnection object for the Tunnel. If Tunnel is
+ *         not in an established state, a null pointer is returned
+ *
+ */
+
+nl::Weave::WeaveConnection * WeaveTunnelConnectionMgr::GetTunnelConnection(void) const
+{
+    if (mConnectionState == kState_ConnectionEstablished || mConnectionState == kState_TunnelOpen)
+    {
+        return mServiceCon;
+    }
+    else
+    {
+        return NULL;
+    }
+}
+
+/**
  * Handler to receive tunneled IPv6 packets from the Service TCP connection and forward to the Tunnel
  * EndPoint interface after decapsulating the raw IPv6 packet from inside the tunnel header.
  *

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.h
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.h
@@ -241,6 +241,11 @@ class NL_DLL_EXPORT WeaveTunnelConnectionMgr
  */
     void StopAndReconnectTunnelConn(ReconnectParam & reconnParam);
 
+/**
+ * Get a pointer to the Weave Tunnel Connection object for this
+ * Tunnel Connection Manager.
+ */
+    nl::Weave::WeaveConnection * GetTunnelConnection(void) const;
   private:
 
     WEAVE_ERROR StartServiceTunnelConn(uint64_t destNodeId, IPAddress destIPAddr,


### PR DESCRIPTION
Needed for getting information about PeerAddress, PeerPort of TunnelConnection as well as suspension of TunnelConnection CASE session persistence during shutdown.