### PR TITLE
Add nl::Logevent debug logs

### DIFF
--- a/src/lib/profiles/data-management/Current/LoggingManagement.cpp
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.cpp
@@ -1239,7 +1239,7 @@ exit:
             GetImportanceBuffer(inSchema.mImportance)->AddEventUTC(opts.timestamp.utcTimestamp);
 
 #if WEAVE_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
-            WeaveLogDetail(
+            WeaveLogProgress(
                 EventLogging, "LogEvent event id: %u importance: %u profile id: 0x%x structure id: 0x%x utc timestamp: 0x%" PRIx64,
                 event_id, inSchema.mImportance, inSchema.mProfileId, inSchema.mStructureType, opts.timestamp.utcTimestamp);
 #endif // WEAVE_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
@@ -1250,7 +1250,7 @@ exit:
             GetImportanceBuffer(inSchema.mImportance)->AddEvent(opts.timestamp.systemTimestamp);
 
 #if WEAVE_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
-            WeaveLogDetail(
+            WeaveLogProgress(
                 EventLogging, "LogEvent event id: %u importance: %u profile id: 0x%x structure id: 0x%x sys timestamp: 0x%" PRIx32,
                 event_id, inSchema.mImportance, inSchema.mProfileId, inSchema.mStructureType, opts.timestamp.systemTimestamp);
 #endif // WEAVE_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
@@ -1840,12 +1840,18 @@ WEAVE_ERROR LoggingManagement::ScheduleFlushIfNeeded(bool inRequestFlush)
         if ((mExchangeMgr != NULL) && (mExchangeMgr->MessageLayer != NULL) && (mExchangeMgr->MessageLayer->SystemLayer != NULL))
         {
             mExchangeMgr->MessageLayer->SystemLayer->ScheduleWork(LoggingFlushHandler, this);
+            WeaveLogProgress(EventLogging, "Scheduled flush for urgent event.");
         }
         else
         {
             err              = WEAVE_ERROR_INCORRECT_STATE;
             mUploadRequested = false;
+            WeaveLogError(EventLogging, "Schedule flush failed with error: %s", ErrorStr(err));
         }
+    }
+    else if (inRequestFlush)
+    {
+        WeaveLogProgress(EventLogging, "Flush already scheduled, no need to schedule an additional flush.");
     }
 
     return err;


### PR DESCRIPTION
There are several reports that urgent events such are doorbell events failed to make to cloud. It's possible that urgent events failed to schedule flush and later get dropped silently due to event buffer overflow. Add more logs to indicate the status of scheudling flush for urgent events to see if there's any correaltion that need to be wary about.
In addition, NCCM people reported that they only called nl::Logevent once but multiple events are logged at the same timestamp. Currently WeaveLogDetail is disabled on user build and we don't have any logs regarding the event logging on weave side. Increasing the log level of 'logevent' to WeaveLogProgess. This should be ok as it's still guarded by WEAVE_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS.

This change will
1) Add debug logs for scheduling flush for urgent events.
2) Print error logs if scheduling flush failed with error (currently this error doesn't get printed or surfaced up).
3) Increase level of 'logevent' to WeaveLogProgess, guarded by WEAVE_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS