### PR TITLE
Fix Weave TCPEndPoint crash in some lwIP cases

### DIFF
--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -621,9 +621,16 @@ private:
     void StopConnectTimer(void);
 
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
-    Weave::System::PacketBuffer *mUnsentQueue;
-    uint16_t mUnsentOffset;
+    struct BufferOffset {
+        const Weave::System::PacketBuffer *buffer;
+        uint32_t offset;
+    };
 
+    uint32_t mUnackedLength;                            // Amount sent but awaiting ACK. Used as a form of reference count
+                                                        // to hang-on to backing packet buffers until they are no longer needed.
+
+    uint32_t RemainingToSend();
+    BufferOffset FindStartOfUnsent();
     INET_ERROR GetPCB(IPAddressType addrType);
     void HandleDataSent(uint16_t len);
     void HandleDataReceived(Weave::System::PacketBuffer *buf);


### PR DESCRIPTION
* Weave, when using an lwIP networking interface, employs
  the raw lwIP callback-based scheme to handle TCP sends.
  In order to avoid multiple copies of packet buffers on
  small devices, the TCP sends are done in-place over the
  incoming packet buffers. Packet buffers must be retained
  in full until acknowledgement has been received by lwIP.
* The existing logic had a corner case where if there was
  more data queued than the local TCP send window, the
  accounting of buffers and lengths to retain the un-acked
  buffers could get out of balance, leading to an eventual
  crash. This was root caused to an invalid assumption that
  the packet buffer chain did not need traversal for offset
  readjustment (which is true in most cases, only by
  coincidence).
* This change removes separate accounting of the unsent
  data position and replaces it with simple counting of
  sent-but-not-acked data and a skip-loop at the start
  of DriveSending().