### PR TITLE
Add more logs to help debug event missing issue

### DIFF
--- a/src/lib/profiles/data-management/Current/LoggingManagement.cpp
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.cpp
@@ -1094,6 +1094,10 @@ event_id_t LoggingManagement::LogEvent(const EventSchema & inSchema, EventWriter
 
 exit:
     Platform::CriticalSectionExit();
+    if (event_id == 0)
+    {
+        WeaveLogProgress(EventLogging, "Failed to log event with ProfileId: %d, return event id 0", inSchema.mProfileId);
+    }
     return event_id;
 }
 
@@ -2117,7 +2121,9 @@ void CircularEventBuffer::AddEventUTC(utc_timestamp_t inEventTimestamp)
 
 void CircularEventBuffer::RemoveEvent(size_t aNumEvents)
 {
+    event_id_t currentFirstEventID = mFirstEventID;
     mFirstEventID += aNumEvents;
+    WeaveLogDetail(EventLogging, "Dropping events | Move first event id from %u to %u", currentFirstEventID, mFirstEventID);
 }
 
 /**

--- a/src/lib/profiles/data-management/Current/NotificationEngine.cpp
+++ b/src/lib/profiles/data-management/Current/NotificationEngine.cpp
@@ -1226,6 +1226,8 @@ WEAVE_ERROR NotificationEngine::BuildSingleNotifyRequestEventList(SubscriptionHa
             event_id_t tmp_id = logger.GetFirstEventID(static_cast<ImportanceType>(i + 1));
             if (tmp_id > initialEvents[i])
             {
+                WeaveLogProgress(DataManagement, "BuildSingleNotifyRequestEventList | Missing event_id range: { %u, %u };",
+                                 initialEvents[i], tmp_id - 1);
                 initialEvents[i] = tmp_id;
             }
         }
@@ -1342,6 +1344,8 @@ exit:
         if (aSubHandler->mSelfVendedEvents[i] > initialEvents[i])
         {
             event_count += aSubHandler->mSelfVendedEvents[i] - initialEvents[i];
+            WeaveLogProgress(DataManagement, "Fetched events [importance: %d, event_id: %u - %u]",
+                             i, initialEvents[i], aSubHandler->mSelfVendedEvents[i] - 1);
         }
     }
 


### PR DESCRIPTION
In this change we 
1) specify the event id range of dropped events, 
2) Log profileId and print out the message when logEvent failed and returned 0.
3) Log range of event_id fetched and being flushed