### PR TITLE
Add a path fixup for DeviceManager headers

### DIFF
--- a/src/test-apps/Makefile.am
+++ b/src/test-apps/Makefile.am
@@ -1654,6 +1654,7 @@ $(WEAVE_LIBS_COVERAGE_INFO): $(WEAVE_COVERAGE_INFO) | $(WEAVE_LIBS_COVERAGE_BUND
 	    -e 's,include/Weave/Core/,lib/core/,g' \
 	    -e 's,include/Weave/Profiles/,lib/profiles/,g' \
 	    -e 's,include/Weave/Support/,lib/support/,g' \
+	    -e 's,include/Weave/DeviceManager/,device-manager/,g' \
 	    -e '/\/nlio/,/end_of_record/'d \
 	    < $(@) \
 	    > $(@).clean


### PR DESCRIPTION
Coverage targets that included test_weave_pairing_01.py were failing on some builds, this change fixes the header location.