### PR TITLE
Persistent delivered event id

### DIFF
--- a/src/lib/core/WeaveConfig.h
+++ b/src/lib/core/WeaveConfig.h
@@ -1922,6 +1922,26 @@
 #endif // WEAVE_CONFIG_PERSIST_SERVICE_DIRECTORY
 
 /**
+ *  @def WEAVE_CONFIG_PERSIST_DELIVERED_EVENTS
+ *
+ *  @brief
+ *    If set to (1), use of the persistent delivered event id
+ *    implementation is enabled. Default value is (0) or disabled.
+ *
+ *  @note
+ *    Enabling this profile allows applications using Weave to
+ *    persist the ids of events that have been offloaded to the
+ *    subscriber across device reboots. It is relevant for
+ *    applications that interacts with a service which subscribes
+ *    to all events but cannot provide updated event ids it already
+ *    received during subscription.
+ *
+ */
+#ifndef WEAVE_CONFIG_PERSIST_DELIVERED_EVENTS
+#define WEAVE_CONFIG_PERSIST_DELIVERED_EVENTS               0
+#endif // WEAVE_CONFIG_PERSIST_DELIVERED_EVENTS
+
+/**
  *  @def WEAVE_CONFIG_SERVICE_DIR_CONNECT_TIMEOUT_MSECS
  *
  *  @brief

--- a/src/lib/profiles/data-management/Current/NotificationEngine.cpp
+++ b/src/lib/profiles/data-management/Current/NotificationEngine.cpp
@@ -1152,6 +1152,9 @@ void NotificationEngine::OnNotifyConfirm(SubscriptionHandler * aSubHandler, bool
             size_t i                  = static_cast<size_t>(iterator - kImportanceType_First);
             ImportanceType importance = (ImportanceType) iterator;
             logger.NotifyEventsDelivered(importance, aSubHandler->mSelfVendedEvents[i] - 1, aSubHandler->GetPeerNodeId());
+#if WEAVE_CONFIG_PERSIST_DELIVERED_EVENTS
+            aSubHandler->UpdateDeliveredEvents(importance);
+#endif // WEAVE_CONFIG_PERSIST_DELIVERED_EVENTS
         }
     }
 

--- a/src/lib/profiles/data-management/Current/SubscriptionEngine.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionEngine.cpp
@@ -55,6 +55,21 @@ void SubscriptionEngine::SetEventCallback(void * const aAppState, const EventCal
     mEventCallback = aEventCallback;
 }
 
+void SubscriptionEngine::IterateSubscriptionHandler(SubscriptionHandlerIteratorCallback aCallback, const uint64_t aPeerNodeId)
+{
+    for (size_t i = 0; i < kMaxNumSubscriptionHandlers; ++i)
+    {
+        if ((mHandlers[i].mCurrentState >= SubscriptionHandler::kState_SubscriptionInfoValid_Begin) &&
+            (mHandlers[i].mCurrentState <= SubscriptionHandler::kState_SubscriptionInfoValid_End))
+        {
+            if (aPeerNodeId == mHandlers[i].mBinding->GetPeerNodeId())
+            {
+                aCallback(&mHandlers[i], aPeerNodeId);
+            }
+        }
+    }
+}
+
 void SubscriptionEngine::DefaultEventHandler(EventID aEvent, const InEventParam & aInParam, OutEventParam & aOutParam)
 {
     IgnoreUnusedVariable(aInParam);

--- a/src/lib/profiles/data-management/Current/SubscriptionEngine.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionEngine.h
@@ -225,12 +225,28 @@ public:
     typedef void (*EventCallback)(void * const aAppState, EventID aEvent, const InEventParam & aInParam, OutEventParam & aOutParam);
 
     /**
+     * @brief Iterate through the valid subscription handlers for peer specific call backs
+     *
+     * @param[in]  aPeerNodeId             A weave node id of a peer
+     * @param[out] aSubscriptionHandler    A pointer to a valid subscription handler with a specific peer node id
+     */
+    typedef void (*SubscriptionHandlerIteratorCallback)(void * aSubscriptionHandler, const uint64_t aPeerNodeId);
+
+    /**
      * @brief Set the event back function and pointer to associated state object for SubscriptionEngine specific call backs
      *
      * @param[in]  aAppState  		A pointer to application layer supplied state object
      * @param[in]  aEventCallback  	A function pointer for event call back
      */
     void SetEventCallback(void * const aAppState, const EventCallback aEventCallback);
+
+    /**
+     * @brief Iterate through the valid subscription handlers for peer specific call backs
+     *
+     * @param[in]  aCallback  		A function pointer for event call back
+     * @param[in]  aPeerNodeId  	An application layer supplied peer node id
+     */
+    void IterateSubscriptionHandler(SubscriptionHandlerIteratorCallback aCallback, const uint64_t aPeerNodeId);
 
     /**
      * @brief This is the default event handler to be called by application layer for any ignored or unrecognized event


### PR DESCRIPTION
Allow applications to persist the delivered event ids that have been successfully offloaded to the subscriber across power cycles. 
For a service that subscribes to all events but cannot send up-to-date "delivered event ids" during subscription, enabling this feature can avoid sending duplicated events to service.