### PR TITLE
Subscription state persistence

### DIFF
--- a/src/lib/core/WeaveConfig.h
+++ b/src/lib/core/WeaveConfig.h
@@ -1881,6 +1881,22 @@
 #define WEAVE_CONFIG_ENABLE_CONDITION_LOGGING 0
 #endif // WEAVE_CONFIG_ENABLE_CONDITION_LOGGING
 
+/**
+ *  @def WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+ *
+ *  @brief
+ *    If set to (1), use of the persistent subscription state
+ *    implementation is enabled. Default value is (0) or disabled.
+ *
+ *  @note
+ *    Enabling this profile allows applications using Weave to
+ *    persist the mutual subscription states between device and service
+ *    across device reboots.
+ *
+ */
+#ifndef WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+#define WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE               0
+#endif // WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
 
 /**
  *  @def WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY

--- a/src/lib/profiles/data-management/Current/NotificationEngine.cpp
+++ b/src/lib/profiles/data-management/Current/NotificationEngine.cpp
@@ -1152,6 +1152,9 @@ void NotificationEngine::OnNotifyConfirm(SubscriptionHandler * aSubHandler, bool
             size_t i                  = static_cast<size_t>(iterator - kImportanceType_First);
             ImportanceType importance = (ImportanceType) iterator;
             logger.NotifyEventsDelivered(importance, aSubHandler->mSelfVendedEvents[i] - 1, aSubHandler->GetPeerNodeId());
+#if WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+            aSubHandler->UpdateDeliveredEvents(importance);
+#endif // WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
         }
     }
 

--- a/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
@@ -163,6 +163,153 @@ exit:
     return err;
 }
 
+#if WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+// load subscription id and liveness timeout
+// AddRef to Binding
+// store pointers to binding and delegate
+// move to kState_SubscriptionEstablished_Idle
+WEAVE_ERROR SubscriptionClient::LoadFromPersistedState(Binding * const apBinding, void * const apAppState, EventCallback const aEventCallback,
+                                                       const TraitCatalogBase<TraitDataSink> * const apCatalog,
+                                                       const uint32_t aInactivityTimeoutDuringSubscribingMsec, IWeaveWDMMutex * aUpdateMutex,
+                                                       TLVReader & reader)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+    WeaveLogIfFalse(0 == mRefCount);
+
+    // AddRef for the duration of this method
+    _AddRef();
+
+    // add reference to the binding
+    apBinding->AddRef();
+
+    // set subscription id and liveness timeout
+    err = LoadSubscriptionState(reader);
+    SuccessOrExit(err);
+
+    // make a copy of the pointers
+    mBinding                                = apBinding;
+    mAppState                               = apAppState;
+    mEventCallback                          = aEventCallback;
+
+    // Set the protocol callback on the binding object so that the SubscriptionClient gets
+    // notified of changes in the binding's state.
+    mBinding->SetProtocolLayerCallback(BindingEventCallback, this);
+
+    err = _PrepareBinding();
+    SuccessOrExit(err);
+
+    if (NULL == apCatalog)
+    {
+        mDataSinkCatalog = NULL;
+    }
+    else
+    {
+        mDataSinkCatalog = const_cast <TraitCatalogBase<TraitDataSink>*>(apCatalog);
+    }
+
+    mInactivityTimeoutDuringSubscribingMsec = aInactivityTimeoutDuringSubscribingMsec;
+
+
+#if WEAVE_CONFIG_ENABLE_WDM_UPDATE
+    mUpdateMutex                            = aUpdateMutex;
+    mUpdateInFlight                         = false;
+    mMaxUpdateSize                          = 0;
+
+    err = mUpdateClient.Init(mBinding, this, UpdateEventCallback);
+    SuccessOrExit(err);
+
+    ConfigureUpdatableSinks();
+
+#endif // WEAVE_CONFIG_ENABLE_WDM_UPDATE
+
+    // Hold this instance until we clear the protocol state machine
+    _AddRef();
+    MoveToState(kState_SubscriptionEstablished_Idle);
+
+    WeaveLogDetail(DataManagement, "Client[%u] [%5.5s] %s Ref(%d)", SubscriptionEngine::GetInstance()->GetClientId(this),
+                   GetStateStr(), __func__, mRefCount);
+
+    {
+        InEventParam inParam;
+        OutEventParam outParam;
+
+        // Emit an OnSubscriptionActivity event to the application.
+        inParam.mSubscriptionActivity.mClient = this;
+        mEventCallback(mAppState, kEvent_OnSubscriptionActivity, inParam, outParam);
+
+        // Emit an OnSubscriptionEstablished event to the application.
+        // Note that it's allowed to cancel or even abandon this subscription right inside this callback.
+        inParam.mSubscriptionEstablished.mSubscriptionId = mSubscriptionId;
+        inParam.mSubscriptionEstablished.mClient         = this;
+        mEventCallback(mAppState, kEvent_OnSubscriptionEstablished, inParam, outParam);
+    }
+
+exit:
+    _Release();
+    return err;
+}
+
+WEAVE_ERROR SubscriptionClient::SerializeSubscriptionState(TLVWriter & writer)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    TLV::TLVType container;
+
+    err = writer.StartContainer(TLV::AnonymousTag, TLV::kTLVType_Structure, container);
+    SuccessOrExit(err);
+
+    err = writer.Put(TLV::ContextTag(kTag_PersistSubscriptionClient_SubscriptionId), mSubscriptionId);
+    SuccessOrExit(err);
+    err = writer.Put(TLV::ContextTag(kTag_PersistSubscriptionClient_LivenessTimeoutMsec), mLivenessTimeoutMsec);
+    SuccessOrExit(err);
+
+    err = writer.EndContainer(container);
+    SuccessOrExit(err);
+
+exit:
+
+    if (err != WEAVE_NO_ERROR)
+    {
+        WeaveLogError(DataManagement, "Serialize persistent subscription data for subscription client error: %d", err);
+    }
+    return err;
+}
+
+WEAVE_ERROR SubscriptionClient::LoadSubscriptionState(TLVReader & reader)
+{
+    WEAVE_ERROR err = WEAVE_NO_ERROR;
+
+    TLV::TLVType container;
+
+    err = reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag);
+    SuccessOrExit(err);
+    err = reader.EnterContainer(container);
+    SuccessOrExit(err);
+
+    err = reader.Next(TLV::kTLVType_UnsignedInteger, TLV::ContextTag(kTag_PersistSubscriptionClient_SubscriptionId));
+    SuccessOrExit(err);
+    err = reader.Get(mSubscriptionId);
+    SuccessOrExit(err);
+
+    err = reader.Next(TLV::kTLVType_UnsignedInteger, TLV::ContextTag(kTag_PersistSubscriptionClient_LivenessTimeoutMsec));
+    SuccessOrExit(err);
+    err = reader.Get(mLivenessTimeoutMsec);
+    SuccessOrExit(err);
+
+    err = reader.ExitContainer(container);
+    SuccessOrExit(err);
+
+
+exit:
+
+    if (err != WEAVE_NO_ERROR)
+    {
+        WeaveLogError(DataManagement, "Load persistent subscription data for subscription client error: %d", err);
+    }
+    return err;
+}
+#endif // WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+
 #if WEAVE_DETAIL_LOGGING
 const char * SubscriptionClient::GetStateStr() const
 {

--- a/src/lib/profiles/data-management/Current/SubscriptionClient.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.h
@@ -448,6 +448,18 @@ private:
         kConfig_CounterSubscriber /**< Start a "counter subscription" */
     };
 
+#if WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+    /**
+     * @brief
+     *  Tags for the persistent subscription data
+     */
+    enum
+    {
+        kTag_PersistSubscriptionClient_SubscriptionId          = 1,
+        kTag_PersistSubscriptionClient_LivenessTimeoutMsec     = 2
+    };
+#endif // WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+
     bool IsInitiator() { return mConfig == kConfig_Initiator; }
     bool IsCounterSubscriber() { return mConfig == kConfig_CounterSubscriber; }
     bool ShouldSubscribe() { return mConfig > kConfig_Down; }
@@ -492,6 +504,20 @@ private:
     WEAVE_ERROR Init(Binding * const apBinding, void * const apAppState, EventCallback const aEventCallback,
                      const TraitCatalogBase<TraitDataSink> * const apCatalog,
                      const uint32_t aInactivityTimeoutDuringSubscribingMsec, IWeaveWDMMutex * aUpdateMutex);
+
+#if WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+    // load subscription id and liveness timeout
+    // AddRef to Binding
+    // store pointers to binding and delegate
+    // move to kState_SubscriptionEstablished_Idle
+    WEAVE_ERROR LoadFromPersistedState(Binding * const apBinding, void * const apAppState, EventCallback const aEventCallback,
+                                       const TraitCatalogBase<TraitDataSink> * const apCatalog,
+                                       const uint32_t aInactivityTimeoutDuringSubscribingMsec, IWeaveWDMMutex * aUpdateMutex,
+                                       TLVReader & reader);
+
+    WEAVE_ERROR SerializeSubscriptionState(TLVWriter & writer);
+    WEAVE_ERROR LoadSubscriptionState(TLVReader & reader);
+#endif // WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
 
     void _InitiateSubscription(void);
     WEAVE_ERROR SendSubscribeRequest(void);

--- a/src/lib/profiles/data-management/Current/SubscriptionEngine.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionEngine.h
@@ -300,7 +300,33 @@ public:
                           const TraitCatalogBase<TraitDataSink> * const apCatalog,
                           const uint32_t aInactivityTimeoutDuringSubscribingMsec, IWeaveWDMMutex * aUpdateMutex);
 
+#if WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+    /**
+     * @brief This is the default event handler to be called by application layer for any ignored or unrecognized event
+     *
+     * @param[in]  appClient        A pointer to pointer for the new subscription client object
+     * @param[in]  apBinding        A pointer to Binding to be used for this subscription client
+     * @param[in]  apAppState       A pointer to application layer supplied state object
+     * @param[in]  aEventCallback   A function pointer for event call back
+     * @param[in]  apCatalog        A pointer to data sink catalog object
+     * @param[in]  aTimeoutMsecBeforeSubscribeResponse    Max number of milliseconds before subscribe
+     *                                                    response must be received after subscribe request is sent
+     * @param[in]  reader           A reference to TLVReader to load subscription client
+     */
+    WEAVE_ERROR NewClientFromPersistedState(SubscriptionClient ** const appClient, Binding * const apBinding, void * const apAppState,
+                                            SubscriptionClient::EventCallback const aEventCallback,
+                                            const TraitCatalogBase<TraitDataSink> * const apCatalog,
+                                            const uint32_t aInactivityTimeoutDuringSubscribingMsec, TLVReader & reader);
+    WEAVE_ERROR SaveClient(uint64_t aPeerNodeID, TLVWriter &aWriter);
+#endif // WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+
     WEAVE_ERROR NewSubscriptionHandler(SubscriptionHandler ** const subHandler);
+
+#if WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+    WEAVE_ERROR NewSubscriptionHandlerFromPersistedState(Binding * const apBinding, void * const apAppState,
+                                                         SubscriptionHandler::EventCallback const aEventCallback, TLVReader & reader);
+    WEAVE_ERROR SaveSubscriptionHandler(uint64_t aPeerNodeID, TLVWriter &aWriter);
+#endif // WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
 
     uint16_t GetClientId(const SubscriptionClient * const apClient) const;
 
@@ -536,6 +562,11 @@ private:
 #endif // WDM_PUBLISHER_ENABLE_CUSTOM_COMMANDS
 
 #endif // WDM_ENABLE_SUBSCRIPTION_PUBLISHER
+
+#if WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
+    SubscriptionClient * FindEstablishedIdleClient(const uint64_t aPeerNodeId);
+    SubscriptionHandler * FindEstablishedIdleHandler(const uint64_t aPeerNodeId);
+#endif // WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
 };
 
 }; // namespace WeaveMakeManagedNamespaceIdentifier(DataManagement, kWeaveManagedNamespaceDesignation_Current)


### PR DESCRIPTION
This commit enables a set of APIs to persist and restore the
subscription state.  Such functionality may be used when the
Weave process needs to shutdown and restart in an orderly fashion
while preserving the illusion that the subscription remains
unchanged.  In order to successfully accomplish this task, the
commit introduces the functionality to:

* serialize SubscriptionClient and SubscriptionHandler data.  

* load SubscriptionClient and SubscriptionHandler from
  serialized data and integrate it into the subscription engine
  mechanisms.

* find established subscription handlers and clients from the SubscriptionEngine