### PR TITLE
Improve woble connection close

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -419,17 +419,8 @@ void BLEEndPoint::FinalizeClose(uint8_t oldState, uint8_t flags, BLE_ERROR err)
             }
             else if (mConnObj != BLE_CONNECTION_UNINITIALIZED)
             {
-                // Unsubscribe request was sent successfully, and a confirmation wasn't spontaneously generated or
-                // received in the downcall to UnsubscribeCharacteristic, so set timer for the unsubscribe to complete.
-                err = StartUnsubscribeTimer();
-
-                if (err != BLE_NO_ERROR)
-                {
-                    Free();
-                }
-
-                // Mark unsubscribe GATT operation in progress.
-                SetFlag(mConnStateFlags, kConnState_GattOperationInFlight, true);
+                //Force to free endpoint's BLE connection
+                Free();
             }
         }
         else // mRole == kBleRole_Peripheral, OR GetFlag(mTimerStateFlags, kConnState_DidBeginSubscribe) == false...

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -407,6 +407,7 @@ void BLEEndPoint::FinalizeClose(uint8_t oldState, uint8_t flags, BLE_ERROR err)
             StopAckReceivedTimer();
             StopSendAckTimer();
 
+            WeaveLogProgress(Ble, "BLEEndPoint::FinalizeClose will call UnsubscribeCharacteristic");
             // Indicate close of WeaveConnection to peripheral via GATT unsubscribe. Keep end point allocated until
             // unsubscribe completes or times out, so platform doesn't close underlying BLE connection before
             // we're really sure the unsubscribe request has been sent.

--- a/src/device-manager/WeaveDeviceManager.h
+++ b/src/device-manager/WeaveDeviceManager.h
@@ -136,11 +136,11 @@ public:
     WEAVE_ERROR PassiveRendezvousDevice(const uint8_t *accessToken, uint32_t accessTokenLen, void *appReqState, CompleteFunct onComplete, ErrorFunct onError);
 #if CONFIG_NETWORK_LAYER_BLE
     WEAVE_ERROR ConnectBle(BLE_CONNECTION_OBJECT connObj,
-        void *appReqState, CompleteFunct onComplete, ErrorFunct onError, bool autoClose = true);
+        void *appReqState, CompleteFunct onComplete, ErrorFunct onError, bool autoClose = false);
     WEAVE_ERROR ConnectBle(BLE_CONNECTION_OBJECT connObj, const char *pairingCode,
-        void *appReqState, CompleteFunct onComplete, ErrorFunct onError, bool autoClose = true);
+        void *appReqState, CompleteFunct onComplete, ErrorFunct onError, bool autoClose = false);
     WEAVE_ERROR ConnectBle(BLE_CONNECTION_OBJECT connObj, const uint8_t *accessToken, uint32_t accessTokenLen,
-        void *appReqState, CompleteFunct onComplete, ErrorFunct onError, bool autoClose = true);
+        void *appReqState, CompleteFunct onComplete, ErrorFunct onError, bool autoClose = false);
 #endif // CONFIG_NETWORK_LAYER_BLE
 
     // ----- Remote Passive Rendezvous -----

--- a/src/device-manager/cocoa/NLWeaveBleDelegate.mm
+++ b/src/device-manager/cocoa/NLWeaveBleDelegate.mm
@@ -145,6 +145,7 @@ namespace Ble {
             characteristic = [CBUUID UUIDWithData:[NSData dataWithBytes:charId->bytes length:sizeof(charId->bytes)]];
         }
 
+        WDM_LOG_DEBUG(@"Calling BleDelegateTrampoline::UnsubscribeCharacteristic\n");
         result = [mBleDelegate UnsubscribeCharacteristic:(__bridge id) connObj serivce:service characteristic:characteristic];
 
     exit:
@@ -488,6 +489,7 @@ exit:
 {
     WDM_LOG_METHOD_SIG();
 
+    WDM_LOG_DEBUG(@"forceBleDisconnect_Sync is called");
     // force BleLayer to forget about this connObj
     _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_REMOTE_DEVICE_DISCONNECTED);
 }


### PR DESCRIPTION
In openweave, when application call device manager Close, which would send unsubscribe request to peripheral, and start the unsubscribe timer, after it receive unsubscribe confirm or timeout happens, openweave would close ble endpoint's connection.
App don't know when the ble connection goes away when using above async Close and use delay/retry to alleviate this issue, but failure may still happen, so we force close ble endpoint no matter whether we receive unsubscribe confirm or not.

 we see iOS app forces ble connection close before weave close  so that ios app would not send woble unsubscribe request to close woble connection in device.In order to fix this issue, we move ble disconnection after woble shutdown/close so that unsubcribe can be sent out and further disable autoclose when connecting ble so that woble shutdown/close would
 not close ble connection, and app/device manager can close ble connection explicitly after close.