### PR TITLE
Address truncation warning in gcc 8+

### DIFF
--- a/src/inet/TunEndPoint.cpp
+++ b/src/inet/TunEndPoint.cpp
@@ -695,6 +695,7 @@ INET_ERROR TunEndPoint::TunDevOpen (const char *intfName)
     {
         //Keep member copy of interface name and Id
         strncpy(tunIntfName, ifr.ifr_name, sizeof(tunIntfName) - 1);
+        tunIntfName[sizeof(tunIntfName) - 1] = '\0';
     }
     else
     {


### PR DESCRIPTION
The compile is failing with -Werror enabled. In this particular case, a
call to strncpy can fail to null-terminate tunIntfName if ifr.ifr_name
is maxed out on its number of characters.

The compiler pretty-much expects the user to explicitly set the null
terminator at the end of the copied-to array in order to address the
warning, so that's what we do here.

Relevant compiler output (though it's a little cryptic):
```
src/inet/TunEndPoint.cpp:697:16: error:
'char* strncpy(char*, const char*, size_t)' output may be truncated
copying 15 bytes from a string of length 15
[-Werror=stringop-truncation]
697 |         strncpy(tunIntfName, ifr.ifr_name, sizeof(tunIntfName) - 1);
    |         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```