### PR TITLE
Openweave Python packages should not depend on Python ABI version

### DIFF
--- a/src/device-manager/python/build-openweave-wheel.py
+++ b/src/device-manager/python/build-openweave-wheel.py
@@ -119,6 +119,12 @@ try:
         def finalize_options(self):
             bdist_wheel.finalize_options(self)
             self.root_is_pure = False
+
+        def get_tag(self):
+            python, abi, platform = bdist_wheel.get_tag(self)
+            # Openweave does not depend on Python version or ABI
+            python, abi = 'py2.py3', 'none'
+            return python, abi, platform
     
     # Construct the package version string.  If building under Travis use the Travis
     # build number as the package version.  Otherwise use a dummy version of '0.0'.


### PR DESCRIPTION
We've noticed that Openweave Python packages on PyPI are only uploaded
for specific Python versions. This was a problem when we switched from
Python 3.7 to Python 3.8, and it was finally solved by uploading a new
Python package to PyPI. But now we've switched to Python 3.9 and the
problem surfaced again... so it's high time we find a better solution.

Since Openweave Python package includes, and wraps around, a binary
shared object, it is not a "pure" package.  However, in that case,
Python's "wheel" packer assumes the package uses Python ABI (e.g. it
builds a Python module as a shared object), and tags it with the version
of ABI and the interpreter. Openweave does not use Python ABI, so this
is an unnecessary constraint. This PR removes it.