### PR TITLE
Retain TCPEndPoint upon TCP repair

### DIFF
--- a/src/inet/TCPEndPoint.cpp
+++ b/src/inet/TCPEndPoint.cpp
@@ -533,6 +533,9 @@ INET_ERROR TCPEndPoint::RepairConnection(const TCPConnRepairInfo &connRepairInfo
 
     mAddrType = connRepairInfo.addrType;
 
+    // Bump the ref count on the TCPEndPoint after repairing the socket.
+    Retain();
+
     // Mark state as Connected
     State = kState_Connected;
 #endif // WEAVE_SYSTEM_CONFIG_USE_SOCKETS

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.cpp
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelConnectionMgr.cpp
@@ -643,11 +643,19 @@ void WeaveTunnelConnectionMgr::StopServiceTunnelConn(WEAVE_ERROR err)
     // Close connection to the Service
 
 #if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
-    if (mTunAgent->mServiceMgr)
+
+#if WEAVE_CONFIG_TCP_CONN_REPAIR_SUPPORTED
+    // If underlying TCP connection was repaired, then no need to invoke Service
+    // Manager.
+    if (!mServiceCon->IsRepaired)
+#endif // WEAVE_CONFIG_TCP_CONN_REPAIR_SUPPORTED
     {
-        mTunAgent->mServiceMgr->cancel(mTunAgent->mPeerNodeId, this);
+        if (mTunAgent->mServiceMgr)
+        {
+            mTunAgent->mServiceMgr->cancel(mTunAgent->mPeerNodeId, this);
+        }
     }
-#endif
+#endif // WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
 
     if (mServiceCon)
     {


### PR DESCRIPTION
Also, remove redundant call to ServiceMgr->cancel() when closing a repaired connection.