### PR TITLE
Do not set trait instance to dirty after loading persisted subscription

### DIFF
--- a/src/lib/profiles/data-management/Current/SubscriptionHandler.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionHandler.cpp
@@ -1964,14 +1964,6 @@ WEAVE_ERROR SubscriptionHandler::LoadTraitInstances(TLVReader & reader)
             // mNumTraitInstanceList has already be incremented
             mTraitInstanceList = traitInstance;
         }
-
-        // TODO (didis) Check if data source is persisted, set to dirty if trait data changed from persisted data
-        WeaveLogDetail(DataManagement, "Handler[%u] Syncing is requested for trait[%u].path[%u]",
-                       SubscriptionEngine::GetInstance()->GetHandlerId(this), traitDataHandle, kRootPropertyPathHandle);
-        err = SubscriptionEngine::GetInstance()->mPublisherCatalog->Locate(traitDataHandle, &dataSource);
-        SuccessOrExit(err);
-        dataSource->SetRootDirty();
-        traitInstance->SetDirty();
     }
 
     if (err != WEAVE_END_OF_TLV)


### PR DESCRIPTION
If subscription is not persisted, publisher sends trait data to client
after client sends trait version list to publisher during subscription.
If subscription is persisted, we load trait instance from persisted data.
Currently, we set all trait instance to dirty when we load  the
trait instances. This would sometimes result in sending empty traits to
client. This PR stops marking trait instance as dirty during loading
subscription.