### PR TITLE
Make sure protocol callback is set on the binding object in SubscriptionClient

### DIFF
--- a/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionClient.cpp
@@ -863,6 +863,9 @@ void SubscriptionClient::InitiateSubscription(void)
 {
     mConfig = kConfig_Initiator;
 
+    // Make double sure the protocol callback is set on the binding object
+    mBinding->SetProtocolLayerCallback(BindingEventCallback, this);
+
     if (IsRetryEnabled())
     {
         if (false == mBinding->IsPreparing())

--- a/src/lib/profiles/data-management/Current/SubscriptionHandler.cpp
+++ b/src/lib/profiles/data-management/Current/SubscriptionHandler.cpp
@@ -1785,7 +1785,6 @@ WEAVE_ERROR SubscriptionHandler::LoadFromPersistedState(Binding * const apBindin
 
     // Capture the binding and arrange to receive event callbacks.
     mBinding->AddRef();
-    mBinding->SetProtocolLayerCallback(BindingEventCallback, this);
 
     mBytesOffloaded = 0;
 


### PR DESCRIPTION
SubscriptionClient is written in a way that it's not released upon abort. When peer send
a "cancel subscription" request, SubscriptionClient is reset to initiated state and
is going to be reused by the next subscription attempt. However, SubscriptionClient
only sets the protocol callback on its binding upon init(), which doesn't happen
when the same subscriptionClient is reused for the second (and new) subscription
attempt.
In recent tests, we found that some application resets binding during AbortSubscription.
In some corner cases, when subscriptionClient is reused for second subscription, 
protocol callback is not set for its binding.  We should double check binding has 
valid protocol callback when InitiateSubscription() happens. This PR is also a temporary 
fix to unblock cancel/re-subscribe for some application.

We might also consider release subscriptionClient upon "cancel" to align with this: 
https://github.com/openweave/openweave-core/blob/9f9d2450ba3308f16cc729324801992d37130813/src/lib/profiles/data-management/Current/SubscriptionClient.h#L446