### PR TITLE
Prefer using mDeliveredEvents to update mSelfVendedEvents

### DIFF
--- a/src/lib/profiles/data-management/Current/SubscriptionHandler.h
+++ b/src/lib/profiles/data-management/Current/SubscriptionHandler.h
@@ -351,6 +351,7 @@ private:
 
 #if WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
     void UpdateDeliveredEvents(ImportanceType importance);
+    bool DeliveredEventsExist(ImportanceType importance);
 #endif // WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE
 
     static void BindingEventCallback(void * const apAppState, const Binding::EventType aEvent,


### PR DESCRIPTION
mDeliveredEvent is set to 0 during initialization, and updated after ack from client is recieved. when WEAVE_CONFIG_PERSIST_SUBSCRIPTION_STATE is enabled, prefer mDeliveredEvents over event ids sent from client to update mSelfVendedEvents. This would further reduce the traffic during subscription establishment if client sends old event id.