### PR TITLE
Prevent occasional crash during NLWeaveStack shutdown.

### DIFF
--- a/src/device-manager/cocoa/NLWeaveStack.mm
+++ b/src/device-manager/cocoa/NLWeaveStack.mm
@@ -382,8 +382,10 @@ exit:
 exit:
     if (WEAVE_NO_ERROR != err) {
         WDM_LOG_ERROR(@"Error in ShutdownStack_Stage1 : (%d) %@\n", err, [NSString stringWithUTF8String:nl::ErrorStr(err)]);
-
-        _mShutdownCompletionBlock(err);
+        if (_mShutdownCompletionBlock) {
+          _mShutdownCompletionBlock(err);
+          _mShutdownCompletionBlock = nil;
+        }
     }
 }
 


### PR DESCRIPTION
Prevent occasional crash during NLWeaveStack shutdown.

  If shutdown fails, NLWeaveStack needs to nil-out the stored callback block.
  If for some reason the callback block is called multiple times, NLGWeaveDeviceManager should make sure the calls to dispatch_group are balanced.