### PR TITLE
Fix broken iOS build.

### DIFF
--- a/src/device-manager/cocoa/Makefile.am
+++ b/src/device-manager/cocoa/Makefile.am
@@ -63,6 +63,7 @@ libNLWeaveDeviceManager_a_HEADERS        = \
     NLWeavePasscodeEncryptionSupport.h     \
     NLWeaveKeyExportClient.h               \
     NLWeaveKeyExportSupport.h              \
+    NLWeaveLogging.h                       \
     NLWdmClient.h                          \
     NLGenericTraitUpdatableDataSink.h      \
     NLResourceIdentifier.h                 \

--- a/src/device-manager/cocoa/NLWeaveDeviceManagerTypes.h
+++ b/src/device-manager/cocoa/NLWeaveDeviceManagerTypes.h
@@ -23,6 +23,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "NLWeaveErrorCodes.h"
 
 #ifndef __NLWEAVEDEVICEMANAGERTYPES_H__
 #define __NLWEAVEDEVICEMANAGERTYPES_H__

--- a/src/device-manager/cocoa/NLWeaveLogging.h
+++ b/src/device-manager/cocoa/NLWeaveLogging.h
@@ -96,7 +96,7 @@ typedef NS_ENUM(NSInteger, NLLogLevel) {
  */
 @interface NLWeaveLogging : NSObject
 
-#pragma Logging Configuration
+#pragma mark Logging Configuration
 
 /**
  * Sets the shared @c NLWeaveLogWriter to start receiving Weave logs.
@@ -108,7 +108,7 @@ typedef NS_ENUM(NSInteger, NLLogLevel) {
  */
 + (void)setSharedLogWriter:(nullable id<NLWeaveLogWriter>)logWriter;
 
-#pragma Log Methods
+#pragma mark Log Methods
 
 /**
  * Internal handler method for logging a message to the console and notifying the shared log writer.


### PR DESCRIPTION
- Add NLWeaveLogging.h to Makefile.am so it's included in the exported headers.
- Fix incorrect #pragma statements in NLWeaveLogging.h
- Add missing #include to NLWeaveDeviceManagerTypes.h