### PR TITLE
Disable the ephemeral UDP port feature.

### DIFF
--- a/build/config/android/WeaveProjectConfig.h
+++ b/build/config/android/WeaveProjectConfig.h
@@ -26,7 +26,7 @@
 #define WEAVEPROJECTCONFIG_H
 
 // Enable use of an ephemeral UDP source port for locally initiated Weave exchanges.
-#define WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT 1
+#define WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT 0
 
 // Enable UDP listening on demand in the WeaveDeviceManager
 #define WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP 1

--- a/build/config/ios/WeaveProjectConfig.h
+++ b/build/config/ios/WeaveProjectConfig.h
@@ -26,7 +26,7 @@
 #define WEAVEPROJECTCONFIG_H
 
 // Enable use of an ephemeral UDP source port for locally initiated Weave exchanges.
-#define WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT 1
+#define WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT 0
 
 // Enable UDP listening on demand in the WeaveDeviceManager
 #define WEAVE_CONFIG_DEVICE_MGR_DEMAND_ENABLE_UDP 1


### PR DESCRIPTION
Nest D3 devices require a specific src and dest UDP port. Enabling this feature prevents D3 devices from being used in assisted pairing.