### PR TITLE
Add NULL-check for `MessageLayer->FabricState` on connection close.

### DIFF
--- a/src/lib/core/WeaveConnection.cpp
+++ b/src/lib/core/WeaveConnection.cpp
@@ -1117,7 +1117,8 @@ void WeaveConnection::DoClose(WEAVE_ERROR err, uint8_t flags)
             MessageLayer->ExchangeMgr->HandleConnectionClosed(this, err);
 
         // Call the Fabric state object to alert it of the connection close.
-        MessageLayer->FabricState->HandleConnectionClosed(this);
+        if (MessageLayer->FabricState != NULL)
+            MessageLayer->FabricState->HandleConnectionClosed(this);
 
         // Call the appropriate app callback if allowed.
         if ((flags & kDoCloseFlag_SuppressCallback) == 0)


### PR DESCRIPTION
https://crash.corp.google.com/browse?q=stable_signature%3D%27nl%3A%3AWeave%3A%3AWeaveConnection%3A%3ADoClose-24bb06ea%27