### PR TITLE
Fix class-memaccess warning from GCC 9

### DIFF
--- a/src/lib/profiles/data-management/Current/UpdateEncoder.h
+++ b/src/lib/profiles/data-management/Current/UpdateEncoder.h
@@ -138,7 +138,13 @@ private:
      */
     struct DataElementDataContext
     {
-        DataElementDataContext() { memset(this, 0, sizeof(*this)); }
+        DataElementDataContext() :
+            mTraitPath(0, 0),
+            mUpdateRequiredVersion(0),
+            mForceMerge(false),
+            mDataSink(nullptr),
+            mSchemaEngine(nullptr),
+            mNextDictionaryElementPathHandle(0) {}
 
         TraitPath mTraitPath;                   /**< The TraitPath to encode. */
         DataVersion mUpdateRequiredVersion;     /**< If the update is conditional, the version the update is based off. */


### PR DESCRIPTION
GCC's class-memaccess warning reports cases where functions like memset,
memcpy, etc. are used on non-trivial types.  This change replaces a
memset(this, 0, sizeof(*this)) in the DataElementDataContext struct with
explicit zero-initialization of each member, since
DataElementDataContext is a non-trivial type (member mTraitPath has a
user-defined default constructor).