### PR TITLE
Fix several warnings issued by the more modern compilers

### DIFF
--- a/src/device-manager/WeaveDataManagementClient.cpp
+++ b/src/device-manager/WeaveDataManagementClient.cpp
@@ -575,7 +575,6 @@ WEAVE_ERROR GenericTraitUpdatableDataSink::GetTLVBytes(const char * apPath, Byte
 {
     WEAVE_ERROR err                                       = WEAVE_NO_ERROR;
     TraitSchemaEngine::IGetDataDelegate * getDataDelegate = NULL;
-    TLVType dummyContainerType;
     nl::Weave::TLV::TLVWriter writer;
     PropertyPathHandle propertyPathHandle = kNullPropertyPathHandle;
 
@@ -751,8 +750,6 @@ exit:
 WEAVE_ERROR GenericTraitUpdatableDataSink::DeleteData(const char * apPath)
 {
     WEAVE_ERROR err = WEAVE_NO_ERROR;
-    nl::Weave::TLV::TLVReader reader;
-    PacketBuffer * pMsgBuf                = NULL;
     PropertyPathHandle propertyPathHandle = kNullPropertyPathHandle;
     std::map<PropertyPathHandle, PacketBuffer *>::iterator it;
 

--- a/src/device-manager/WeaveDataManagementClient.h
+++ b/src/device-manager/WeaveDataManagementClient.h
@@ -137,10 +137,6 @@ public:
     void * mpAppState;
 
 private:
-    union
-    {
-        DMCompleteFunct General;
-    } mOnComplete;
     DMErrorFunct mOnError;
 
     template <class T>

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -53,19 +53,6 @@ bool IPAddress::operator!=(const IPAddress& other) const
     return Addr[0] != other.Addr[0] || Addr[1] != other.Addr[1] || Addr[2] != other.Addr[2] || Addr[3] != other.Addr[3];
 }
 
-IPAddress & IPAddress::operator=(const IPAddress& other)
-{
-    if (this != &other)
-    {
-        Addr[0] = other.Addr[0];
-        Addr[1] = other.Addr[1];
-        Addr[2] = other.Addr[2];
-        Addr[3] = other.Addr[3];
-    }
-
-    return *this;
-}
-
 #if WEAVE_SYSTEM_CONFIG_USE_LWIP
 
 #if LWIP_VERSION_MAJOR > 1 || LWIP_VERSION_MINOR >= 5

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -289,15 +289,6 @@ public:
     bool operator !=(const IPAddress& other) const;
 
     /**
-     * @brief   Conventional assignment operator.
-     *
-     * @param[in]   other   The address to copy.
-     *
-     * @return  A reference to this object.
-     */
-    IPAddress& operator =(const IPAddress& other);
-
-    /**
      * @brief   Emit the IP address in conventional text presentation format.
      *
      * @param[out]  buf         The address of the emitted text.

--- a/src/inet/IPPrefix.cpp
+++ b/src/inet/IPPrefix.cpp
@@ -53,17 +53,6 @@ bool IPPrefix::operator!=(const IPPrefix& other) const
     return IPAddr != other.IPAddr || Length != other.Length;
 }
 
-IPPrefix & IPPrefix::operator=(const IPPrefix& other)
-{
-    if (this != &other)
-    {
-        IPAddr = other.IPAddr;
-        Length = other.Length;
-    }
-
-    return *this;
-}
-
 bool IPPrefix::MatchAddress(const IPAddress& addr) const
 {
     uint8_t l = (Length <= 128) ? Length : 128;

--- a/src/inet/IPPrefix.h
+++ b/src/inet/IPPrefix.h
@@ -100,15 +100,6 @@ public:
     bool operator !=(const IPPrefix& other) const;
 
     /**
-     * @brief   Conventional assignment operator.
-     *
-     * @param[in]   other   the prefix to copy.
-     *
-     * @return  a reference to this object.
-     */
-    IPPrefix& operator =(const IPPrefix& other);
-
-    /**
      * @brief   Test if an address matches the prefix.
      *
      * @param[in]   addr   the address to test.

--- a/src/lib/core/HostPortList.cpp
+++ b/src/lib/core/HostPortList.cpp
@@ -35,15 +35,6 @@ namespace Weave {
 using namespace nl::Weave::Encoding;
 
 /**
- *  Class default (void) constructor.
- *
- */
-HostPortList::HostPortList(void)
-{
-    Clear();
-}
-
-/**
  *  Reset the list to empty.
  *
  */

--- a/src/lib/core/HostPortList.h
+++ b/src/lib/core/HostPortList.h
@@ -46,7 +46,7 @@ namespace Weave {
 class HostPortList
 {
  public:
-    HostPortList(void);
+    HostPortList(void) = default;
     inline HostPortList(const uint8_t *hostPortList, uint8_t hostPortCount, const uint8_t *suffixList, const uint8_t suffixCount)
     {
         mElements    = hostPortList;

--- a/src/lib/profiles/data-management/Current/Command.h
+++ b/src/lib/profiles/data-management/Current/Command.h
@@ -77,18 +77,6 @@ typedef enum CommandFlags
 class NL_DLL_EXPORT Command
 {
 public:
-    /**
-     *  @brief
-     *    The Command flag bits.
-     */
-    typedef enum CommandFlags
-    {
-        kCommandFlag_MustBeVersionValid   = 0x0001,  /**< Set when the version field is valid */
-        kCommandFlag_InitiationTimeValid  = 0x0002,  /**< Set when the init time is valid */
-        kCommandFlag_ActionTimeValid      = 0x0004,  /**< Set when the action time is valid */
-        kCommandFlag_ExpiryTimeValid      = 0x0008,  /**< Set when the expiry time is valid */
-        kCommandFlag_IsOneWay             = 0x0010,  /**< Set when the command is one-way */
-    } CommandFlags;
 
     uint64_t commandType;
     uint64_t mustBeVersion;

--- a/src/lib/profiles/data-management/Current/CommandSender.cpp
+++ b/src/lib/profiles/data-management/Current/CommandSender.cpp
@@ -209,9 +209,7 @@ void CommandSender::Close(bool aAbortNow)
 
 WEAVE_ERROR CommandSender::SendCommand(nl::Weave::PacketBuffer *aPayload, nl::Weave::Binding *aBinding, ResourceIdentifier &aResourceId, uint32_t aProfileId, uint32_t aCommandType)
 {
-    SendParams sendParams;
-
-    memset(&sendParams, 0, sizeof(sendParams));
+    SendParams sendParams = SendParams();
 
     sendParams.ResourceId = aResourceId;
     sendParams.ProfileId = aProfileId;
@@ -431,12 +429,11 @@ exit:
 
 void CommandSender::OnResponseTimeout(ExchangeContext *aEC)
 {
-    WEAVE_ERROR err = WEAVE_NO_ERROR;
     CommandSender *_this = static_cast<CommandSender *>(aEC->AppState);
     InEventParam inEventParam;
     OutEventParam outEventParam;
 
-    VerifyOrExit(_this, err = WEAVE_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(_this, );
 
     inEventParam.CommunicationError.error = WEAVE_ERROR_TIMEOUT;
     _this->mEventCallback(_this->mAppState, kEvent_CommunicationError, inEventParam, outEventParam);

--- a/src/lib/profiles/data-management/Current/LoggingManagement.cpp
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.cpp
@@ -2276,9 +2276,9 @@ WEAVE_ERROR CircularEventBuffer::SerializeEvents(TLVWriter & writer)
     size_t bufLen = mBuffer.GetQueueSize();
 
     size_t initLen = inBufLen;
-    if ((inBufStart + initLen) > (bufStart + bufLen))
+    if (initLen > ((size_t) ((bufStart - inBufStart) + bufLen)))
     {
-        initLen = bufStart + bufLen - inBufStart;
+        initLen = (size_t) ((bufStart - inBufStart) + bufLen);
     }
 
     err = writer.StartContainer(AnonymousTag, kTLVType_Structure, container);

--- a/src/lib/profiles/data-management/Current/LoggingManagement.cpp
+++ b/src/lib/profiles/data-management/Current/LoggingManagement.cpp
@@ -2276,7 +2276,7 @@ WEAVE_ERROR CircularEventBuffer::SerializeEvents(TLVWriter & writer)
     size_t bufLen = mBuffer.GetQueueSize();
 
     size_t initLen = inBufLen;
-    if (initLen > bufStart + bufLen - inBufStart)
+    if ((inBufStart + initLen) > (bufStart + bufLen))
     {
         initLen = bufStart + bufLen - inBufStart;
     }

--- a/src/lib/profiles/data-management/Current/UpdateClient.h
+++ b/src/lib/profiles/data-management/Current/UpdateClient.h
@@ -83,7 +83,6 @@ private:
     EventCallback mEventCallback;
     nl::Weave::ExchangeContext * mEC;
     UpdateClientState mState;
-    utc_timestamp_t mExpiryTimeMicroSecond;
 
     static void OnSendError(ExchangeContext * aEC, WEAVE_ERROR aErrorCode, void * aMsgSpecificContext);
     static void OnResponseTimeout(nl::Weave::ExchangeContext * aEC);

--- a/src/lib/profiles/data-management/Current/UpdateEncoder.h
+++ b/src/lib/profiles/data-management/Current/UpdateEncoder.h
@@ -144,7 +144,7 @@ private:
             mForceMerge(false),
             mDataSink(nullptr),
             mSchemaEngine(nullptr),
-            mNextDictionaryElementPathHandle(0) {}
+            mNextDictionaryElementPathHandle(0) { }
 
         TraitPath mTraitPath;                   /**< The TraitPath to encode. */
         DataVersion mUpdateRequiredVersion;     /**< If the update is conditional, the version the update is based off. */

--- a/src/lib/support/crypto/CTRMode.cpp
+++ b/src/lib/support/crypto/CTRMode.cpp
@@ -38,9 +38,11 @@ namespace Weave {
 namespace Crypto {
 
 template <class BlockCipher>
-CTRMode<BlockCipher>::CTRMode()
+CTRMode<BlockCipher>::CTRMode() : mBlockCipher()
 {
-    memset(this, 0, sizeof(*this));
+    mMsgIndex = 0;
+    memset(Counter, 0, sizeof(Counter));
+    ClearSecretData(mEncryptedCounter, sizeof(mEncryptedCounter));
 }
 
 template <class BlockCipher>

--- a/src/lib/support/crypto/DRBG.cpp
+++ b/src/lib/support/crypto/DRBG.cpp
@@ -36,9 +36,12 @@ namespace Weave {
 namespace Crypto {
 
 template <class BlockCipher>
-CTR_DRBG<BlockCipher>::CTR_DRBG()
+CTR_DRBG<BlockCipher>::CTR_DRBG() : mBlockCipher()
 {
-    memset(this, 0, sizeof(*this));
+    mEntropyFunct = NULL;
+    mReseedCounter = 0;
+    mEntropyFunct = 0;
+    memset(mCounter, 0, kBlockLength);
 }
 
 template <class BlockCipher>

--- a/src/test-apps/MockSourceTraits.h
+++ b/src/test-apps/MockSourceTraits.h
@@ -156,7 +156,7 @@ private:
     uint32_t tae[10];
 
     // weave.common.StringRef is implemented as a union
-    char *tag_string = "stringreftest";
+    char tag_string[20] = "stringreftest";
     uint16_t tag_ref;
     bool tag_use_ref;
     uint32_t tai_stageditem;
@@ -186,7 +186,7 @@ private:
     uint32_t tat;
     int32_t tau;
     bool tav;
-    char *taw = "boxedstring";
+    char taw[20] = "boxedstring";
     // boxed float
     int16_t tax;
 

--- a/src/test-apps/MockWdmSubscriptionResponder.cpp
+++ b/src/test-apps/MockWdmSubscriptionResponder.cpp
@@ -79,27 +79,6 @@ static bool gClearDataSink = false;
 static bool gCleanStatus = true;
 static nl::Weave::WRMPConfig gWRMPConfig = { kWRMPInitialRetransTimeoutMsec, kWRMPActiveRetransTimeoutMsec, kWRMPAckTimeoutMsec, kWRMPMaxRetrans };
 
-
-#if 0
-// Re-enable should there be any requirement to use the debug pretty print
-static void TLVPrettyPrinter(const char *aFormat, ...)
-{
-    va_list args;
-
-    va_start(args, aFormat);
-
-    // There is no proper Weave logging routine for us to use here
-    vprintf(aFormat, args);
-
-    va_end(args);
-}
-
-static WEAVE_ERROR DebugPrettyPrint(nl::Weave::TLV::TLVReader & aReader)
-{
-    return nl::Weave::TLV::Debug::Dump(aReader, TLVPrettyPrinter);
-}
-#endif
-
 nl::Weave::Profiles::DataManagement::SubscriptionEngine * nl::Weave::Profiles::DataManagement::SubscriptionEngine::GetInstance()
 {
     static nl::Weave::Profiles::DataManagement::SubscriptionEngine gWdmSubscriptionEngine;

--- a/src/test-apps/MockWdmSubscriptionResponder.cpp
+++ b/src/test-apps/MockWdmSubscriptionResponder.cpp
@@ -80,6 +80,8 @@ static bool gCleanStatus = true;
 static nl::Weave::WRMPConfig gWRMPConfig = { kWRMPInitialRetransTimeoutMsec, kWRMPActiveRetransTimeoutMsec, kWRMPAckTimeoutMsec, kWRMPMaxRetrans };
 
 
+#if 0
+// Re-enable should there be any requirement to use the debug pretty print
 static void TLVPrettyPrinter(const char *aFormat, ...)
 {
     va_list args;
@@ -96,6 +98,7 @@ static WEAVE_ERROR DebugPrettyPrint(nl::Weave::TLV::TLVReader & aReader)
 {
     return nl::Weave::TLV::Debug::Dump(aReader, TLVPrettyPrinter);
 }
+#endif
 
 nl::Weave::Profiles::DataManagement::SubscriptionEngine * nl::Weave::Profiles::DataManagement::SubscriptionEngine::GetInstance()
 {
@@ -1082,9 +1085,7 @@ void MockWdmSubscriptionResponderImpl::Command_Send(void)
 
     {
         uint64_t nowMicroSecs, deadline;
-        CommandSender::SendParams sendParams;
-
-        memset(&sendParams, 0, sizeof(sendParams));
+        CommandSender::SendParams sendParams = CommandSender::SendParams();
 
         if (mTestCaseId == kTestCase_ForwardCompatibleVersionedRequest) {
             sendParams.VersionRange.mMaxVersion = 4;

--- a/src/test-apps/TestSystemObject.cpp
+++ b/src/test-apps/TestSystemObject.cpp
@@ -295,7 +295,7 @@ void* TestObject::CheckConcurrencyThread(void* aContext)
 void* TestObject::CheckHighWatermarkThread(void* aContext)
 {
     TestContext&        lContext        = *static_cast<TestContext*>(aContext);
-    unsigned int        i;
+    int        i;
     nl::Weave::System::Stats::count_t lNumInUse;
     nl::Weave::System::Stats::count_t lHighWatermark;
 
@@ -359,11 +359,11 @@ void TestObject::CheckHighWatermark(nlTestSuite* inSuite, void* aContext)
 {
     memset(&sPool, 0, sizeof(sPool));
 
-    const unsigned int  kNumObjects     = kPoolSize;
+    const int           kNumObjects     = kPoolSize;
     TestObject*         lObject         = NULL;
     TestContext&        lContext        = *static_cast<TestContext*>(aContext);
     Layer               lLayer;
-    unsigned int        i;
+    int                 i;
     nl::Weave::System::Stats::count_t lNumInUse;
     nl::Weave::System::Stats::count_t lHighWatermark;
 

--- a/src/test-apps/TestWdmUpdateServer.cpp
+++ b/src/test-apps/TestWdmUpdateServer.cpp
@@ -265,7 +265,6 @@ WEAVE_ERROR WdmUpdateServerTest::VerifyUpdateRequest(nlTestSuite * inSuite, Pack
     PacketBuffer * pBuf = NULL;
     UpdateRequest::Parser update;
     Weave::TLV::TLVReader reader;
-    bool isDataListPresent                                             = false;
     bool existFailure                                                  = false;
     uint32_t numDataElements                                           = 0;
     uint32_t maxPayloadSize                                            = 0;
@@ -297,14 +296,9 @@ WEAVE_ERROR WdmUpdateServerTest::VerifyUpdateRequest(nlTestSuite * inSuite, Pack
     {
         DataList::Parser dataList;
         err = update.GetDataList(&dataList);
-        if (WEAVE_NO_ERROR == err)
+        if (WEAVE_END_OF_TLV == err)
         {
-            isDataListPresent = true;
-        }
-        else if (WEAVE_END_OF_TLV == err)
-        {
-            isDataListPresent = false;
-            err               = WEAVE_NO_ERROR;
+            err = WEAVE_NO_ERROR;
         }
         SuccessOrExit(err);
 

--- a/src/test-apps/TestWeaveTunnelCASEPersistClient.cpp
+++ b/src/test-apps/TestWeaveTunnelCASEPersistClient.cpp
@@ -62,12 +62,14 @@ using namespace ::nl::Weave::Profiles::DeviceDescription;
 
 static bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg);
 static bool HandleNonOptionArgs(const char *progName, int argc, char *argv[]);
+#if WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
 static void HandleLoadPersistedTunnelCASESession(nl::Weave::WeaveConnection *con);
-static void HandleSessionPersistOnTunnelClosure(nl::Weave::WeaveConnection *con);
-static WEAVE_ERROR RestorePersistedTunnelCASESession(nl::Weave::WeaveConnection *con);
-static WEAVE_ERROR SuspendAndPersistTunnelCASESession(nl::Weave::WeaveConnection *con);
 static bool IsPersistentTunnelSessionPresent(uint64_t peerNodeId);
+static WEAVE_ERROR RestorePersistedTunnelCASESession(nl::Weave::WeaveConnection *con);
+#endif
 
+static void HandleSessionPersistOnTunnelClosure(nl::Weave::WeaveConnection *con);
+static WEAVE_ERROR SuspendAndPersistTunnelCASESession(nl::Weave::WeaveConnection *con);
 static void
 WeaveTunnelOnStatusNotifyHandlerCB(WeaveTunnelConnectionMgr::TunnelConnNotifyReasons reason,
                                    WEAVE_ERROR aErr, void *appCtxt);
@@ -326,6 +328,7 @@ exit:
     return err;
 }
 
+#if WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
 WEAVE_ERROR
 RestorePersistedTunnelCASESession(nl::Weave::WeaveConnection *con)
 {
@@ -397,6 +400,14 @@ void HandleLoadPersistedTunnelCASESession(nl::Weave::WeaveConnection *con)
     }
 }
 
+bool IsPersistentTunnelSessionPresent(uint64_t peerNodeId)
+{
+    const char * persistentTunnelSessionPath = PERSISTENT_TUNNEL_SESSION_PATH;
+
+    return (access(persistentTunnelSessionPath, F_OK) != -1);
+}
+#endif // WEAVE_CONFIG_PERSIST_CONNECTED_SESSION
+
 void HandleSessionPersistOnTunnelClosure(nl::Weave::WeaveConnection *con)
 {
     WEAVE_ERROR err = WEAVE_NO_ERROR;
@@ -407,13 +418,6 @@ void HandleSessionPersistOnTunnelClosure(nl::Weave::WeaveConnection *con)
     {
         printf("Suspending and persisting Tunnel CASE Session failed with Weave error: %d\n", err);
     }
-}
-
-bool IsPersistentTunnelSessionPresent(uint64_t peerNodeId)
-{
-    const char * persistentTunnelSessionPath = PERSISTENT_TUNNEL_SESSION_PATH;
-
-    return (access(persistentTunnelSessionPath, F_OK) != -1);
 }
 #endif // WEAVE_CONFIG_ENABLE_TUNNELING
 


### PR DESCRIPTION
* Fix class-memaccess warning in src/lib/support/crypto/CTRMode.cpp
  and in src/lib/support/crypto/DBRG.cpp by implementing a more robust
  constructor

* Remove unused local variables in
  src/device-manager/WeaveDataManagementClient.cpp

* Remove trivial implementations of `operator=` in
  src/inet/IPAddress.{h,cpp} and in src/inet/IPPrefix.{h,cpp} s.t. any
  classes containing members of these types remain trivially copyable.

* Fix several warnings about comparisons between signed and unsigned integers.

* Remove the duplicated enum within the class completely
  mirrored/shadowed the enum within the namespace
  (DataManagement_Current::Command::CommandFlags)

* Replace memset-based initialization with the 0-initialization constructor

* Replace the no-arg constuctor for HostPortList with the default one
  to preserve trivial copyable nature of WeaveConnection

* Properly guard the functions to avoid the unused function warning

* Declare proper storage for strings in MockTraitDataSource

* Fix signedness of comparisons against Stats::count_t