### PR TITLE
Weave Message Capture logic.

### DIFF
--- a/src/lib/core/WeaveBinding.cpp
+++ b/src/lib/core/WeaveBinding.cpp
@@ -1374,6 +1374,14 @@ WEAVE_ERROR Binding::NewExchangeContext(nl::Weave::ExchangeContext *& appExchang
         appExchangeContext->SetAutoReleaseKey(true);
     }
 
+#if WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
+    // If message is marked for capture set flag in Exchange Context
+    if (GetFlag(kFlag_CaptureTxMessage))
+    {
+        appExchangeContext->SetCaptureSentMessage(true);
+    }
+#endif // WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
+
     err = AdjustResponseTimeout(appExchangeContext);
     SuccessOrExit(err);
 
@@ -1929,6 +1937,19 @@ Binding::Configuration& Binding::Configuration::Security_AuthenticationMode(Weav
     mBinding.mAuthMode = aAuthMode;
     return *this;
 }
+
+#if WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
+/**
+ *  Set the flag for capturing sent messages
+ *
+ *  @return                     A reference to the Binding object.
+ */
+Binding::Configuration& Binding::Configuration::CaptureTxMessage(void)
+{
+    mBinding.SetFlag(kFlag_CaptureTxMessage);
+    return *this;
+}
+#endif // WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
 
 /**
  *  Configure the binding to allow communication with the sender of a received message.

--- a/src/lib/core/WeaveBinding.h
+++ b/src/lib/core/WeaveBinding.h
@@ -268,6 +268,7 @@ private:
     {
         kFlag_KeyReserved                           = 0x1,
         kFlag_ConnectionReferenced                  = 0x2,
+        kFlag_CaptureTxMessage                      = 0x4,
     };
 
     WeaveExchangeManager * mExchangeManager;
@@ -388,6 +389,10 @@ public:
     Configuration& Security_AppGroupKey(uint32_t aAppGroupGlobalId, uint32_t aRootKeyId, bool aUseRotatingKey);
     Configuration& Security_EncryptionType(uint8_t aEncType);
     Configuration& Security_AuthenticationMode(WeaveAuthMode aAuthMode);
+
+#if WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
+    Configuration& CaptureTxMessage(void);
+#endif // WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
 
     Configuration& ConfigureFromMessage(const WeaveMessageInfo *aMsgInfo, const Inet::IPPacketInfo *aPacketInfo);
 

--- a/src/lib/core/WeaveConfig.h
+++ b/src/lib/core/WeaveConfig.h
@@ -2403,6 +2403,22 @@
 #endif // WEAVE_CONFIG_TCP_CONN_REPAIR_SUPPORTED
 
 /**
+ * @def WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
+ *
+ * @brief
+ *   When this option is enabled, transmitted Weave messages can be captured
+ *   back at the WeaveMessageLayer after being fully encoded with the Weave
+ *   Exchange and Message layer headers.
+ *   In orderr to capture messages, the application can configure a WeaveBinding
+ *   object to vend an ExchangeContext that is tagged for capture. Thereafter,
+ *   all transmitted messages on that ExchangeContext would be captured.
+ *
+ */
+#ifndef WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
+#define WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE                 0
+#endif // WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
+
+/**
  * @def WEAVE_NON_PRODUCTION_MARKER
  *
  * @brief Defines the name of a mark symbol whose presence signals that the Weave code

--- a/src/lib/core/WeaveExchangeMgr.cpp
+++ b/src/lib/core/WeaveExchangeMgr.cpp
@@ -1556,7 +1556,7 @@ WEAVE_ERROR WeaveExchangeManager::AddToRetransTable(ExchangeContext *ec, PacketB
 WEAVE_ERROR WeaveExchangeManager::SendFromRetransTable(RetransTableEntry *entry)
 {
     WEAVE_ERROR err = WEAVE_NO_ERROR;
-    uint16_t msgSendFlags = 0;
+    uint32_t msgSendFlags = 0;
     uint8_t     *p = NULL;
     uint32_t    len = 0;
     ExchangeContext *ec = entry->exchContext;
@@ -1573,6 +1573,12 @@ WEAVE_ERROR WeaveExchangeManager::SendFromRetransTable(RetransTableEntry *entry)
 
     if (ec)
     {
+#if WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
+        if (ec->ShouldCaptureSentMessage())
+        {
+            SetFlag(msgSendFlags, kWeaveMessageFlag_CaptureTxMessage);
+        }
+#endif // WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
         SetFlag(msgSendFlags, kWeaveMessageFlag_RetainBuffer);
 
 #if WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT

--- a/src/lib/core/WeaveExchangeMgr.h
+++ b/src/lib/core/WeaveExchangeMgr.h
@@ -159,6 +159,8 @@ public:
         kSendFlag_RequestAck                    = 0x0400, /**< Used to send a WRM message requesting an acknowledgment. */
         kSendFlag_NoAutoRequestAck              = 0x0800, /**< Suppress the auto-request acknowledgment feature when sending a message. */
 
+        kSendFlag_CaptureSentMessage            = 0x1000, /**< Capture the sent message after encoded with Weave headers */
+
         kSendFlag_MulticastFromLinkLocal        = kSendFlag_DefaultMulticastSourceAddress,
                                                           /**< Deprecated alias for \c kSendFlag_DefaultMulticastSourceAddress */
     };
@@ -191,6 +193,11 @@ public:
 #if WEAVE_CONFIG_ENABLE_EPHEMERAL_UDP_PORT
     void SetUseEphemeralUDPPort(bool val);
 #endif
+
+#if WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
+    void SetCaptureSentMessage(bool inCaptureSentMessage);
+    bool ShouldCaptureSentMessage() const;
+#endif // WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
 
     WEAVE_ERROR SendMessage(uint32_t profileId, uint8_t msgType, PacketBuffer *msgPayload, uint16_t sendFlags = 0, void *msgCtxt = 0);
     WEAVE_ERROR SendMessage(uint32_t profileId, uint8_t msgType, PacketBuffer *msgBuf, uint16_t sendFlags, WeaveMessageInfo * msgInfo, void *msgCtxt = 0);

--- a/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.h
+++ b/src/lib/profiles/weave-tunneling/WeaveTunnelAgent.h
@@ -654,7 +654,7 @@ private:
     // Message encapsulating/decapsulating functions for sending between Tunnel and other interfaces
 
     WEAVE_ERROR AddTunnelHdrToMsg(PacketBuffer *msg);
-    WEAVE_ERROR HandleSendingToService(PacketBuffer *msg);
+    WEAVE_ERROR HandleSendingToService(PacketBuffer *msg, const bool shouldCapture = false);
     WEAVE_ERROR HandleTunneledReceive(PacketBuffer *msg, TunnelType tunType);
 
     /// Decide based on lookup of nexthop table and send locally
@@ -718,6 +718,13 @@ private:
     void WeaveTunnelNotifyTCPSendIdleStateChange(const TunnelType tunType, const bool isIdle);
 #endif // WEAVE_CONFIG_TUNNEL_ENABLE_TCP_IDLE_CALLBACK
 
+#if WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
+    WEAVE_ERROR ReplaceDestSubnetInAddress(PacketBuffer *inMsg, const uint16_t subnetId);
+
+    WEAVE_ERROR ComputeUDPChecksumForIPv6Pkt(PacketBuffer *inMsg, const IPAddress &srcAddr, const IPAddress &destAddr);
+    uint32_t Checksum(uint16_t *buf, uint16_t len);
+
+#endif // WEAVE_CONFIG_ENABLE_MESSAGE_CAPTURE
 };
 
 

--- a/src/test-apps/TestWeaveTunnel.h
+++ b/src/test-apps/TestWeaveTunnel.h
@@ -83,6 +83,7 @@ enum
     kTestNum_TestTunnelRestrictedRoutingOnStandaloneTunnelOpen  = 27,
     kTestNum_TestTunnelTCPIdle                                  = 28,
     kTestNum_TestTunnelPersistCASESession                       = 29,
+    kTestNum_TestTunneledPacketCapture                          = 30,
 };
 
 #endif // WEAVE_CONFIG_ENABLE_TUNNELING


### PR DESCRIPTION
This feature allows an application to formulate an Exchange for
capturing Weave messages by setting a WeaveBindiing flag before vending
the ExchangeContext. For tunneled messages, they are directed towards a
'capture subnet' as a means of tagging the messages for capturing, as
they traverse the underlying network stack and get encapsulated within
an [IPv6|UDP] packet. The capture subnet is then reinstated back to the
original subnet before the packet is captured and delivered up to
the application.

* Expose WeaveBinding setting API.
* Percolate setting via message flags from WeaveExchange layer to
  WeaveMessageLayer.
* Encode reserved capture subnet for Tunneled packets to Phoenix
* Reinstate Phoenix address and tag tunneled packet for capture.
* Add functional test case for capturing a tunneled packet.