### PR TITLE
Weave tool improvements

### DIFF
--- a/src/lib/core/WeaveTLVDebug.cpp
+++ b/src/lib/core/WeaveTLVDebug.cpp
@@ -154,7 +154,10 @@ static void DumpHandler(DumpWriter aWriter, const char *aIndent, const TLVReader
                 err = temp.GetDataPtr(strbuf);
                 VerifyOrExit(err == WEAVE_NO_ERROR, aWriter("Error in kTLVType_ByteString"));
             }
-            aWriter("%p\n", strbuf);
+            for (int i = 0; i < len; i++) {
+              aWriter("%02x ", strbuf[i]);
+            }
+            aWriter("\n");
             break;
 
         case kTLVType_Null:

--- a/src/test-apps/TestWeaveTunnelBR.cpp
+++ b/src/test-apps/TestWeaveTunnelBR.cpp
@@ -2998,20 +2998,6 @@ BindingEventCallback(
         case nl::Weave::Binding::kEvent_PrepareFailed:
         case nl::Weave::Binding::kEvent_BindingFailed:
         {
-#if 0
-            nlVERIFY(binding != NULL);
-
-            // TODO: Currently no effort is made for recovery here.
-            // However, in the future we may be able to fail gracefully by
-            // re-trying the binding
-            NL_LOG((nlLPCrit,
-                   "Binding Failed Peer=%016" PRIX64,
-                   binding->GetPeerNodeId()));
-
-            // Pending command is no longer valid so remove command
-            // TODO: Report error back to the command requester.
-            _this->mPendingCommands.erase(binding);
-#endif
             break;
         }
         default:

--- a/src/tools/weave/Cmd_PrintAccessToken.cpp
+++ b/src/tools/weave/Cmd_PrintAccessToken.cpp
@@ -74,7 +74,8 @@ static HelpOptions gHelpOptions(
     "\n"
     "  <access-token>\n"
     "\n"
-    "       A file containing a Weave Access Token, in base-64 format\n"
+    "       A file containing a Weave Access Token either in raw TLV format (default)\n"
+    "       or in base-64 format with -b option.\n"
     "\n"
 );
 
@@ -88,7 +89,7 @@ static OptionSet *gCmdOptionSets[] =
 static const char *gCertFileName = NULL;
 static bool gUseBase64Decoding = false;
 enum {
-    kNumCerts = 3,
+    kNumCerts = 1,
     kCertBufSize = 1024,
 };
 
@@ -114,13 +115,21 @@ bool Cmd_PrintAccessToken(int argc, char *argv[])
     }
 
     if (!ReadFileIntoMem(gCertFileName, accessToken, accessTokenLen))
+    {
         ExitNow(res = false);
+    }
 
     if (gUseBase64Decoding)
     {
         uint32_t b64len = accessTokenLen;
         uint8_t * b64 = accessToken;
         accessToken = (uint8_t *)malloc(accessTokenLen);
+        if (accessToken == NULL)
+        {
+            fprintf(stderr, "Memory allocation error\n");
+            free(b64);
+            ExitNow(res = false);
+        }
         accessTokenLen = nl::Base64Decode((const char *)b64, b64len, accessToken);
         free(b64);
     }

--- a/src/tools/weave/Cmd_PrintAccessToken.cpp
+++ b/src/tools/weave/Cmd_PrintAccessToken.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    Copyright (c) 2022 Nest Labs, Inc.
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
 /**
  *    @file
  *      This file implements the command handler for the 'weave' tool
- *      that decodes and prints the contents of a Weave certificate.
+ *      that decodes and prints the contents of a Weave access token certificate.
  *
  */
 

--- a/src/tools/weave/Cmd_PrintAccessToken.cpp
+++ b/src/tools/weave/Cmd_PrintAccessToken.cpp
@@ -39,7 +39,7 @@
 using namespace nl::Weave::ASN1;
 using namespace nl::Weave::Profiles::Security;
 
-#define CMD_NAME "weave print-cert"
+#define CMD_NAME "weave print-access-token"
 
 static bool HandleNonOptionArgs(const char *progName, int argc, char *argv[]);
 static bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg);
@@ -66,7 +66,7 @@ static OptionSet gCmdOptions =
 };
 static HelpOptions gHelpOptions(
     CMD_NAME,
-    "Usage: " CMD_NAME " [<options...>] <cert-file>\n",
+    "Usage: " CMD_NAME " [<options...>] <access-token>\n",
     WEAVE_VERSION_STRING "\n" COPYRIGHT_STRING,
     "Print a Weave Access Token certificate.\n"
     "\n"
@@ -135,16 +135,10 @@ bool Cmd_PrintAccessToken(int argc, char *argv[])
         ExitNow(res = false);
     }
 
-    err = DetermineCertType(*certData);
-    if (err != WEAVE_NO_ERROR)
-    {
-        fprintf(stderr, "weave: %s.\n", nl::ErrorStr(err));
-        ExitNow(res = false);
-    }
-
     printf("Weave Access Token:\n");
 
     printf("Weave Certificate:\n");
+
     PrintCert(stdout, *certData, NULL, 2, true);
 
     printf("Access Token Private Key omitted\n");

--- a/src/tools/weave/Cmd_PrintAccessToken.cpp
+++ b/src/tools/weave/Cmd_PrintAccessToken.cpp
@@ -68,7 +68,7 @@ static HelpOptions gHelpOptions(
     CMD_NAME,
     "Usage: " CMD_NAME " [<options...>] <cert-file>\n",
     WEAVE_VERSION_STRING "\n" COPYRIGHT_STRING,
-    "Print a Weave certificate.\n"
+    "Print a Weave Access Token certificate.\n"
     "\n"
     "ARGUMENTS\n"
     "\n"

--- a/src/tools/weave/Cmd_PrintAccessToken.cpp
+++ b/src/tools/weave/Cmd_PrintAccessToken.cpp
@@ -1,0 +1,193 @@
+/*
+ *
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the command handler for the 'weave' tool
+ *      that decodes and prints the contents of a Weave certificate.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "weave-tool.h"
+#include <Weave/Support/ASN1OID.h>
+#include <Weave/Profiles/security/WeaveSecurityDebug.h>
+#include <Weave/Profiles/security/WeaveAccessToken.h>
+#include <Weave/Support/Base64.h>
+
+using namespace nl::Weave::ASN1;
+using namespace nl::Weave::Profiles::Security;
+
+#define CMD_NAME "weave print-cert"
+
+static bool HandleNonOptionArgs(const char *progName, int argc, char *argv[]);
+static bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg);
+
+static OptionDef gCmdOptionDefs[] =
+{
+    { "base64", kNoArgument, 'b' },
+    { }
+};
+
+static const char *const gCmdOptionHelp =
+    "   -b, --base64\n"
+    "\n"
+    "       The file containing the TLV should be parsed as base64.\n"
+    "\n"
+    ;
+
+static OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+static HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [<options...>] <cert-file>\n",
+    WEAVE_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Print a Weave certificate.\n"
+    "\n"
+    "ARGUMENTS\n"
+    "\n"
+    "  <access-token>\n"
+    "\n"
+    "       A file containing a Weave Access Token, in base-64 format\n"
+    "\n"
+);
+
+static OptionSet *gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    NULL
+};
+
+static const char *gCertFileName = NULL;
+static bool gUseBase64Decoding = false;
+enum {
+    kNumCerts = 3,
+    kCertBufSize = 1024,
+};
+
+bool Cmd_PrintAccessToken(int argc, char *argv[])
+{
+    bool res = true;
+    WEAVE_ERROR err;
+    WeaveCertificateData *certData;
+    WeaveCertificateSet certSet;
+    uint8_t * accessToken = NULL;
+    uint32_t accessTokenLen = 0;
+    TLVReader reader;
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        ExitNow(res = true);
+    }
+
+    if (!ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs))
+    {
+        ExitNow(res = false);
+    }
+
+    if (!ReadFileIntoMem(gCertFileName, accessToken, accessTokenLen))
+        ExitNow(res = false);
+
+    if (gUseBase64Decoding)
+    {
+        uint32_t b64len = accessTokenLen;
+        uint8_t * b64 = accessToken;
+        accessToken = (uint8_t *)malloc(accessTokenLen);
+        accessTokenLen = nl::Base64Decode((const char *)b64, b64len, accessToken);
+        free(b64);
+    }
+
+    reader.Init(accessToken, accessTokenLen);
+    certSet.Init(kNumCerts, kCertBufSize);
+    err = LoadAccessTokenCerts(reader, certSet, 0, certData);
+
+    if (err != WEAVE_NO_ERROR)
+    {
+        fprintf(stderr, "Error reading cert info: %s.\n", nl::ErrorStr(err));
+        ExitNow(res = false);
+    }
+
+    err = DetermineCertType(*certData);
+    if (err != WEAVE_NO_ERROR)
+    {
+        fprintf(stderr, "weave: %s.\n", nl::ErrorStr(err));
+        ExitNow(res = false);
+    }
+
+    printf("Weave Access Token:\n");
+
+    printf("Weave Certificate:\n");
+    PrintCert(stdout, *certData, NULL, 2, true);
+
+    printf("Access Token Private Key omitted\n");
+
+    res = (err == WEAVE_NO_ERROR);
+
+exit:
+    if (accessToken != NULL)
+        free(accessToken);
+    return res;
+}
+
+bool HandleNonOptionArgs(const char *progName, int argc, char *argv[])
+{
+    if (argc == 0)
+    {
+        PrintArgError("%s: Please specify the name of the certificate to be printed.\n", progName);
+        return false;
+    }
+
+    if (argc > 1)
+    {
+        PrintArgError("%s: Unexpected argument: %s\n", progName, argv[1]);
+        return false;
+    }
+
+    gCertFileName = argv[0];
+
+    return true;
+}
+
+bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg)
+{
+    switch (id)
+    {
+    case 'b':
+        gUseBase64Decoding = true;
+        break;
+
+    default:
+        PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}

--- a/src/tools/weave/Cmd_PrintServiceConfig.cpp
+++ b/src/tools/weave/Cmd_PrintServiceConfig.cpp
@@ -44,7 +44,7 @@ using namespace nl::Weave::TLV;
 using namespace nl::Weave::Profiles::ServiceProvisioning;
 using namespace nl::Weave::Profiles;
 
-#define CMD_NAME "weave print-cert"
+#define CMD_NAME "weave print-service-config"
 
 static WEAVE_ERROR PrintServiceHostname(TLVReader &reader);
 static bool HandleNonOptionArgs(const char *progName, int argc, char *argv[]);
@@ -72,13 +72,13 @@ static OptionSet gCmdOptions =
 };
 static HelpOptions gHelpOptions(
     CMD_NAME,
-    "Usage: " CMD_NAME " [<options...>] <cert-file>\n",
+    "Usage: " CMD_NAME " [<options...>] <service-config-file>\n",
     WEAVE_VERSION_STRING "\n" COPYRIGHT_STRING,
     "Print a service config object.\n"
     "\n"
     "ARGUMENTS\n"
     "\n"
-    "  <access-token>\n"
+    "  <service-config-file>\n"
     "\n"
     "       A file containing a service config object either in binary (default) or in base-64 format\n"
     "\n"
@@ -152,7 +152,7 @@ bool Cmd_PrintServiceConfig(int argc, char *argv[])
     for (int i = 0; i < certSet.CertCount; i++)
     {
         printf("Certificate %d\n", i + 1);
-        PrintCert(stdout, certSet.Certs[i],NULL, 2, true);
+        PrintCert(stdout, certSet.Certs[i], NULL, 2, true);
     }
 
     err = reader.Next(kTLVType_Structure, ContextTag(kTag_ServiceEndPoint));

--- a/src/tools/weave/Cmd_PrintServiceConfig.cpp
+++ b/src/tools/weave/Cmd_PrintServiceConfig.cpp
@@ -1,0 +1,274 @@
+/*
+ *
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the command handler for the 'weave' tool
+ *      that decodes and prints the contents of a Weave certificate.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "weave-tool.h"
+#include <Weave/Support/ASN1OID.h>
+#include <Weave/Profiles/security/WeaveSecurityDebug.h>
+#include <Weave/Profiles/security/WeaveAccessToken.h>
+#include <Weave/Profiles/service-provisioning/ServiceProvisioning.h>
+#include <Weave/Profiles/service-directory/ServiceDirectory.h>
+#include <Weave/Support/Base64.h>
+
+using namespace nl::Weave::ASN1;
+using namespace nl::Weave::Profiles::Security;
+using namespace nl::Weave::TLV;
+using namespace nl::Weave::Profiles::ServiceProvisioning;
+using namespace nl::Weave::Profiles;
+
+#define CMD_NAME "weave print-cert"
+
+static WEAVE_ERROR PrintServiceHostname(TLVReader &reader);
+static bool HandleNonOptionArgs(const char *progName, int argc, char *argv[]);
+static bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg);
+
+static OptionDef gCmdOptionDefs[] =
+{
+    { "base64", kNoArgument, 'b' },
+    { }
+};
+
+static const char *const gCmdOptionHelp =
+    "   -b, --base64\n"
+    "\n"
+    "       The file containing the TLV should be parsed as base64.\n"
+    "\n"
+    ;
+
+static OptionSet gCmdOptions =
+{
+    HandleOption,
+    gCmdOptionDefs,
+    "COMMAND OPTIONS",
+    gCmdOptionHelp
+};
+static HelpOptions gHelpOptions(
+    CMD_NAME,
+    "Usage: " CMD_NAME " [<options...>] <cert-file>\n",
+    WEAVE_VERSION_STRING "\n" COPYRIGHT_STRING,
+    "Print a service config object.\n"
+    "\n"
+    "ARGUMENTS\n"
+    "\n"
+    "  <access-token>\n"
+    "\n"
+    "       A file containing a service config object either in binary (default) or in base-64 format\n"
+    "\n"
+);
+
+static OptionSet *gCmdOptionSets[] =
+{
+    &gCmdOptions,
+    &gHelpOptions,
+    NULL
+};
+
+static const char *gCertFileName = NULL;
+static bool gUseBase64Decoding = false;
+enum {
+    kNumCerts = 3,
+    kCertBufSize = 1024,
+};
+
+bool Cmd_PrintServiceConfig(int argc, char *argv[])
+{
+    bool res = true;
+    WEAVE_ERROR err;
+    WeaveCertificateSet certSet;
+    uint8_t * serviceConfig = NULL;
+    uint32_t serviceConfigLen = 0;
+    TLVReader reader;
+    uint64_t serviceEndpoint;
+    TLVType serviceConfigContainer, serviceEndpointContainer, serviceDirectoryContainer;
+
+    if (argc == 1)
+    {
+        gHelpOptions.PrintBriefUsage(stderr);
+        ExitNow(res = true);
+    }
+
+    if (!ParseArgs(CMD_NAME, argc, argv, gCmdOptionSets, HandleNonOptionArgs))
+    {
+        ExitNow(res = false);
+    }
+
+    if (!ReadFileIntoMem(gCertFileName, serviceConfig, serviceConfigLen))
+        ExitNow(res = false);
+
+    if (gUseBase64Decoding)
+    {
+        uint32_t b64len = serviceConfigLen;
+        uint8_t * b64 = serviceConfig;
+        serviceConfig = (uint8_t *)malloc(serviceConfigLen);
+        serviceConfigLen = nl::Base64Decode((const char *)b64, b64len, serviceConfig);
+        free(b64);
+    }
+
+    reader.Init(serviceConfig, serviceConfigLen);
+    certSet.Init(kNumCerts, kCertBufSize);
+
+    err = reader.Next(kTLVType_Structure, ProfileTag(kWeaveProfile_ServiceProvisioning, kTag_ServiceConfig));
+    SuccessOrExit(err);
+
+    err = reader.EnterContainer(serviceConfigContainer);
+    SuccessOrExit(err);
+
+    err = reader.Next(kTLVType_Array, ContextTag(kTag_ServiceConfig_CACerts));
+    SuccessOrExit(err);
+
+    err = certSet.LoadCerts(reader, 0);
+    SuccessOrExit(err);
+
+    printf("Weave Service Config:\n\n");
+    printf("Trusted certificates:\n");
+    for (int i = 0; i < certSet.CertCount; i++)
+    {
+        printf("Certificate %d\n", i + 1);
+        PrintCert(stdout, certSet.Certs[i],NULL, 2, true);
+    }
+
+    err = reader.Next(kTLVType_Structure, ContextTag(kTag_ServiceEndPoint));
+    SuccessOrExit(err);
+
+    err = reader.EnterContainer(serviceEndpointContainer);
+    SuccessOrExit(err);
+
+    err = reader.Next(kTLVType_UnsignedInteger, ContextTag(kTag_ServiceEndPoint_Id));
+    SuccessOrExit(err);
+
+    err = reader.Get(serviceEndpoint);
+    SuccessOrExit(err);
+
+    printf("Service Endpoint ID: %016" PRIX64 "\n", serviceEndpoint);
+
+    err = reader.Next(kTLVType_Array, ContextTag(kTag_ServiceEndPoint_Addresses));
+    SuccessOrExit(err);
+
+    err = reader.EnterContainer(serviceDirectoryContainer);
+    SuccessOrExit(err);
+
+    while (err == WEAVE_NO_ERROR)
+    {
+        err = PrintServiceHostname(reader);
+    }
+    if (err == WEAVE_END_OF_TLV)
+    {
+        err = WEAVE_NO_ERROR;
+    }
+
+exit:
+    res = (err == WEAVE_NO_ERROR);
+
+    if (serviceConfig != NULL)
+        free(serviceConfig);
+    return res;
+}
+
+bool HandleNonOptionArgs(const char *progName, int argc, char *argv[])
+{
+    if (argc == 0)
+    {
+        PrintArgError("%s: Please specify the name of the certificate to be printed.\n", progName);
+        return false;
+    }
+
+    if (argc > 1)
+    {
+        PrintArgError("%s: Unexpected argument: %s\n", progName, argv[1]);
+        return false;
+    }
+
+    gCertFileName = argv[0];
+
+    return true;
+}
+
+bool HandleOption(const char *progName, OptionSet *optSet, int id, const char *name, const char *arg)
+{
+    switch (id)
+    {
+    case 'b':
+        gUseBase64Decoding = true;
+        break;
+
+    default:
+        PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", progName, name);
+        return false;
+    }
+
+    return true;
+}
+
+WEAVE_ERROR PrintServiceHostname(TLVReader &reader)
+{
+    WEAVE_ERROR err;
+    TLVType container;
+    uint32_t len;
+    const uint8_t * strbuf = NULL;
+    uint16_t port;
+    err = reader.Next();
+    SuccessOrExit(err);
+
+    err = reader.EnterContainer(container);
+    SuccessOrExit(err);
+
+    while ((err = reader.Next()) == WEAVE_NO_ERROR)
+    {
+        uint64_t tag = reader.GetTag();
+        uint8_t tagNum;
+        if (!IsContextTag(tag))
+        {
+            continue;
+        }
+
+        tagNum = TagNumFromTag(tag);
+
+        switch (tagNum)
+        {
+            case kTag_ServiceEndPointAddress_HostName:
+                reader.GetDataPtr(strbuf);
+                len = reader.GetLength();
+                printf("Hostname: %-.*s ", (int)len, strbuf);
+                break;
+            case kTag_ServiceEndPointAddress_Port:
+                reader.Get(port);
+                printf("Port: %d ", port);
+                break;
+
+            default:
+                printf("Unknown tag num %d", tagNum);
+        }
+    }
+    printf("\n");
+    reader.ExitContainer(container);
+exit:
+    return err;
+}

--- a/src/tools/weave/Cmd_PrintServiceConfig.cpp
+++ b/src/tools/weave/Cmd_PrintServiceConfig.cpp
@@ -121,13 +121,21 @@ bool Cmd_PrintServiceConfig(int argc, char *argv[])
     }
 
     if (!ReadFileIntoMem(gCertFileName, serviceConfig, serviceConfigLen))
+    {
         ExitNow(res = false);
+    }
 
     if (gUseBase64Decoding)
     {
         uint32_t b64len = serviceConfigLen;
         uint8_t * b64 = serviceConfig;
         serviceConfig = (uint8_t *)malloc(serviceConfigLen);
+        if (serviceConfig == NULL)
+        {
+            fprintf(stderr, "Memory allocation error\n");
+            free(b64);
+            ExitNow(res = false);
+        }
         serviceConfigLen = nl::Base64Decode((const char *)b64, b64len, serviceConfig);
         free(b64);
     }
@@ -188,7 +196,9 @@ exit:
     res = (err == WEAVE_NO_ERROR);
 
     if (serviceConfig != NULL)
+    {
         free(serviceConfig);
+    }
     return res;
 }
 

--- a/src/tools/weave/Cmd_PrintServiceConfig.cpp
+++ b/src/tools/weave/Cmd_PrintServiceConfig.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    Copyright (c) 2022 Nest Labs, Inc.
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
 /**
  *    @file
  *      This file implements the command handler for the 'weave' tool
- *      that decodes and prints the contents of a Weave certificate.
+ *      that decodes and prints the contents of a service config object.
  *
  */
 

--- a/src/tools/weave/Makefile.am
+++ b/src/tools/weave/Makefile.am
@@ -74,6 +74,7 @@ weave_SOURCES				            = \
     Cmd_GenServiceEndpointCert.cpp        \
     Cmd_MakeAccessToken.cpp               \
     Cmd_MakeServiceConfig.cpp             \
+    Cmd_PrintAccessToken.cpp              \
     Cmd_PrintCert.cpp                     \
     Cmd_PrintSig.cpp                      \
     Cmd_PrintTLV.cpp                      \

--- a/src/tools/weave/Makefile.am
+++ b/src/tools/weave/Makefile.am
@@ -75,6 +75,7 @@ weave_SOURCES				            = \
     Cmd_MakeAccessToken.cpp               \
     Cmd_MakeServiceConfig.cpp             \
     Cmd_PrintAccessToken.cpp              \
+    Cmd_PrintServiceConfig.cpp            \
     Cmd_PrintCert.cpp                     \
     Cmd_PrintSig.cpp                      \
     Cmd_PrintTLV.cpp                      \

--- a/src/tools/weave/weave-tool.cpp
+++ b/src/tools/weave/weave-tool.cpp
@@ -61,6 +61,8 @@ static const char *const sHelp =
         "\n"
         "    validate-cert -- Validate a Weave certificate chain.\n"
         "\n"
+        "    print-access-token -- Print a Weave Access Token.\n"
+        "\n"
         "    print-cert -- Print a Weave certificate.\n"
         "\n"
         "    print-sig -- Print a Weave signature.\n"
@@ -136,6 +138,9 @@ int main(int argc, char *argv[])
 
     else if (strcasecmp(argv[1], "validate-cert") == 0 || strcasecmp(argv[1], "validatecert") == 0)
         res = Cmd_ValidateCert(argc - 1, argv + 1);
+
+    else if (strcasecmp(argv[1], "print-access-token") == 0 || strcasecmp(argv[1], "printaccesstoken") == 0)
+        res = Cmd_PrintAccessToken(argc - 1, argv + 1);
 
     else if (strcasecmp(argv[1], "print-cert") == 0 || strcasecmp(argv[1], "printcert") == 0)
         res = Cmd_PrintCert(argc - 1, argv + 1);

--- a/src/tools/weave/weave-tool.cpp
+++ b/src/tools/weave/weave-tool.cpp
@@ -59,9 +59,13 @@ static const char *const sHelp =
         "\n"
         "    make-service-config -- Make a service config object.\n"
         "\n"
+        "    make-access-token -- Make a Weave Access Token.\n"
+        "\n"
         "    validate-cert -- Validate a Weave certificate chain.\n"
         "\n"
         "    print-access-token -- Print a Weave Access Token.\n"
+        "\n"
+        "    print-service-config -- Print a service config object\n"
         "\n"
         "    print-cert -- Print a Weave certificate.\n"
         "\n"
@@ -141,6 +145,9 @@ int main(int argc, char *argv[])
 
     else if (strcasecmp(argv[1], "print-access-token") == 0 || strcasecmp(argv[1], "printaccesstoken") == 0)
         res = Cmd_PrintAccessToken(argc - 1, argv + 1);
+
+    else if (strcasecmp(argv[1], "print-service-config") == 0 || strcasecmp(argv[1], "printserviceconfig") == 0)
+        res = Cmd_PrintServiceConfig(argc - 1, argv + 1);
 
     else if (strcasecmp(argv[1], "print-cert") == 0 || strcasecmp(argv[1], "printcert") == 0)
         res = Cmd_PrintCert(argc - 1, argv + 1);

--- a/src/tools/weave/weave-tool.h
+++ b/src/tools/weave/weave-tool.h
@@ -92,6 +92,7 @@ extern bool Cmd_MakeServiceConfig(int argc, char *argv[]);
 extern bool Cmd_MakeAccessToken(int argc, char *argv[]);
 extern bool Cmd_GenProvisioningData(int argc, char *argv[]);
 extern bool Cmd_ValidateCert(int argc, char *argv[]);
+extern bool Cmd_PrintAccessToken(int argc, char *argv[]);
 extern bool Cmd_PrintCert(int argc, char *argv[]);
 extern bool Cmd_PrintSig(int argc, char *argv[]);
 extern bool Cmd_PrintTLV(int argc, char *argv[]);

--- a/src/tools/weave/weave-tool.h
+++ b/src/tools/weave/weave-tool.h
@@ -93,6 +93,7 @@ extern bool Cmd_MakeAccessToken(int argc, char *argv[]);
 extern bool Cmd_GenProvisioningData(int argc, char *argv[]);
 extern bool Cmd_ValidateCert(int argc, char *argv[]);
 extern bool Cmd_PrintAccessToken(int argc, char *argv[]);
+extern bool Cmd_PrintServiceConfig(int argc, char *argv[]);
 extern bool Cmd_PrintCert(int argc, char *argv[]);
 extern bool Cmd_PrintSig(int argc, char *argv[]);
 extern bool Cmd_PrintTLV(int argc, char *argv[]);


### PR DESCRIPTION
* add a command to print out the contents of the access token
* add a command to print out the contents of the service config object
* add the ability to specify the implicit profile ID to the print-tlv command
* change the printing of binary string dump to dump the contents rather than the pointer value