### PR TITLE
Split status report strings to save flash

### DIFF
--- a/src/lib/support/StatusReportStr.cpp
+++ b/src/lib/support/StatusReportStr.cpp
@@ -101,238 +101,254 @@ static char sErrorStr[1024];
 
 NL_DLL_EXPORT const char *StatusReportStr(uint32_t profileId, uint16_t statusCode)
 {
-    const char *fmt = NULL;
+    const char *fmt = "[ %s(%08" PRIX32 "):%" PRIu16 " ] %s";
+    const char *profileName = NULL;
+    const char *errorMsg = "";
 
     switch (profileId)
     {
     case kWeaveProfile_BDX:
+        profileName = "BDX";
         switch (statusCode)
         {
 #if WEAVE_CONFIG_BDX_NAMESPACE == kWeaveManagedNamespace_Development
-        case BulkDataTransfer::kStatus_Overflow                                         : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Overflow"; break;
-        case BulkDataTransfer::kStatus_LengthTooShort                                   : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Length too short"; break;
-        case BulkDataTransfer::kStatus_XferFailedUnknownErr                             : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Transfer failed for unknown reason"; break;
-        case BulkDataTransfer::kStatus_XferMethodNotSupported                           : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Transfer method not supported"; break;
-        case BulkDataTransfer::kStatus_UnknownFile                                      : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Unknown file"; break;
-        case BulkDataTransfer::kStatus_StartOffsetNotSupported                          : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Start offset not support"; break;
-        case BulkDataTransfer::kStatus_Unknown                                          : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Unknown error"; break;
+        case BulkDataTransfer::kStatus_Overflow                            : errorMsg = "Overflow"; break;
+        case BulkDataTransfer::kStatus_LengthTooShort                      : errorMsg = "Length too short"; break;
+        case BulkDataTransfer::kStatus_XferFailedUnknownErr                : errorMsg = "Transfer failed for unknown reason"; break;
+        case BulkDataTransfer::kStatus_XferMethodNotSupported              : errorMsg = "Transfer method not supported"; break;
+        case BulkDataTransfer::kStatus_UnknownFile                         : errorMsg = "Unknown file"; break;
+        case BulkDataTransfer::kStatus_StartOffsetNotSupported             : errorMsg = "Start offset not support"; break;
+        case BulkDataTransfer::kStatus_Unknown                             : errorMsg = "Unknown error"; break;
 #else
-        case BulkDataTransfer::kStatus_Overflow                                         : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Overflow"; break;
-        case BulkDataTransfer::kStatus_LengthTooLarge                                   : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Length too long"; break;
-        case BulkDataTransfer::kStatus_LengthTooShort                                   : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Length too short"; break;
-        case BulkDataTransfer::kStatus_LengthMismatch                                   : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Length mismatch"; break;
-        case BulkDataTransfer::kStatus_LengthRequired                                   : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Length required"; break;
-        case BulkDataTransfer::kStatus_BadMessageContents                               : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Bad message contents"; break;
-        case BulkDataTransfer::kStatus_BadBlockCounter                                  : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Bad block counter"; break;
-        case BulkDataTransfer::kStatus_XferFailedUnknownErr                             : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Transfer failed for unknown reason"; break;
-        case BulkDataTransfer::kStatus_ServerBadState                                   : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Server is in incorrect state"; break;
-        case BulkDataTransfer::kStatus_FailureToSend                                    : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Failure to send"; break;
-        case BulkDataTransfer::kStatus_XferMethodNotSupported                           : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Transfer method not supported"; break;
-        case BulkDataTransfer::kStatus_UnknownFile                                      : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Unknown file"; break;
-        case BulkDataTransfer::kStatus_StartOffsetNotSupported                          : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Start offset not support"; break;
-        case BulkDataTransfer::kStatus_VersionNotSupported                              : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Protocol version not supported"; break;
-        case BulkDataTransfer::kStatus_Unknown                                          : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ] Unknown error"; break;
+        case BulkDataTransfer::kStatus_Overflow                            : errorMsg = "Overflow"; break;
+        case BulkDataTransfer::kStatus_LengthTooLarge                      : errorMsg = "Length too long"; break;
+        case BulkDataTransfer::kStatus_LengthTooShort                      : errorMsg = "Length too short"; break;
+        case BulkDataTransfer::kStatus_LengthMismatch                      : errorMsg = "Length mismatch"; break;
+        case BulkDataTransfer::kStatus_LengthRequired                      : errorMsg = "Length required"; break;
+        case BulkDataTransfer::kStatus_BadMessageContents                  : errorMsg = "Bad message contents"; break;
+        case BulkDataTransfer::kStatus_BadBlockCounter                     : errorMsg = "Bad block counter"; break;
+        case BulkDataTransfer::kStatus_XferFailedUnknownErr                : errorMsg = "Transfer failed for unknown reason"; break;
+        case BulkDataTransfer::kStatus_ServerBadState                      : errorMsg = "Server is in incorrect state"; break;
+        case BulkDataTransfer::kStatus_FailureToSend                       : errorMsg = "Failure to send"; break;
+        case BulkDataTransfer::kStatus_XferMethodNotSupported              : errorMsg = "Transfer method not supported"; break;
+        case BulkDataTransfer::kStatus_UnknownFile                         : errorMsg = "Unknown file"; break;
+        case BulkDataTransfer::kStatus_StartOffsetNotSupported             : errorMsg = "Start offset not support"; break;
+        case BulkDataTransfer::kStatus_VersionNotSupported                 : errorMsg = "Protocol version not supported"; break;
+        case BulkDataTransfer::kStatus_Unknown                             : errorMsg = "Unknown error"; break;
 #endif // WEAVE_CONFIG_BDX_NAMESPACE == kWeaveManagedNamespace_Development
-        default                                                                         : fmt = "[ BDX(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 
     case kWeaveProfile_Common:
+        profileName = "Common";
         switch (statusCode)
         {
-        case nl::Weave::Profiles::Common::kStatus_Success                               : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Success"; break;
-        case nl::Weave::Profiles::Common::kStatus_Canceled                              : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Canceled"; break;
-        case nl::Weave::Profiles::Common::kStatus_BadRequest                            : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Bad/malformed request"; break;
-        case nl::Weave::Profiles::Common::kStatus_UnsupportedMessage                    : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Unrecognized/unsupported message"; break;
-        case nl::Weave::Profiles::Common::kStatus_UnexpectedMessage                     : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Unexpected message"; break;
-        case nl::Weave::Profiles::Common::kStatus_AuthenticationRequired                : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Authentication required"; break;
-        case nl::Weave::Profiles::Common::kStatus_AccessDenied                          : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Access denied"; break;
-        case nl::Weave::Profiles::Common::kStatus_OutOfMemory                           : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Out of memory"; break;
-        case nl::Weave::Profiles::Common::kStatus_NotAvailable                          : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Not available"; break;
-        case nl::Weave::Profiles::Common::kStatus_LocalSetupRequired                    : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Local setup required"; break;
-        case nl::Weave::Profiles::Common::kStatus_Relocated                             : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Relocated"; break;
-        case nl::Weave::Profiles::Common::kStatus_Busy                                  : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Sender busy"; break;
-        case nl::Weave::Profiles::Common::kStatus_Timeout                               : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Timeout"; break;
-        case nl::Weave::Profiles::Common::kStatus_InternalError                         : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Internal error"; break;
-        case nl::Weave::Profiles::Common::kStatus_Continue                              : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ] Continue"; break;
-        default                                                                         : fmt = "[ Common(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        case nl::Weave::Profiles::Common::kStatus_Success                  : errorMsg = "Success"; break;
+        case nl::Weave::Profiles::Common::kStatus_Canceled                 : errorMsg = "Canceled"; break;
+        case nl::Weave::Profiles::Common::kStatus_BadRequest               : errorMsg = "Bad/malformed request"; break;
+        case nl::Weave::Profiles::Common::kStatus_UnsupportedMessage       : errorMsg = "Unrecognized/unsupported message"; break;
+        case nl::Weave::Profiles::Common::kStatus_UnexpectedMessage        : errorMsg = "Unexpected message"; break;
+        case nl::Weave::Profiles::Common::kStatus_AuthenticationRequired   : errorMsg = "Authentication required"; break;
+        case nl::Weave::Profiles::Common::kStatus_AccessDenied             : errorMsg = "Access denied"; break;
+        case nl::Weave::Profiles::Common::kStatus_OutOfMemory              : errorMsg = "Out of memory"; break;
+        case nl::Weave::Profiles::Common::kStatus_NotAvailable             : errorMsg = "Not available"; break;
+        case nl::Weave::Profiles::Common::kStatus_LocalSetupRequired       : errorMsg = "Local setup required"; break;
+        case nl::Weave::Profiles::Common::kStatus_Relocated                : errorMsg = "Relocated"; break;
+        case nl::Weave::Profiles::Common::kStatus_Busy                     : errorMsg = "Sender busy"; break;
+        case nl::Weave::Profiles::Common::kStatus_Timeout                  : errorMsg = "Timeout"; break;
+        case nl::Weave::Profiles::Common::kStatus_InternalError            : errorMsg = "Internal error"; break;
+        case nl::Weave::Profiles::Common::kStatus_Continue                 : errorMsg = "Continue"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 
     case kWeaveProfile_WDM:
+        profileName = "WDM";
         switch (statusCode)
             {
-        case DataManagement_Legacy::kStatus_CancelSuccess                               : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Subscription canceled"; break;
-        case DataManagement_Legacy::kStatus_InvalidPath                                 : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Invalid path"; break;
-        case DataManagement_Legacy::kStatus_UnknownTopic                                : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Unknown topic"; break;
-        case DataManagement_Legacy::kStatus_IllegalReadRequest                          : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Illegal read request"; break;
-        case DataManagement_Legacy::kStatus_IllegalWriteRequest                         : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Illegal write request"; break;
-        case DataManagement_Legacy::kStatus_InvalidVersion                              : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Invalid version"; break;
-        case DataManagement_Legacy::kStatus_UnsupportedSubscriptionMode                 : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Unsupported subscription mode"; break;
+        case DataManagement_Legacy::kStatus_CancelSuccess                  : errorMsg = "Subscription canceled"; break;
+        case DataManagement_Legacy::kStatus_InvalidPath                    : errorMsg = "Invalid path"; break;
+        case DataManagement_Legacy::kStatus_UnknownTopic                   : errorMsg = "Unknown topic"; break;
+        case DataManagement_Legacy::kStatus_IllegalReadRequest             : errorMsg = "Illegal read request"; break;
+        case DataManagement_Legacy::kStatus_IllegalWriteRequest            : errorMsg = "Illegal write request"; break;
+        case DataManagement_Legacy::kStatus_InvalidVersion                 : errorMsg = "Invalid version"; break;
+        case DataManagement_Legacy::kStatus_UnsupportedSubscriptionMode    : errorMsg = "Unsupported subscription mode"; break;
 
-        case DataManagement_Current::kStatus_InvalidValueInNotification                 : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Invalid value in notification"; break;
-        case DataManagement_Current::kStatus_InvalidPath                                : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Invalid path"; break;
-        case DataManagement_Current::kStatus_ExpiryTimeNotSupported                     : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Expiry time not supported"; break;
-        case DataManagement_Current::kStatus_NotTimeSyncedYet                           : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Not time-synced yet"; break;
-        case DataManagement_Current::kStatus_RequestExpiredInTime                       : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Request expired in time"; break;
-        case DataManagement_Current::kStatus_VersionMismatch                            : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Version mismatch"; break;
-        case DataManagement_Current::kStatus_GeneralProtocolError                       : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] General protocol error"; break;
-        case DataManagement_Current::kStatus_SecurityError                              : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Security error"; break;
-        case DataManagement_Current::kStatus_InvalidSubscriptionID                      : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Invalid subscription ID"; break;
-        case DataManagement_Current::kStatus_GeneralSchemaViolation                     : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] General schema violation"; break;
-        case DataManagement_Current::kStatus_UnpairedDeviceRejected                     : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Unpaired device rejected"; break;
-        case DataManagement_Current::kStatus_IncompatibleDataSchemaVersion              : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Incompatible data schema violation"; break;
-        case DataManagement_Current::kStatus_MultipleFailures                           : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Multiple failures"; break;
-        case DataManagement_Current::kStatus_UpdateOutOfSequence                        : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ] Update out of sequence"; break;
-        default                                                                         : fmt = "[ WDM(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        case DataManagement_Current::kStatus_InvalidValueInNotification    : errorMsg = "Invalid value in notification"; break;
+        case DataManagement_Current::kStatus_InvalidPath                   : errorMsg = "Invalid path"; break;
+        case DataManagement_Current::kStatus_ExpiryTimeNotSupported        : errorMsg = "Expiry time not supported"; break;
+        case DataManagement_Current::kStatus_NotTimeSyncedYet              : errorMsg = "Not time-synced yet"; break;
+        case DataManagement_Current::kStatus_RequestExpiredInTime          : errorMsg = "Request expired in time"; break;
+        case DataManagement_Current::kStatus_VersionMismatch               : errorMsg = "Version mismatch"; break;
+        case DataManagement_Current::kStatus_GeneralProtocolError          : errorMsg = "General protocol error"; break;
+        case DataManagement_Current::kStatus_SecurityError                 : errorMsg = "Security error"; break;
+        case DataManagement_Current::kStatus_InvalidSubscriptionID         : errorMsg = "Invalid subscription ID"; break;
+        case DataManagement_Current::kStatus_GeneralSchemaViolation        : errorMsg = "General schema violation"; break;
+        case DataManagement_Current::kStatus_UnpairedDeviceRejected        : errorMsg = "Unpaired device rejected"; break;
+        case DataManagement_Current::kStatus_IncompatibleDataSchemaVersion : errorMsg = "Incompatible data schema violation"; break;
+        case DataManagement_Current::kStatus_MultipleFailures              : errorMsg = "Multiple failures"; break;
+        case DataManagement_Current::kStatus_UpdateOutOfSequence           : errorMsg = "Update out of sequence"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 
     case kWeaveProfile_DeviceControl:
+        profileName = "DeviceControl";
         switch (statusCode)
         {
-        case DeviceControl::kStatusCode_FailSafeAlreadyActive                           : fmt = "[ DeviceControl(%08" PRIX32 "):%" PRIu16 " ] Fail-safe already active"; break;
-        case DeviceControl::kStatusCode_NoFailSafeActive                                : fmt = "[ DeviceControl(%08" PRIX32 "):%" PRIu16 " ] No fail-safe active"; break;
-        case DeviceControl::kStatusCode_NoMatchingFailSafeActive                        : fmt = "[ DeviceControl(%08" PRIX32 "):%" PRIu16 " ] No matching fail-safe active"; break;
-        case DeviceControl::kStatusCode_UnsupportedFailSafeMode                         : fmt = "[ DeviceControl(%08" PRIX32 "):%" PRIu16 " ] Unsupported fail-safe mode"; break;
-        case DeviceControl::kStatusCode_RemotePassiveRendezvousTimedOut                 : fmt = "[ DeviceControl(%08" PRIX32 "):%" PRIu16 " ] Remote Passive Rendezvous timed out"; break;
-        case DeviceControl::kStatusCode_UnsecuredListenPreempted                        : fmt = "[ DeviceControl(%08" PRIX32 "):%" PRIu16 " ] Unsecured Listen pre-empted"; break;
-        case DeviceControl::kStatusCode_ResetSuccessCloseCon                            : fmt = "[ DeviceControl(%08" PRIX32 "):%" PRIu16 " ] ResetConfig will succeed after connection close"; break;
-        case DeviceControl::kStatusCode_ResetNotAllowed                                 : fmt = "[ DeviceControl(%08" PRIX32 "):%" PRIu16 " ] Reset not allowed"; break;
-        case DeviceControl::kStatusCode_NoSystemTestDelegate                            : fmt = "[ DeviceControl(%08" PRIX32 "):%" PRIu16 " ] System test cannot run without a delegate"; break;
-        default                                                                         : fmt = "[ DeviceControl(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        case DeviceControl::kStatusCode_FailSafeAlreadyActive              : errorMsg = "Fail-safe already active"; break;
+        case DeviceControl::kStatusCode_NoFailSafeActive                   : errorMsg = "No fail-safe active"; break;
+        case DeviceControl::kStatusCode_NoMatchingFailSafeActive           : errorMsg = "No matching fail-safe active"; break;
+        case DeviceControl::kStatusCode_UnsupportedFailSafeMode            : errorMsg = "Unsupported fail-safe mode"; break;
+        case DeviceControl::kStatusCode_RemotePassiveRendezvousTimedOut    : errorMsg = "Remote Passive Rendezvous timed out"; break;
+        case DeviceControl::kStatusCode_UnsecuredListenPreempted           : errorMsg = "Unsecured Listen pre-empted"; break;
+        case DeviceControl::kStatusCode_ResetSuccessCloseCon               : errorMsg = "ResetConfig will succeed after connection close"; break;
+        case DeviceControl::kStatusCode_ResetNotAllowed                    : errorMsg = "Reset not allowed"; break;
+        case DeviceControl::kStatusCode_NoSystemTestDelegate               : errorMsg = "System test cannot run without a delegate"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 
     case kWeaveProfile_DeviceDescription:
+        profileName = "DeviceDescription";
         switch (statusCode)
         {
-        default                                                                         : fmt = "[ DeviceDescription(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 
     case kWeaveProfile_Echo:
+        profileName = "Echo";
         switch (statusCode)
         {
-        default                                                                         : fmt = "[ Echo(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 
     case kWeaveProfile_FabricProvisioning:
+        profileName = "FabricProvisioning";
         switch (statusCode)
         {
-        case FabricProvisioning::kStatusCode_AlreadyMemberOfFabric                      : fmt = "[ FabricProvisioning(%08" PRIX32 "):%" PRIu16 " ] Already member of fabric"; break;
-        case FabricProvisioning::kStatusCode_NotMemberOfFabric                          : fmt = "[ FabricProvisioning(%08" PRIX32 "):%" PRIu16 " ] Not member of fabric"; break;
-        case FabricProvisioning::kStatusCode_InvalidFabricConfig                        : fmt = "[ FabricProvisioning(%08" PRIX32 "):%" PRIu16 " ] Invalid fabric config"; break;
-        default                                                                         : fmt = "[ FabricProvisioning(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        case FabricProvisioning::kStatusCode_AlreadyMemberOfFabric         : errorMsg = "Already member of fabric"; break;
+        case FabricProvisioning::kStatusCode_NotMemberOfFabric             : errorMsg = "Not member of fabric"; break;
+        case FabricProvisioning::kStatusCode_InvalidFabricConfig           : errorMsg = "Invalid fabric config"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 
     case kWeaveProfile_NetworkProvisioning:
+        profileName = "NetworkProvisioning";
         switch (statusCode)
         {
-        case NetworkProvisioning::kStatusCode_UnknownNetwork                            : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Unknown network"; break;
-        case NetworkProvisioning::kStatusCode_TooManyNetworks                           : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Too many networks"; break;
-        case NetworkProvisioning::kStatusCode_InvalidNetworkConfiguration               : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Invalid network configuration"; break;
-        case NetworkProvisioning::kStatusCode_UnsupportedNetworkType                    : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Unsupported network configuration"; break;
-        case NetworkProvisioning::kStatusCode_UnsupportedWiFiMode                       : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Unsupported WiFi mode"; break;
-        case NetworkProvisioning::kStatusCode_UnsupportedWiFiRole                       : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Unsupported WiFi role"; break;
-        case NetworkProvisioning::kStatusCode_UnsupportedWiFiSecurityType               : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Unsupported WiFi security type"; break;
-        case NetworkProvisioning::kStatusCode_InvalidState                              : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Invalid state"; break;
-        case NetworkProvisioning::kStatusCode_TestNetworkFailed                         : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Test network failed"; break;
-        case NetworkProvisioning::kStatusCode_NetworkConnectFailed                      : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Network connect failed"; break;
-        case NetworkProvisioning::kStatusCode_NoRouterAvailable                         : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] No router available"; break;
-        case NetworkProvisioning::kStatusCode_UnsupportedRegulatoryDomain               : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Unsupported wireless regulatory domain"; break;
-        case NetworkProvisioning::kStatusCode_UnsupportedOperatingLocation              : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ] Unsupported wireless operating location"; break;
-        default                                                                         : fmt = "[ NetworkProvisioning(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        case NetworkProvisioning::kStatusCode_UnknownNetwork               : errorMsg = "Unknown network"; break;
+        case NetworkProvisioning::kStatusCode_TooManyNetworks              : errorMsg = "Too many networks"; break;
+        case NetworkProvisioning::kStatusCode_InvalidNetworkConfiguration  : errorMsg = "Invalid network configuration"; break;
+        case NetworkProvisioning::kStatusCode_UnsupportedNetworkType       : errorMsg = "Unsupported network configuration"; break;
+        case NetworkProvisioning::kStatusCode_UnsupportedWiFiMode          : errorMsg = "Unsupported WiFi mode"; break;
+        case NetworkProvisioning::kStatusCode_UnsupportedWiFiRole          : errorMsg = "Unsupported WiFi role"; break;
+        case NetworkProvisioning::kStatusCode_UnsupportedWiFiSecurityType  : errorMsg = "Unsupported WiFi security type"; break;
+        case NetworkProvisioning::kStatusCode_InvalidState                 : errorMsg = "Invalid state"; break;
+        case NetworkProvisioning::kStatusCode_TestNetworkFailed            : errorMsg = "Test network failed"; break;
+        case NetworkProvisioning::kStatusCode_NetworkConnectFailed         : errorMsg = "Network connect failed"; break;
+        case NetworkProvisioning::kStatusCode_NoRouterAvailable            : errorMsg = "No router available"; break;
+        case NetworkProvisioning::kStatusCode_UnsupportedRegulatoryDomain  : errorMsg = "Unsupported wireless regulatory domain"; break;
+        case NetworkProvisioning::kStatusCode_UnsupportedOperatingLocation : errorMsg = "Unsupported wireless operating location"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 
     case kWeaveProfile_Security:
+        profileName = "Security";
         switch (statusCode)
         {
-        case Security::kStatusCode_SessionAborted                                       : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Session aborted"; break;
-        case Security::kStatusCode_PASESupportsOnlyConfig1                              : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] PASE Engine only supports Config1"; break;
-        case Security::kStatusCode_UnsupportedEncryptionType                            : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Unsupported encryption type"; break;
-        case Security::kStatusCode_InvalidKeyId                                         : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Invalid key id"; break;
-        case Security::kStatusCode_DuplicateKeyId                                       : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Duplicate key id"; break;
-        case Security::kStatusCode_KeyConfirmationFailed                                : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Key confirmation failed"; break;
-        case Security::kStatusCode_InternalError                                        : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Internal error"; break;
-        case Security::kStatusCode_AuthenticationFailed                                 : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Authentication failed"; break;
-        case Security::kStatusCode_UnsupportedCASEConfiguration                         : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Unsupported CASE configuration"; break;
-        case Security::kStatusCode_UnsupportedCertificate                               : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Unsupported certificate"; break;
-        case Security::kStatusCode_NoCommonPASEConfigurations                           : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] No supported PASE configurations in common"; break;
-        case Security::kStatusCode_KeyNotFound                                          : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Key not found"; break;
-        case Security::kStatusCode_WrongEncryptionType                                  : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Wrong encryption type"; break;
-        case Security::kStatusCode_UnknownKeyType                                       : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Unknown key type"; break;
-        case Security::kStatusCode_InvalidUseOfSessionKey                               : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Invalid use of session key"; break;
-        case Security::kStatusCode_InternalKeyError                                     : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Internal key error"; break;
-        case Security::kStatusCode_NoCommonKeyExportConfiguration                       : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] No common key export configuration"; break;
-        case Security::kStatusCode_UnauthorizedKeyExportRequest                         : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Unauthorized key export request"; break;
-        case Security::kStatusCode_NoNewOperationalCertRequired                         : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] No new operational certificate required"; break;
-        case Security::kStatusCode_OperationalNodeIdInUse                               : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Operational node Id collision"; break;
-        case Security::kStatusCode_InvalidOperationalNodeId                             : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Invalid operational node Id"; break;
-        case Security::kStatusCode_InvalidOperationalCertificate                        : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ] Invalid operational certificate"; break;
-        default                                                                         : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        case Security::kStatusCode_SessionAborted                          : errorMsg = "Session aborted"; break;
+        case Security::kStatusCode_PASESupportsOnlyConfig1                 : errorMsg = "PASE Engine only supports Config1"; break;
+        case Security::kStatusCode_UnsupportedEncryptionType               : errorMsg = "Unsupported encryption type"; break;
+        case Security::kStatusCode_InvalidKeyId                            : errorMsg = "Invalid key id"; break;
+        case Security::kStatusCode_DuplicateKeyId                          : errorMsg = "Duplicate key id"; break;
+        case Security::kStatusCode_KeyConfirmationFailed                   : errorMsg = "Key confirmation failed"; break;
+        case Security::kStatusCode_InternalError                           : errorMsg = "Internal error"; break;
+        case Security::kStatusCode_AuthenticationFailed                    : errorMsg = "Authentication failed"; break;
+        case Security::kStatusCode_UnsupportedCASEConfiguration            : errorMsg = "Unsupported CASE configuration"; break;
+        case Security::kStatusCode_UnsupportedCertificate                  : errorMsg = "Unsupported certificate"; break;
+        case Security::kStatusCode_NoCommonPASEConfigurations              : errorMsg = "No supported PASE configurations in common"; break;
+        case Security::kStatusCode_KeyNotFound                             : errorMsg = "Key not found"; break;
+        case Security::kStatusCode_WrongEncryptionType                     : errorMsg = "Wrong encryption type"; break;
+        case Security::kStatusCode_UnknownKeyType                          : errorMsg = "Unknown key type"; break;
+        case Security::kStatusCode_InvalidUseOfSessionKey                  : errorMsg = "Invalid use of session key"; break;
+        case Security::kStatusCode_InternalKeyError                        : errorMsg = "Internal key error"; break;
+        case Security::kStatusCode_NoCommonKeyExportConfiguration          : errorMsg = "No common key export configuration"; break;
+        case Security::kStatusCode_UnauthorizedKeyExportRequest            : errorMsg = "Unauthorized key export request"; break;
+        case Security::kStatusCode_NoNewOperationalCertRequired            : errorMsg = "No new operational certificate required"; break;
+        case Security::kStatusCode_OperationalNodeIdInUse                  : errorMsg = "Operational node Id collision"; break;
+        case Security::kStatusCode_InvalidOperationalNodeId                : errorMsg = "Invalid operational node Id"; break;
+        case Security::kStatusCode_InvalidOperationalCertificate           : errorMsg = "Invalid operational certificate"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 #if WEAVE_CONFIG_ENABLE_SERVICE_DIRECTORY
     case kWeaveProfile_ServiceDirectory:
+        profileName = "ServiceDirectory";
         switch (statusCode)
         {
-        case ServiceDirectory::kStatus_DirectoryUnavailable                             : fmt = "[ ServiceDirectory(%08" PRIX32 "):%" PRIu16 " ] Service directory unavailable"; break;
-        default                                                                         : fmt = "[ ServiceDirectory(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        case ServiceDirectory::kStatus_DirectoryUnavailable                : errorMsg = "Service directory unavailable"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 #endif
     case kWeaveProfile_ServiceProvisioning:
+        profileName = "ServiceProvisioning";
         switch (statusCode)
         {
-        case ServiceProvisioning::kStatusCode_TooManyServices                           : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Too many services"; break;
-        case ServiceProvisioning::kStatusCode_ServiceAlreadyRegistered                  : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Service already registered"; break;
-        case ServiceProvisioning::kStatusCode_InvalidServiceConfig                      : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Invalid service configuration"; break;
-        case ServiceProvisioning::kStatusCode_NoSuchService                             : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] No such service"; break;
-        case ServiceProvisioning::kStatusCode_PairingServerError                        : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Error talking to pairing server"; break;
-        case ServiceProvisioning::kStatusCode_InvalidPairingToken                       : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Invalid pairing token"; break;
-        case ServiceProvisioning::kStatusCode_PairingTokenOld                           : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Pairing token no longer valid"; break;
-        case ServiceProvisioning::kStatusCode_ServiceCommunicationError                 : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Service communication error"; break;
-        case ServiceProvisioning::kStatusCode_ServiceConfigTooLarge                     : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Service configuration too large"; break;
-        case ServiceProvisioning::kStatusCode_WrongFabric                               : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Wrong fabric"; break;
-        case ServiceProvisioning::kStatusCode_TooManyFabrics                            : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ] Too many fabrics"; break;
-        default                                                                         : fmt = "[ ServiceProvisioning(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        case ServiceProvisioning::kStatusCode_TooManyServices              : errorMsg = "Too many services"; break;
+        case ServiceProvisioning::kStatusCode_ServiceAlreadyRegistered     : errorMsg = "Service already registered"; break;
+        case ServiceProvisioning::kStatusCode_InvalidServiceConfig         : errorMsg = "Invalid service configuration"; break;
+        case ServiceProvisioning::kStatusCode_NoSuchService                : errorMsg = "No such service"; break;
+        case ServiceProvisioning::kStatusCode_PairingServerError           : errorMsg = "Error talking to pairing server"; break;
+        case ServiceProvisioning::kStatusCode_InvalidPairingToken          : errorMsg = "Invalid pairing token"; break;
+        case ServiceProvisioning::kStatusCode_PairingTokenOld              : errorMsg = "Pairing token no longer valid"; break;
+        case ServiceProvisioning::kStatusCode_ServiceCommunicationError    : errorMsg = "Service communication error"; break;
+        case ServiceProvisioning::kStatusCode_ServiceConfigTooLarge        : errorMsg = "Service configuration too large"; break;
+        case ServiceProvisioning::kStatusCode_WrongFabric                  : errorMsg = "Wrong fabric"; break;
+        case ServiceProvisioning::kStatusCode_TooManyFabrics               : errorMsg = "Too many fabrics"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 
     case kWeaveProfile_SWU:
+        profileName = "SWU";
         switch (statusCode)
         {
-        case SoftwareUpdate::kStatus_NoUpdateAvailable                                  : fmt = "[ SWU(%08" PRIX32 "):%" PRIu16 " ] No software update available"; break;
-        case SoftwareUpdate::kStatus_UpdateFailed                                       : fmt = "[ SWU(%08" PRIX32 "):%" PRIu16 " ] Software update failed"; break;
-        case SoftwareUpdate::kStatus_InvalidInstructions                                : fmt = "[ SWU(%08" PRIX32 "):%" PRIu16 " ] Invalid software image download instructions"; break;
-        case SoftwareUpdate::kStatus_DownloadFailed                                     : fmt = "[ SWU(%08" PRIX32 "):%" PRIu16 " ] Software image download failed"; break;
-        case SoftwareUpdate::kStatus_IntegrityCheckFailed                               : fmt = "[ SWU(%08" PRIX32 "):%" PRIu16 " ] Software image integrity check failed"; break;
-        case SoftwareUpdate::kStatus_Abort                                              : fmt = "[ SWU(%08" PRIX32 "):%" PRIu16 " ] Software image query aborted"; break;
-        case SoftwareUpdate::kStatus_Retry                                              : fmt = "[ SWU(%08" PRIX32 "):%" PRIu16 " ] Retry software image query"; break;
-        default                                                                         : fmt = "[ SWU(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        case SoftwareUpdate::kStatus_NoUpdateAvailable                     : errorMsg = "No software update available"; break;
+        case SoftwareUpdate::kStatus_UpdateFailed                          : errorMsg = "Software update failed"; break;
+        case SoftwareUpdate::kStatus_InvalidInstructions                   : errorMsg = "Invalid software image download instructions"; break;
+        case SoftwareUpdate::kStatus_DownloadFailed                        : errorMsg = "Software image download failed"; break;
+        case SoftwareUpdate::kStatus_IntegrityCheckFailed                  : errorMsg = "Software image integrity check failed"; break;
+        case SoftwareUpdate::kStatus_Abort                                 : errorMsg = "Software image query aborted"; break;
+        case SoftwareUpdate::kStatus_Retry                                 : errorMsg = "Retry software image query"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
     case kWeaveProfile_Tunneling:
+        profileName = "WeaveTunnel";
         switch (statusCode)
 	{
 #if WEAVE_CONFIG_ENABLE_TUNNELING
-	case WeaveTunnel::kStatusCode_TunnelOpenFail                                    : fmt = "[ WeaveTunnel(%08" PRIX32 "):%" PRIu16 " ] Tunnel open failed"; break;
-	case WeaveTunnel::kStatusCode_TunnelCloseFail                                   : fmt = "[ WeaveTunnel(%08" PRIX32 "):%" PRIu16 " ] Tunnel close failed"; break;
-	case WeaveTunnel::kStatusCode_TunnelRouteUpdateFail                             : fmt = "[ WeaveTunnel(%08" PRIX32 "):%" PRIu16 " ] Tunnel route update failed"; break;
-	case WeaveTunnel::kStatusCode_TunnelReconnectFail                               : fmt = "[ WeaveTunnel(%08" PRIX32 "):%" PRIu16 " ] Tunnel reconnect failed"; break;
+	case WeaveTunnel::kStatusCode_TunnelOpenFail                       : errorMsg = "Tunnel open failed"; break;
+	case WeaveTunnel::kStatusCode_TunnelCloseFail                      : errorMsg = "Tunnel close failed"; break;
+	case WeaveTunnel::kStatusCode_TunnelRouteUpdateFail                : errorMsg = "Tunnel route update failed"; break;
+	case WeaveTunnel::kStatusCode_TunnelReconnectFail                  : errorMsg = "Tunnel reconnect failed"; break;
 #endif
-	default                                                                         : fmt = "[ WeaveTunnel(%08" PRIX32 "):%" PRIu16 " ]"; break;
+	default                                                            : errorMsg = ""; break;
 	}
         break;
 
     case kWeaveProfile_StatusReport_Deprecated:
+        profileName = "Security";
         switch (statusCode)
         {
-        default                                                                         : fmt = "[ Security(%08" PRIX32 "):%" PRIu16 " ]"; break;
+        default                                                            : errorMsg = ""; break;
         }
         break;
 
@@ -342,10 +358,18 @@ NL_DLL_EXPORT const char *StatusReportStr(uint32_t profileId, uint16_t statusCod
 
     }
 
-    if (fmt == NULL)
-        fmt = "[ %08" PRIX32 ":%" PRIu16 " ]";
+    if (profileName != NULL)
+    {
+        snprintf(sErrorStr, sizeof(sErrorStr) - 2, fmt, profileName, profileId, statusCode, errorMsg);
+    }
+    else
+    {
+        if (fmt == NULL)
+            fmt = "[ %08" PRIX32 ":%" PRIu16 " ]";
 
-    snprintf(sErrorStr, sizeof(sErrorStr) - 2, fmt, profileId, statusCode);
+        snprintf(sErrorStr, sizeof(sErrorStr) - 2, fmt, profileId, statusCode);
+    }
+
     sErrorStr[sizeof(sErrorStr) - 1] = 0;
     return sErrorStr;
 }


### PR DESCRIPTION
The optimization slightly increases the text size, and significantly
decreases the size of readonly data.  On a typical embedded platform,
we expect a net flash savings of over 2.5 kbytes.